### PR TITLE
fix issue with getting project repository archive for gitlab 12.9.1

### DIFF
--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -441,7 +441,7 @@ public class RepositoryApi extends AbstractApi {
      */
     public InputStream getRepositoryArchive(Object projectIdOrPath, String sha) throws GitLabApiException {
         Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
+        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
                 "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive");
         return (response.readEntity(InputStream.class));
     }
@@ -487,7 +487,7 @@ public class RepositoryApi extends AbstractApi {
          *         https://gitlab.com/gitlab-com/support-forum/issues/3067
          */
         Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
+        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
                 "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive" + "." + format.toString());
         return (response.readEntity(InputStream.class));
     }
@@ -507,7 +507,7 @@ public class RepositoryApi extends AbstractApi {
     public File getRepositoryArchive(Object projectIdOrPath, String sha, File directory) throws GitLabApiException {
 
         Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
+        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
                 "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive");
 
         try {
@@ -572,7 +572,7 @@ public class RepositoryApi extends AbstractApi {
          *         https://gitlab.com/gitlab-com/support-forum/issues/3067
          */
         Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
+        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
                 "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive" + "." + format.toString());
 
         try {


### PR DESCRIPTION
In `Gitlab 12.9.1` we see a problem with the [`repository archive` API](https://docs.gitlab.com/ee/api/repositories.html#get-file-archive). It behaves quite differently due to changes in how Gitlab handle [hotlinking](https://gitlab.com/gitlab-org/gitlab/-/commit/50c11f278d18fe1f3fb12eb595067216bb58ade2) and [blocking inappropriate repository archive creation](https://gitlab.com/gitlab-org/gitlab/-/merge_requests/23926). Based on this, we did a little bit of digging and we have categorized the new behaviors into 3 following cases:
1. If we DO NOT send `Accept` header to `/repository/archive`: it works
2. If we send `Accept: *`: we get `404 File Not Found` for internal projects and `406 Not Acceptable` for public projects
3. If we send `Accept: */*`: it works

Now it seems that by the [RFC spec](https://tools.ietf.org/html/rfc7231#section-5.3.2) we should send `Accept: */*` instead of `Accept: *` and this PR addresses this issue. I have limited this fix to only `repository/archive` API so maybe, you @gmessner with a much better understanding of the problem will see where it fits in the current codebase of `gitlab4j` and apply this to other places. 

@gmessner  As for this PR alone can please you review and publish it since it's breaking right now in our production as our dev ops have already deployed `Gitlab@12.9.1` :(. Thank you so much! 