### PR TITLE
Fix ISO8601 parser for date with colon offset

### DIFF
--- a/src/main/java/org/gitlab4j/api/utils/ISO8601.java
+++ b/src/main/java/org/gitlab4j/api/utils/ISO8601.java
@@ -28,7 +28,7 @@ public class ISO8601 {
     public static final String UTC_PATTERN = "yyyy-MM-dd HH:mm:ss 'UTC'";
 
     private static final DateTimeFormatter ODT_WITH_MSEC_PARSER = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd[['T'][ ]HH:mm:ss.SSS[ ][XXXXX][XXXX]]").toFormatter();
-    private static final DateTimeFormatter ODT_PARSER = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS][ ][X][XXX]]")
+    private static final DateTimeFormatter ODT_PARSER = new DateTimeFormatterBuilder().appendPattern("yyyy-MM-dd[['T'][ ]HH:mm:ss[.SSS][ ][XXX][X]]")
         .parseDefaulting(ChronoField.HOUR_OF_DAY, 0)
         .parseDefaulting(ChronoField.MINUTE_OF_HOUR, 0)
         .parseDefaulting(ChronoField.SECOND_OF_MINUTE, 0)

--- a/src/test/java/org/gitlab4j/api/TestISO8601.java
+++ b/src/test/java/org/gitlab4j/api/TestISO8601.java
@@ -20,8 +20,10 @@ public class TestISO8601 {
     private static final String SPACEY_GITLAB_DATE_WITH_MSEC = "2018-03-12 10:16:46.123 +0700";
     private static final String ISO8601_GITLAB_DATE_WITH_MSEC ="2018-03-12T10:16:46.123+0700";
 
+    private static final String ISO8601_DATE_OFFSET_COLON = "2018-03-12T10:16:46+07:00";
+
     private static final String ISO8601_DATE_MSEC = "2018-03-12T10:16:46.123Z";
-    private static final String ISO8601_DATE_OFFSET_COLON = "2018-03-12T10:16:46.123+00:00";
+    private static final String ISO8601_DATE_MSEC_OFFSET_COLON = "2018-03-12T10:16:46.123+00:00";
     private static final String ISO8601_GITLAB_DATE_MSEC = "2018-03-12T03:16:46.123-0700";
     private static final String SPACEY_GITLAB_UTC_DATE_MSEC = "2018-03-12 10:16:46.123 UTC";
 
@@ -69,8 +71,15 @@ public class TestISO8601 {
 
     @Test
     public void testOffsetColonDateParse() throws ParseException {
+        Date gitlabOffsetDate = ISO8601.toDate(ISO8601_DATE_OFFSET_COLON);
+        Date gitlabDate = ISO8601.toDate(ISO8601_GITLAB_DATE);
+        assertEquals(gitlabDate, gitlabOffsetDate);
+    }
+
+    @Test
+    public void testOffsetColonMsecDateParse() throws ParseException {
         Date msecDate = ISO8601.toDate(ISO8601_DATE_MSEC);
-        Date gitlabMsecDate = ISO8601.toDate(ISO8601_DATE_OFFSET_COLON);
+        Date gitlabMsecDate = ISO8601.toDate(ISO8601_DATE_MSEC_OFFSET_COLON);
         assertEquals(msecDate, gitlabMsecDate);
     }
 }


### PR DESCRIPTION
 - Dates with colon offset like "2018-03-12T10:16:46+07:00" threw a
   DateTimeParseException
 - Changing the order of the offset patterns fixes this