### PR TITLE
Add search branch

### DIFF
--- a/README.md
+++ b/README.md
@@ -500,7 +500,11 @@ List<Release> releases = gitLabApi.getReleasesApi().getReleases(projectId);
 #### RepositoryApi
 ```java
 // Get a list of repository branches from a project, sorted by name alphabetically
-List<Branch> branches = gitLabApi.getRepositoryApi().getBranches();
+List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(projectId);
+```
+```java
+// Search repository branches from a project, by name
+List<Branch> branches = gitLabApi.getRepositoryApi().searchBranch(projectId, searchTerm);
 ```
 
 #### RepositoryFileApi

--- a/README.md
+++ b/README.md
@@ -504,7 +504,7 @@ List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(projectId);
 ```
 ```java
 // Search repository branches from a project, by name
-List<Branch> branches = gitLabApi.getRepositoryApi().searchBranch(projectId, searchTerm);
+List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(projectId, searchTerm);
 ```
 
 #### RepositoryFileApi

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -12,6 +12,7 @@ import java.util.stream.Stream;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MediaType;
+import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.gitlab4j.api.GitLabApi.ApiVersion;
@@ -104,6 +105,26 @@ public class RepositoryApi extends AbstractApi {
         Response response = get(Response.Status.OK, null, "projects",
                 getProjectIdOrPath(projectIdOrPath), "repository", "branches", urlEncode(branchName));
         return (response.readEntity(Branch.class));
+    }
+
+    /**
+     * Search a single project repository branch by term.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:term</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param term the branch name search term
+     * @return the branches matching the saerch term by name for the specified project ID
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Branch> searchBranch(Object projectIdOrPath, String term) throws GitLabApiException {
+        MultivaluedMap<String, String> queryParams =
+            new GitLabApiForm().withParam("search", urlEncode(term)).asMap();
+
+        Response response = get(Response.Status.OK, queryParams, "projects",
+                getProjectIdOrPath(projectIdOrPath), "repository", "branches");
+        return (response.readEntity(new GenericType<List<Branch>>() {}));
+
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -42,7 +42,7 @@ public class RepositoryApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public List<Branch> getBranches(Object projectIdOrPath) throws GitLabApiException {
-        return (getBranches(projectIdOrPath, getDefaultPerPage()).all());
+        return getBranches(projectIdOrPath, null);
     }
 
     /**
@@ -74,8 +74,7 @@ public class RepositoryApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Pager<Branch> getBranches(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Branch>(this, Branch.class, itemsPerPage, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches"));
+        return getBranches(projectIdOrPath, null, itemsPerPage);
     }
 
     /**
@@ -88,7 +87,7 @@ public class RepositoryApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Stream<Branch> getBranchesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getBranches(projectIdOrPath, getDefaultPerPage()).stream());
+        return getBranchesStream(projectIdOrPath, null);
     }
 
     /**
@@ -108,23 +107,52 @@ public class RepositoryApi extends AbstractApi {
     }
 
     /**
-     * Search a single project repository branch by term.
+     * Get a List of repository branches from a project, sorted by name alphabetically, filter by the search term.
      *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:term</code></pre>
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
-     * @param term the branch name search term
-     * @return the branches matching the saerch term by name for the specified project ID
+     * @param search the branch name search term
+     * @return the List of repository branches for the specified project ID and search term
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Branch> searchBranch(Object projectIdOrPath, String term) throws GitLabApiException {
-        MultivaluedMap<String, String> queryParams =
-            new GitLabApiForm().withParam("search", urlEncode(term)).asMap();
+    public List<Branch> getBranches(Object projectIdOrPath, String search) throws GitLabApiException {
+        return (getBranches(projectIdOrPath, search, getDefaultPerPage()).all());
+    }
 
-        Response response = get(Response.Status.OK, queryParams, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches");
-        return (response.readEntity(new GenericType<List<Branch>>() {}));
+    /**
+     * Get a Stream of repository branches from a project, sorted by name alphabetically, filter by the search term.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param search the branch name search term
+     * @return the Stream of repository branches for the specified project ID and search term
+     *
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Stream<Branch> getBranchesStream(Object projectIdOrPath, String search) throws GitLabApiException {
+        return (getBranches(projectIdOrPath, search, getDefaultPerPage()).stream());
+    }
 
+    /**
+     * Get a Pager of repository branches from a project, sorted by name alphabetically, filter by the search term.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param search the branch name search term
+     * @param itemsPerPage the number of Project instances that will be fetched per page
+     * @return the list of repository branches for the specified project ID and search term
+     *
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Branch> getBranches(Object projectIdOrPath, String search, int itemsPerPage) throws GitLabApiException {
+        MultivaluedMap<String, String> queryParams = ( search == null ? null :
+            new GitLabApiForm().withParam("search", urlEncode(search)).asMap() );
+
+        return (new Pager<Branch>(this, Branch.class, itemsPerPage, queryParams, "projects",
+                getProjectIdOrPath(projectIdOrPath), "repository", "branches"));
     }
 
     /**
@@ -243,7 +271,7 @@ public class RepositoryApi extends AbstractApi {
     }
 
     /**
-     * Get a list of repository files and directories in a project.
+     * Get a Stream of repository files and directories in a project.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
      *

--- a/src/test/java/org/gitlab4j/api/IntegrationTestSuite.java
+++ b/src/test/java/org/gitlab4j/api/IntegrationTestSuite.java
@@ -128,7 +128,7 @@ public class IntegrationTestSuite implements PropertyConstants {
                 AccessTokenUtils.revokePersonalAccessToken(
                     TEST_HOST_URL, TEST_LOGIN_USERNAME, TEST_LOGIN_PASSWORD,
                     TEST_PRIVATE_TOKEN_NAME, Arrays.asList(Scope.API, Scope.SUDO));
-                System.out.format("Revoved '%s'%n", TEST_PRIVATE_TOKEN_NAME);
+                System.out.format("Revoked '%s'%n", TEST_PRIVATE_TOKEN_NAME);
             } catch (Exception ignore) {}
         }
 
@@ -137,7 +137,7 @@ public class IntegrationTestSuite implements PropertyConstants {
                 AccessTokenUtils.revokePersonalAccessToken(
                     TEST_HOST_URL, TEST_LOGIN_USERNAME, TEST_LOGIN_PASSWORD,
                     TEST_ACCESS_TOKEN_NAME, Arrays.asList(Scope.API, Scope.SUDO));
-                System.out.format("Revoved '%s'%n", TEST_ACCESS_TOKEN_NAME);
+                System.out.format("Revoked '%s'%n", TEST_ACCESS_TOKEN_NAME);
             } catch (Exception ignore) {}
         }
     }

--- a/src/test/java/org/gitlab4j/api/TestRepositoryApi.java
+++ b/src/test/java/org/gitlab4j/api/TestRepositoryApi.java
@@ -44,6 +44,7 @@ import org.junit.runners.MethodSorters;
 public class TestRepositoryApi extends AbstractIntegrationTest {
 
     private static final String TEST_BRANCH_NAME = "feature/test_branch";
+    private static final String TEST_BRANCH_SEARCH_TERM = "test";
     private static final String TEST_BRANCH1 = "feature/test_branch1";
     private static final String TEST_BRANCH2 = "feature/test_branch2";
     private static final String TEST_PROTECT_BRANCH_NAME = "feature/protect_branch";
@@ -108,6 +109,16 @@ public class TestRepositoryApi extends AbstractIntegrationTest {
         assertNotNull(fetchedBranch);
 
         assertEquals(branch.getName(), fetchedBranch.getName());
+    }
+
+    @Test
+    public void testCreateBranchAndAfterSearch() throws GitLabApiException {
+        Project project = gitLabApi.getProjectApi().getProject(TEST_NAMESPACE, TEST_PROJECT_NAME);
+        assertNotNull(project);
+
+        List<Branch> searchBranch = gitLabApi.getRepositoryApi().searchBranch(project.getId(), TEST_BRANCH_SEARCH_TERM);
+
+        assertEquals(searchBranch.size(),1);
     }
 
     @Test

--- a/src/test/java/org/gitlab4j/api/TestRepositoryApi.java
+++ b/src/test/java/org/gitlab4j/api/TestRepositoryApi.java
@@ -108,17 +108,13 @@ public class TestRepositoryApi extends AbstractIntegrationTest {
         Branch fetchedBranch = gitLabApi.getRepositoryApi().getBranch(project.getId(), TEST_BRANCH_NAME);
         assertNotNull(fetchedBranch);
 
+        List<Branch> searchBranches = gitLabApi.getRepositoryApi().getBranches(project.getId(), TEST_BRANCH_SEARCH_TERM);
+        assertEquals(searchBranches.size(), 1);
+
+        searchBranches = gitLabApi.getRepositoryApi().getBranches(project.getId());
+        assertTrue(searchBranches.size() > 1);
+
         assertEquals(branch.getName(), fetchedBranch.getName());
-    }
-
-    @Test
-    public void testCreateBranchAndAfterSearch() throws GitLabApiException {
-        Project project = gitLabApi.getProjectApi().getProject(TEST_NAMESPACE, TEST_PROJECT_NAME);
-        assertNotNull(project);
-
-        List<Branch> searchBranch = gitLabApi.getRepositoryApi().searchBranch(project.getId(), TEST_BRANCH_SEARCH_TERM);
-
-        assertEquals(searchBranch.size(),1);
     }
 
     @Test


### PR DESCRIPTION
Since Gitlab 10.6 the Branches API has a search param for branch search.
See: https://gitlab.com/gitlab-org/gitlab-foss/-/merge_requests/17005/diffs
Documentation: https://docs.gitlab.com/ee/api/branches.html
Example call: http://localhost:8090/api/v4/projects/1/repository/branches?search=test