### PR TITLE
Add squash option to `acceptMergeRequest` method. Fixes #516

### DIFF
--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -10,6 +10,7 @@ import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
 import org.gitlab4j.api.GitLabApi.ApiVersion;
+import org.gitlab4j.api.models.AcceptMergeRequestParams;
 import org.gitlab4j.api.models.ApprovalRule;
 import org.gitlab4j.api.models.ApprovalRuleParams;
 import org.gitlab4j.api.models.ApprovalState;
@@ -593,6 +594,41 @@ public class MergeRequestApi extends AbstractApi {
 
         Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
         delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid);
+    }
+
+    /**
+     * Merge changes to the merge request. If the MR has any conflicts and can not be merged,
+     * you'll get a 405 and the error message 'Branch cannot be merged'. If merge request is
+     * already merged or closed, you'll get a 406 and the error message 'Method Not Allowed'.
+     * If the sha parameter is passed and does not match the HEAD of the source, you'll get
+     * a 409 and the error message 'SHA does not match HEAD of source branch'.  If you don't
+     * have permissions to accept this merge request, you'll get a 401.
+     *
+     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
+     *
+     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @param params the MergeRequest instance holding the parameters for accepting the merge request
+     * @return the merged merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public MergeRequest acceptMergeRequest(
+            Object projectIdOrPath,
+            Integer mergeRequestIid,
+            AcceptMergeRequestParams params
+    ) throws GitLabApiException {
+        Response response = put(
+                Response.Status.OK,
+                params.getForm(),
+                "projects",
+                getProjectIdOrPath(projectIdOrPath),
+                "merge_requests",
+                mergeRequestIid,
+                "merge"
+        );
+        return (response.readEntity(MergeRequest.class));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
+++ b/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
@@ -1,0 +1,94 @@
+package org.gitlab4j.api.models;
+
+import org.gitlab4j.api.GitLabApiForm;
+
+public class AcceptMergeRequestParams {
+
+    private String mergeCommitMessage;
+    private Boolean mergeWhenPipelineSucceeds;
+    private String sha;
+    private Boolean shouldRemoveSourceBranch;
+    private Boolean squash;
+    private String squashCommitMessage;
+
+    /**
+     * Custom merge commit message.
+     *
+     * @param mergeCommitMessage Custom merge commit message
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withMergeCommitMessage(String mergeCommitMessage) {
+        this.mergeCommitMessage = mergeCommitMessage;
+        return this;
+    }
+
+    /**
+     * If {@code true} the MR is merged when the pipeline succeeds.
+     *
+     * @param mergeWhenPipelineSucceeds If {@code true} the MR is merged when the pipeline succeeds.
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withMergeWhenPipelineSucceeds(Boolean mergeWhenPipelineSucceeds) {
+        this.mergeWhenPipelineSucceeds = mergeWhenPipelineSucceeds;
+        return this;
+    }
+
+    /**
+     * If present, then this SHA must match the HEAD of the source branch, otherwise the merge will fail.
+     *
+     * @param sha If present, then this SHA must match the HEAD of the source branch, otherwise the merge will fail.
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withSha(String sha) {
+        this.sha = sha;
+        return this;
+    }
+
+    /**
+     * If {@code true} removes the source branch.
+     *
+     * @param shouldRemoveSourceBranch If {@code true} removes the source branch.
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withShouldRemoveSourceBranch(Boolean shouldRemoveSourceBranch) {
+        this.shouldRemoveSourceBranch = shouldRemoveSourceBranch;
+        return this;
+    }
+
+    /**
+     * If {@code true} the commits will be squashed into a single commit on merge.
+     *
+     * @param squash If {@code true} the commits will be squashed into a single commit on merge.
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withSquash(Boolean squash) {
+        this.squash = squash;
+        return this;
+    }
+
+    /**
+     * Custom squash commit message.
+     *
+     * @param squashCommitMessage Custom squash commit message.
+     * @return The reference to this AcceptMergeRequestParams instance.
+     */
+    public AcceptMergeRequestParams withSquashCommitMessage(String squashCommitMessage) {
+        this.squashCommitMessage = squashCommitMessage;
+        return this;
+    }
+
+    /**
+     * Get the form params specified by this instance.
+     *
+     * @return a GitLabApiForm instance holding the form parameters for this AcceptMergeRequestParams instance
+     */
+    public GitLabApiForm getForm() {
+        return new GitLabApiForm()
+                .withParam("merge_commit_message", mergeCommitMessage)
+                .withParam("merge_when_pipeline_succeeds", mergeWhenPipelineSucceeds)
+                .withParam("sha", sha)
+                .withParam("should_remove_source_branch", shouldRemoveSourceBranch)
+                .withParam("squash", squash)
+                .withParam("squash_commit_message", squashCommitMessage);
+    }
+}


### PR DESCRIPTION
This pull request adds an additional `Boolean` option to `MergeRequestApi.acceptMergeRequest()` that sets the [squash option](https://docs.gitlab.com/ee/api/merge_requests.html#accept-mr).

This fixes #516.