### PR TITLE
Fix casing of get/set webUrl in Commit

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -164,11 +164,11 @@ public class Commit {
         this.url = url;
     }
 
-    public String getwebUrl() {
+    public String getWebUrl() {
         return webUrl;
     }
 
-    public void setwebUrl(String webUrl) {
+    public void setWebUrl(String webUrl) {
         this.webUrl = webUrl;
     }
 


### PR DESCRIPTION
Noticed an error in the previous patch #556 - fixing the casing of the methods I added.

Sorry about the miss!