### PR TITLE
Include Project in RunnersAPI.getJobs* (Issue #552)

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -300,7 +300,7 @@ public class Job {
         return this;
     }
 
-    public Job allowFailureManual(Boolean allowFailure) {
+    public Job withAllowFailure(Boolean allowFailure) {
         this.allowFailure = allowFailure;
         return this;
     }

--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -29,6 +29,7 @@ public class Job {
     private Boolean manual;
     private Boolean allowFailure;
     private Float duration;
+    private Project project;
 
     public Integer getId() {
         return id;
@@ -205,6 +206,14 @@ public class Job {
     public void setDuration(Float duration) {
         this.duration = duration;
     }
+    
+    public Project getProject() {
+        return project;
+    }
+    
+    public void setProject(Project project) {
+        this.project = project;
+    }
 
     public Job withId(Integer id) {
         this.id = id;
@@ -293,6 +302,16 @@ public class Job {
 
     public Job allowFailureManual(Boolean allowFailure) {
         this.allowFailure = allowFailure;
+        return this;
+    }
+    
+    public Job withDuration(Float duration) {
+        this.duration = duration;
+        return this;
+    }
+    
+    public Job withProject(Project project) {
+        this.project = project;
         return this;
     }
 

--- a/src/test/resources/org/gitlab4j/api/job.json
+++ b/src/test/resources/org/gitlab4j/api/job.json
@@ -50,4 +50,15 @@
       "web_url": "http://gitlab.dev/root",
       "website_url": ""
     }
+    ,
+    "project": {
+      "id": 3,
+      "name": "Diaspora Project Site",
+      "description": "Project description",
+      "name_with_namespace": "Diaspora / Diaspora Project Site",
+      "path": "diaspora-project-site",
+      "path_with_namespace": "diaspora/diaspora-project-site",
+      "created_at": "2013-09-30T13:46:02Z"
+      
+    }
 }


### PR DESCRIPTION
Hi

I added project attribute in Job class, this will work for RunnersAPI but may be confusing for JobAPI (that will never return Project Information but that uses the same class).

I also added withDuration missing method.

Olivier