### PR TITLE
Remove UserListSerializer and UserListDeserializer from approvedBy field in ApprovalRule (fixes #589)

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
@@ -18,9 +18,6 @@ public class ApprovalRule {
     private List<User> users;
     private List<Group> groups;
     private Boolean containsHiddenGroups;
-
-    @JsonSerialize(using = JacksonJson.UserListSerializer.class)
-    @JsonDeserialize(using = JacksonJson.UserListDeserializer.class)
     private List<User> approvedBy;
     private Boolean approved;
 

--- a/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
@@ -1,11 +1,8 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.util.List;
 
 public class ApprovalRule {
 

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -28,6 +28,7 @@ import org.gitlab4j.api.models.AccessRequest;
 import org.gitlab4j.api.models.Application;
 import org.gitlab4j.api.models.ApplicationSettings;
 import org.gitlab4j.api.models.ApprovalRule;
+import org.gitlab4j.api.models.ApprovalState;
 import org.gitlab4j.api.models.ArtifactsFile;
 import org.gitlab4j.api.models.AuditEvent;
 import org.gitlab4j.api.models.AwardEmoji;
@@ -538,6 +539,12 @@ public class TestGitLabApiBeans {
     public void testMergeRequestApprovals() throws Exception {
         MergeRequest mergeRequestApprovals = unmarshalResource(MergeRequest.class, "approvals.json");
         assertTrue(compareJson(mergeRequestApprovals, "approvals.json"));
+    }
+
+    @Test
+    public void testMergeRequestApprovalState() throws Exception {
+        ApprovalState approvalState = unmarshalResource(ApprovalState.class, "approval-state.json");
+        assertTrue(compareJson(approvalState, "approval-state.json"));
     }
 
     @Test


### PR DESCRIPTION
Remove UserListSerializer and UserListDeserializer from approvedBy field in ApprovalRule (fixes #589)