### PR TITLE
Implement AutoCloseable to close the underlying client.

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api;
 
+import java.io.Closeable;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -23,7 +24,7 @@ import org.gitlab4j.api.utils.SecretString;
  * This class is provides a simplified interface to a GitLab API server, and divides the API up into
  * a separate API class for each concern.
  */
-public class GitLabApi {
+public class GitLabApi implements AutoCloseable {
 
     private final static Logger LOGGER = Logger.getLogger(GitLabApi.class.getName());
 
@@ -480,6 +481,17 @@ public class GitLabApi {
     public GitLabApi withRequestResponseLogging(Logger logger, Level level) {
         enableRequestResponseLogging(logger, level);
         return (this);
+    }
+
+
+    /**
+     * Close the underlying {@link javax.ws.rs.client.Client} and its associated resources.
+     */
+    @Override
+    public void close() {
+        if (apiClient != null) {
+            apiClient.close();
+        }
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -48,7 +48,7 @@ import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 /**
  * This class utilizes the Jersey client package to communicate with a GitLab API endpoint.
  */
-public class GitLabApiClient {
+public class GitLabApiClient implements AutoCloseable {
 
     protected static final String PRIVATE_TOKEN_HEADER  = "PRIVATE-TOKEN";
     protected static final String SUDO_HEADER           = "Sudo";
@@ -241,6 +241,16 @@ public class GitLabApiClient {
 
         clientConfig.register(JacksonJson.class);
         clientConfig.register(MultiPartFeature.class);
+    }
+
+    /**
+     * Close the underlying {@link Client} and its associated resources.
+     */
+    @Override
+    public void close() {
+        if (apiClient != null) {
+            apiClient.close();
+        }
     }
 
     /**


### PR DESCRIPTION
I'm not certain if this is completely necessary, but it seems like a "doesn't hurt" sort of thing.

I did notice that the the [Client interface docs](https://docs.oracle.com/javaee/7/api/javax/ws/rs/client/Client.html) say the client should be closed before being disposed; so I made the `GitLabApi` and subsequent `GitLabApiClient` classes implement `AutoCloseable` to close the `JerseyClient` that is used.