### PR TITLE
Added encoding to the tag name where the tag name is used in the url path

### DIFF
--- a/src/main/java/org/gitlab4j/api/TagsApi.java
+++ b/src/main/java/org/gitlab4j/api/TagsApi.java
@@ -94,7 +94,7 @@ public class TagsApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Tag getTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName));
+        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName));
         return (response.readEntity(Tag.class));
     }
 
@@ -198,7 +198,7 @@ public class TagsApi extends AbstractApi {
      */
     public void deleteTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
         Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName));
+        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName));
     }
 
     /**
@@ -215,7 +215,7 @@ public class TagsApi extends AbstractApi {
     public Release createRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
         Form formData = new GitLabApiForm().withParam("description", releaseNotes);
         Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName), "release");
+                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName), "release");
         return (response.readEntity(Release.class));
     }
 
@@ -233,11 +233,8 @@ public class TagsApi extends AbstractApi {
     public Release updateRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
         Form formData = new GitLabApiForm().withParam("description", releaseNotes);
         Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName), "release");
+                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName), "release");
         return (response.readEntity(Release.class));
     }
 
-    private String getTagForPath(String tag) throws GitLabApiException {
-        return urlEncode(tag);
-    }
 }

--- a/src/main/java/org/gitlab4j/api/TagsApi.java
+++ b/src/main/java/org/gitlab4j/api/TagsApi.java
@@ -94,7 +94,7 @@ public class TagsApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Tag getTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", tagName);
+        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName));
         return (response.readEntity(Tag.class));
     }
 
@@ -198,7 +198,7 @@ public class TagsApi extends AbstractApi {
      */
     public void deleteTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
         Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", tagName);
+        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName));
     }
 
     /**
@@ -215,7 +215,7 @@ public class TagsApi extends AbstractApi {
     public Release createRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
         Form formData = new GitLabApiForm().withParam("description", releaseNotes);
         Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", tagName, "release");
+                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName), "release");
         return (response.readEntity(Release.class));
     }
 
@@ -233,7 +233,11 @@ public class TagsApi extends AbstractApi {
     public Release updateRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
         Form formData = new GitLabApiForm().withParam("description", releaseNotes);
         Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", tagName, "release");
+                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", getTagForPath(tagName), "release");
         return (response.readEntity(Release.class));
+    }
+
+    private String getTagForPath(String tag) throws GitLabApiException {
+        return urlEncode(tag);
     }
 }

--- a/src/test/java/org/gitlab4j/api/TestTagsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestTagsApi.java
@@ -23,6 +23,7 @@ public class TestTagsApi extends AbstractIntegrationTest {
 
     private static final String TEST_TAG_NAME_1 = "test-tag-1";
     private static final String TEST_TAG_NAME_0 = "test-tag-0";
+    private static final String TEST_TAG_WITH_SLASH = "env/test-tag";
 
     private static GitLabApi gitLabApi;
     private static Project testProject;
@@ -46,6 +47,10 @@ public class TestTagsApi extends AbstractIntegrationTest {
             try {
                 gitLabApi.getTagsApi().deleteTag(testProject, TEST_TAG_NAME_1);
             } catch (Exception ignore) {}
+
+            try {
+                gitLabApi.getTagsApi().deleteTag(testProject, TEST_TAG_WITH_SLASH);
+            } catch (Exception ignore) {}
         }
     }
 
@@ -58,6 +63,10 @@ public class TestTagsApi extends AbstractIntegrationTest {
 
             try {
                 gitLabApi.getTagsApi().deleteTag(testProject, TEST_TAG_NAME_1);
+            } catch (Exception ignore) {}
+
+            try {
+                gitLabApi.getTagsApi().deleteTag(testProject, TEST_TAG_WITH_SLASH);
             } catch (Exception ignore) {}
         }
     }
@@ -126,5 +135,16 @@ public class TestTagsApi extends AbstractIntegrationTest {
         assertNotNull(tags);
         assertTrue(tags.getTotalItems() > 0);
         assertTrue(tags.stream().map(Tag::getName).anyMatch(s -> TEST_TAG_NAME_0.equals(s)));
+    }
+
+    @Test
+    public void testGetTagWithSpecialCharacersInTagName() throws GitLabApiException {
+        Tag testTag = gitLabApi.getTagsApi().createTag(testProject, TEST_TAG_WITH_SLASH, "master");
+        assertNotNull(testTag);
+        assertEquals(TEST_TAG_WITH_SLASH, testTag.getName());
+
+        testTag = gitLabApi.getTagsApi().getTag(testProject, TEST_TAG_WITH_SLASH);
+        assertNotNull(testTag);
+        assertEquals(TEST_TAG_WITH_SLASH, testTag.getName());
     }
 }


### PR DESCRIPTION
The GET and DELETE calls on Gitlab put the tag name on the path itself.  This is problematic if you have a tag with URL reserved characters (i.e. a slash).  This should fix #369 by url encoding the tag prior to setting it on the path.