### PR TITLE
Add search_namespaces to GroupProjectsFilter

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
@@ -21,6 +21,7 @@ public class GroupProjectsFilter {
     private Boolean withIssuesEnabled;
     private Boolean withMergeRequestsEnabled;
     private Boolean withShared;
+    private Boolean withSearchNamespaces;
     private Boolean includeSubGroups;
 
     /**
@@ -168,6 +169,17 @@ public class GroupProjectsFilter {
     }
 
     /**
+     * Include ancestor namespaces when matching search criteria
+     *
+     * @param withSearchNamespaces if true, ancestor namespaces will be matched by search criteria
+     * @return the reference to this ProjectFilter instance
+     */
+    public GroupProjectsFilter withSearchNamespaces(Boolean withSearchNamespaces) {
+        this.withSearchNamespaces = withSearchNamespaces;
+        return (this);
+    }
+
+    /**
      * Get the query params specified by this filter.
      *
      * @return a GitLabApiForm instance holding the query parameters for this ProjectFilter instance
@@ -186,6 +198,7 @@ public class GroupProjectsFilter {
             .withParam("with_issues_enabled", withIssuesEnabled)
             .withParam("with_merge_requests_enabled ", withMergeRequestsEnabled)
             .withParam("with_shared", withShared)
+            .withParam("search_namespaces", withSearchNamespaces)
             .withParam("include_subgroups", includeSubGroups)
         );
     }

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -470,6 +470,15 @@ public class TestProjectApi extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testProjectsWithSearchFilter() throws GitLabApiException {
+        ProjectFilter filter = new ProjectFilter().withSearch(TEST_PROJECT_NAME_1).withSearchNamespaces(true).withStatistics(false);
+        List<Project> projects = gitLabApi.getProjectApi().getProjects(filter);
+        assertTrue(projects != null);
+        assertTrue(projects.size() > 0);
+        assertNull(projects.get(0).getStatistics());
+    }
+
+    @Test
     public void testProjectsWithFilterAndStatistics() throws GitLabApiException {
         ProjectFilter filter = new ProjectFilter().withOwned(true).withStatistics(true);
         List<Project> projects = gitLabApi.getProjectApi().getProjects(filter);


### PR DESCRIPTION
adds the new search_namespace boolean flag when using search(), to search within namespaces