### PR TITLE
Update commit API to be conformant to spec

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -8,6 +8,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class Commit {
 
+    private Author author;
     private Date authoredDate;
     private String authorEmail;
     private String authorName;
@@ -23,8 +24,17 @@ public class Commit {
     private String status;
     private Date timestamp;
     private String title;
+    private String url;
     private String webUrl;
     private Pipeline lastPipeline;
+
+    public Author getAuthor() {
+        return author;
+    }
+
+    public void setAuthor(Author author) {
+        this.author = author;
+    }
 
     public Date getAuthoredDate() {
         return authoredDate;
@@ -146,11 +156,19 @@ public class Commit {
         this.title = title;
     }
 
-    public String getWebUrl() {
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    public String getwebUrl() {
         return webUrl;
     }
 
-    public void setWebUrl(String webUrl) {
+    public void setwebUrl(String webUrl) {
         this.webUrl = webUrl;
     }
 
@@ -163,6 +181,7 @@ public class Commit {
     }
 
     public Commit withAuthor(Author author) {
+        this.author = author;
         return this;
     }
 
@@ -242,7 +261,7 @@ public class Commit {
     }
 
     public Commit withUrl(String url) {
-        this.webUrl = url;
+        this.url = url;
         return this;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -24,7 +24,7 @@ public class Commit {
     private String status;
     private Date timestamp;
     private String title;
-    private String url;
+    private String webUrl;
     private Pipeline lastPipeline;
 
     public Author getAuthor() {
@@ -155,12 +155,12 @@ public class Commit {
         this.title = title;
     }
 
-    public String getUrl() {
-        return url;
+    public String getWebUrl() {
+        return webUrl;
     }
 
-    public void setUrl(String url) {
-        this.url = url;
+    public void setWebUrl(String webUrl) {
+        this.webUrl = webUrl;
     }
 
     public Pipeline getLastPipeline() {
@@ -252,7 +252,7 @@ public class Commit {
     }
 
     public Commit withUrl(String url) {
-        this.url = url;
+        this.webUrl = url;
         return this;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -8,7 +8,6 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class Commit {
 
-    private Author author;
     private Date authoredDate;
     private String authorEmail;
     private String authorName;
@@ -26,14 +25,6 @@ public class Commit {
     private String title;
     private String webUrl;
     private Pipeline lastPipeline;
-
-    public Author getAuthor() {
-        return author;
-    }
-
-    public void setAuthor(Author author) {
-        this.author = author;
-    }
 
     public Date getAuthoredDate() {
         return authoredDate;
@@ -172,7 +163,6 @@ public class Commit {
     }
 
     public Commit withAuthor(Author author) {
-        this.author = author;
         return this;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Event.java
+++ b/src/main/java/org/gitlab4j/api/models/Event.java
@@ -12,7 +12,6 @@ public class Event {
     private Author author;
     private Integer authorId;
     private String authorUsername;
-    private EventData data;
     private Integer projectId;
     private Integer targetId;
     private Integer targetIid;
@@ -54,14 +53,6 @@ public class Event {
 
     public void setAuthorUsername(String authorUsername) {
         this.authorUsername = authorUsername;
-    }
-
-    public EventData getData() {
-        return data;
-    }
-
-    public void setData(EventData data) {
-        this.data = data;
     }
 
     public Integer getProjectId() {
@@ -153,11 +144,6 @@ public class Event {
 
     public Event withAuthorUsername(String authorUsername) {
         this.authorUsername = authorUsername;
-        return this;
-    }
-
-    public Event withData(EventData data) {
-        this.data = data;
         return this;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/Event.java
+++ b/src/main/java/org/gitlab4j/api/models/Event.java
@@ -12,6 +12,7 @@ public class Event {
     private Author author;
     private Integer authorId;
     private String authorUsername;
+    private EventData data;
     private Integer projectId;
     private Integer targetId;
     private Integer targetIid;
@@ -53,6 +54,14 @@ public class Event {
 
     public void setAuthorUsername(String authorUsername) {
         this.authorUsername = authorUsername;
+    }
+
+    public EventData getData() {
+        return data;
+    }
+
+    public void setData(EventData data) {
+        this.data = data;
     }
 
     public Integer getProjectId() {
@@ -144,6 +153,11 @@ public class Event {
 
     public Event withAuthorUsername(String authorUsername) {
         this.authorUsername = authorUsername;
+        return this;
+    }
+
+    public Event withData(EventData data) {
+        this.data = data;
         return this;
     }
 

--- a/src/test/resources/org/gitlab4j/api/commit.json
+++ b/src/test/resources/org/gitlab4j/api/commit.json
@@ -18,5 +18,6 @@
     "deletions": 10,
     "total": 25
   },
-  "status": "running"
+  "status": "running",
+  "web_url": "http://localhost/diaspora/diaspora-project-site/-/commit/9df4dd1f0dfae80c05eac4b2bd461b86db5c8e2d"
 }

--- a/src/test/resources/org/gitlab4j/api/commit.json
+++ b/src/test/resources/org/gitlab4j/api/commit.json
@@ -19,5 +19,6 @@
     "total": 25
   },
   "status": "running",
+  "url": "http://localhost/diaspora/diaspora-project-site/-/commit/9df4dd1f0dfae80c05eac4b2bd461b86db5c8e2d",
   "web_url": "http://localhost/diaspora/diaspora-project-site/-/commit/9df4dd1f0dfae80c05eac4b2bd461b86db5c8e2d"
 }

--- a/src/test/resources/org/gitlab4j/api/event.json
+++ b/src/test/resources/org/gitlab4j/api/event.json
@@ -1,9 +1,9 @@
 {
     "title": "this is a title",
     "project_id": 15,
-    "action_name": "opened",
+    "action_name": "pushed",
     "target_id": 830,
-    "target_type": "Issue",
+    "target_type": "MergeRequest",
     "author_id": 1,
     "author": {
       "name": "Dmitriy Zaporozhets",
@@ -14,31 +14,14 @@
       "web_url": "http://localhost:3000/root"
     },
     "author_username": "john",
-    "data": {
-      "before": "50d4420237a9de7be1304607147aec22e4a14af7",
-      "after": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
-      "ref": "refs/heads/master",
-      "user_id": 1,
-      "user_name": "Dmitriy Zaporozhets",
-      "repository": {
-        "name": "gitlabhq",
-        "url": "git@dev.gitlab.org:gitlab/gitlabhq.git",
-        "description": "GitLab: self hosted Git management software. \r\nDistributed under the MIT License.",
-        "homepage": "https://dev.gitlab.org/gitlab/gitlabhq"
-      },
-      "commits": [
-        {
-          "id": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
-          "message": "Add simple search to projects in public area",
-          "timestamp": "2013-05-13T18:18:08Z",
-          "url": "https://dev.gitlab.org/gitlab/gitlabhq/commit/c5feabde2d8cd023215af4d2ceeb7a64839fc428",
-          "author": {
-            "name": "Dmitriy Zaporozhets",
-            "email": "dmitriy.zaporozhets@gmail.com"
-          }
-        }
-      ],
-      "total_commits_count": 1
+    "push_data": {
+        "commit_count": 1,
+        "action": "pushed",
+        "ref_type": "branch",
+        "commit_from": "50d4420237a9de7be1304607147aec22e4a14af7",
+        "commit_to": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
+        "ref": "master",
+        "commit_title": "Add simple search to projects in public area"
     },
     "target_title": "target title"
 }

--- a/src/test/resources/org/gitlab4j/api/event.json
+++ b/src/test/resources/org/gitlab4j/api/event.json
@@ -14,14 +14,40 @@
       "web_url": "http://localhost:3000/root"
     },
     "author_username": "john",
-    "push_data": {
-        "commit_count": 1,
-        "action": "pushed",
-        "ref_type": "branch",
-        "commit_from": "50d4420237a9de7be1304607147aec22e4a14af7",
-        "commit_to": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
-        "ref": "master",
-        "commit_title": "Add simple search to projects in public area"
+    "data": {
+      "before": "50d4420237a9de7be1304607147aec22e4a14af7",
+      "after": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
+      "ref": "refs/heads/master",
+      "user_id": 1,
+      "user_name": "Dmitriy Zaporozhets",
+      "repository": {
+        "name": "gitlabhq",
+        "url": "git@dev.gitlab.org:gitlab/gitlabhq.git",
+        "description": "GitLab: self hosted Git management software. \r\nDistributed under the MIT License.",
+        "homepage": "https://dev.gitlab.org/gitlab/gitlabhq"
+      },
+      "commits": [
+        {
+          "id": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
+          "message": "Add simple search to projects in public area",
+          "timestamp": "2013-05-13T18:18:08Z",
+          "url": "https://dev.gitlab.org/gitlab/gitlabhq/commit/c5feabde2d8cd023215af4d2ceeb7a64839fc428",
+          "author": {
+            "name": "Dmitriy Zaporozhets",
+            "email": "dmitriy.zaporozhets@gmail.com"
+          }
+        }
+      ],
+      "total_commits_count": 1
     },
-    "target_title": "target title"
+    "push_data": {
+      "commit_count": 1,
+      "action": "pushed",
+      "ref_type": "branch",
+      "commit_from": "50d4420237a9de7be1304607147aec22e4a14af7",
+      "commit_to": "c5feabde2d8cd023215af4d2ceeb7a64839fc428",
+      "ref": "master",
+      "commit_title": "Add simple search to projects in public area"
+    },
+  "target_title": "target title"
 }


### PR DESCRIPTION
Three updates in this PR.

**1. Fix url field in `Commit`**
The correct url field is `web_url`.

See: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/entities/commit.rb#L13 and https://docs.gitlab.com/ee/api/commits.html

**2. Remove `data` field from `Event`, which does not exist in the spec.**
See: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/entities/event.rb#L15

Additionally, the `push_data` field only exists in Push events, so update the test to reflect that.

**3. Remove `author` from `Commit`, which does not exist in the spec.**
v4: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/master/lib/api/entities/commit.rb#L10
v3: https://gitlab.com/gitlab-org/gitlab-foss/-/blob/8-16-stable/doc/api/commits.md