### PR TITLE
Support event name on web hooks

### DIFF
--- a/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
+++ b/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
@@ -5,6 +5,7 @@ import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME,
+    visible = true,
     property="event_name")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = CreateProjectSystemHookEvent.class, name = ProjectSystemHookEvent.PROJECT_CREATE_EVENT),

--- a/src/main/java/org/gitlab4j/api/webhook/Event.java
+++ b/src/main/java/org/gitlab4j/api/webhook/Event.java
@@ -6,6 +6,7 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
 
 @JsonTypeInfo(use=JsonTypeInfo.Id.NAME,
     include=JsonTypeInfo.As.PROPERTY,
+    visible = true,
     property="object_kind")
 @JsonSubTypes({
     @JsonSubTypes.Type(value = BuildEvent.class, name = BuildEvent.OBJECT_KIND),


### PR DESCRIPTION
Type of PR: Bug resolution
Kind of bug: Null pointer on web hook event types
Solution: https://stackoverflow.com/questions/33611199/jackson-jsontypeinfo-property-is-being-mapped-as-null

It allows the following usage:
```java
    @Override
    public void onProjectEvent(ProjectSystemHookEvent event) {
        switch (event.getEventName()) {
            case ProjectSystemHookEvent.PROJECT_CREATE_EVENT:
                log.info("Project created {}", event.getName());
                break;
            case ProjectSystemHookEvent.PROJECT_DESTROY_EVENT:
                log.info("Project destroyed {}", event.getName());
                break;
        }
    }
```