### PR TITLE
Add default branch protection level to the groups api

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GroupParams.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupParams.java
@@ -29,6 +29,22 @@ public class GroupParams {
         }
     }
 
+    public enum DefaultBranchProtectionLevel {
+        NOT_PROTECTED(0),
+        PARTIALLY_PROTECTED(1),
+        FULLY_PROTECTED(2);
+
+        private final int value;
+
+        private DefaultBranchProtectionLevel(int value) {
+            this.value = value;
+        }
+
+        public String toString() {
+            return Integer.toString(value);
+        }
+    }
+
     private String name;
     private String path;
     private String description;
@@ -45,6 +61,7 @@ public class GroupParams {
     private Integer parentId;
     private Integer sharedRunnersMinutesLimit;
     private Integer extraSharedRunnersMinutesLimit;
+    private DefaultBranchProtectionLevel defaultBranchProtection;
 
     private Boolean membershipLock;
     private Integer fileTemplateProjectId;
@@ -157,6 +174,11 @@ public class GroupParams {
 	return (this);
     }
 
+    public GroupParams withDefaultBranchProtection(DefaultBranchProtectionLevel defaultBranchProtection) {
+    this.defaultBranchProtection = defaultBranchProtection;
+    return (this);
+    }
+
     /**
      * Get the form params for a group create oir update call.
      *
@@ -181,7 +203,8 @@ public class GroupParams {
             .withParam("lfs_enabled", lfsEnabled)
             .withParam("request_access_enabled", requestAccessEnabled)
             .withParam("shared_runners_minutes_limit", sharedRunnersMinutesLimit)
-            .withParam("extra_shared_runners_minutes_limit", extraSharedRunnersMinutesLimit);
+            .withParam("extra_shared_runners_minutes_limit", extraSharedRunnersMinutesLimit)
+            .withParam("default_branch_protection", defaultBranchProtection);
 
         if (isCreate) {
             form.withParam("parent_id", parentId);


### PR DESCRIPTION
Hello,

Whilst using the the api I noticed this missing field in the library, which Gitlab has documented here https://docs.gitlab.com/ee/api/groups.html#options-for-default_branch_protection

Let me know if you guys have any feedback :rocket: 