### PR TITLE
Add support for multiple assignees in Merge Requests

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -14,6 +14,7 @@ public class MergeRequest {
     private Boolean allowMaintainerToPush;
     private Integer approvalsBeforeMerge;
     private Assignee assignee;
+    private List<Assignee> assignees;
     private Author author;
     private List<Diff> changes;
     private Date closedAt;
@@ -84,6 +85,14 @@ public class MergeRequest {
 
     public void setApprovalsBeforeMerge(Integer approvalsBeforeMerge) {
         this.approvalsBeforeMerge = approvalsBeforeMerge;
+    }
+
+    public List<Assignee> getAssignees() {
+        return assignees;
+    }
+
+    public void setAssignees(List<Assignee> assignees) {
+        this.assignees = assignees;
     }
 
     public Assignee getAssignee() {

--- a/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -87,20 +87,20 @@ public class MergeRequest {
         this.approvalsBeforeMerge = approvalsBeforeMerge;
     }
 
-    public List<Assignee> getAssignees() {
-        return assignees;
-    }
-
-    public void setAssignees(List<Assignee> assignees) {
-        this.assignees = assignees;
-    }
-
     public Assignee getAssignee() {
         return assignee;
     }
 
     public void setAssignee(Assignee assignee) {
         this.assignee = assignee;
+    }
+
+    public List<Assignee> getAssignees() {
+        return assignees;
+    }
+
+    public void setAssignees(List<Assignee> assignees) {
+        this.assignees = assignees;
     }
 
     public Author getAuthor() {


### PR DESCRIPTION
GitLab supports multiple assignees for Merge Requests.
I added this field to the MergeRequest object, so it can be used.