### PR TITLE
Fix serialization error with new params.

### DIFF
--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -616,7 +616,7 @@ public class MergeRequestApi extends AbstractApi {
      */
     public MergeRequest acceptMergeRequest(Object projectIdOrPath, Integer mergeRequestIid,
             AcceptMergeRequestParams params) throws GitLabApiException {
-        Response response = put(Response.Status.OK, params.getForm(), "projects",
+        Response response = put(Response.Status.OK, params.getForm().asMap(), "projects",
         	getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "merge");
         return (response.readEntity(MergeRequest.class));
     }


### PR DESCRIPTION
It looks like I forgot to add `.asMap()` to the new merge request acceptance parameters. Without this, it blows up with: `org.gitlab4j.api.GitLabApiException: com.fasterxml.jackson.databind.exc.InvalidDefinitionException: No serializer found for class org.gitlab4j.api.GitLabApiForm and no properties discovered to create BeanSerializer (to avoid exception, disable SerializationFeature.FAIL_ON_EMPTY_BEANS)`

This change fixes that.