### PR TITLE
add a method to get pager of commit refs

### DIFF
--- a/src/main/java/org/gitlab4j/api/CommitsApi.java
+++ b/src/main/java/org/gitlab4j/api/CommitsApi.java
@@ -362,7 +362,7 @@ public class CommitsApi extends AbstractApi {
     }
 
     /**
-     * Get a specific commit identified by the commit hash or name of a branch or tag as an Optional instance
+     * Get all references (from branches or tags) a commit is pushed to
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs</code></pre>
      *
@@ -377,7 +377,23 @@ public class CommitsApi extends AbstractApi {
     }
 
     /**
-     * Get a specific commit identified by the commit hash or name of a branch or tag as an Optional instance
+     * Get all references (from branches or tags) a commit is pushed to
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param sha a commit hash or name of a branch or tag
+     * @param itemsPerPage the number of Commit instances that will be fetched per page
+     * @return Get all references (from branches or tags) a commit is pushed to
+     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+     * @since Gitlab 10.6
+     */
+    public Pager<CommitRef> getCommitRefs(Object projectIdOrPath, String sha, int itemsPerPage) throws GitLabApiException {
+        return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, itemsPerPage));
+    }
+
+    /**
+     * Get all references (from branches or tags) a commit is pushed to
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
      *
@@ -394,6 +410,24 @@ public class CommitsApi extends AbstractApi {
                 .withParam(PER_PAGE_PARAM, getDefaultPerPage());
         Response response = get(Response.Status.OK, form.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha), "refs");
         return (response.readEntity(new GenericType<List<CommitRef>>(){}));
+    }
+
+    /**
+     * Get all references (from branches or tags) a commit is pushed to
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param sha a commit hash or name of a branch or tag
+     * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
+     * @param itemsPerPage the number of Commit instances that will be fetched per page
+     * @return Get all references (from branches or tags) a commit is pushed to
+     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+     * @since Gitlab 10.6
+     */
+    public Pager<CommitRef> getCommitRefs(Object projectIdOrPath, String sha, CommitRef.RefType refType, int itemsPerPage) throws GitLabApiException {
+        Form form = new GitLabApiForm().withParam("type", refType);
+        return (new Pager<CommitRef>(this, CommitRef.class, itemsPerPage, form.asMap(),  "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha), "refs"));
     }
 
     /**


### PR DESCRIPTION
@gmessner Regarding #505 . This is my novice attempt (without integration test since I don't quite know how you like to setup test for Pager -- create multiple branches from a commit?). Hope this helps!