### PR TITLE
Added option to preserve underscores in the JacksonJsonEnumHelper to fix TargetType.MERGE_REQUEST value.

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -466,7 +466,7 @@ public interface Constants {
 
         ISSUE, MILESTONE, MERGE_REQUEST, NOTE, PROJECT, SNIPPET, USER;
 
-        private static JacksonJsonEnumHelper<TargetType> enumHelper = new JacksonJsonEnumHelper<>(TargetType.class, true, true);
+        private static JacksonJsonEnumHelper<TargetType> enumHelper = new JacksonJsonEnumHelper<>(TargetType.class, true, false, true);
 
         @JsonCreator
         public static TargetType forValue(String value) {

--- a/src/main/java/org/gitlab4j/api/utils/JacksonJsonEnumHelper.java
+++ b/src/main/java/org/gitlab4j/api/utils/JacksonJsonEnumHelper.java
@@ -32,6 +32,10 @@ public class JacksonJsonEnumHelper<E extends Enum<E>> {
     }
 
     public JacksonJsonEnumHelper(Class<E> enumType, boolean firstLetterCapitalized, boolean camelCased) {
+        this(enumType, firstLetterCapitalized, camelCased, false);
+    }
+
+    public JacksonJsonEnumHelper(Class<E> enumType, boolean firstLetterCapitalized, boolean camelCased, boolean preserveUnderscores) {
 
         valuesMap = new HashMap<>();
         namesMap = new HashMap<>();
@@ -43,10 +47,14 @@ public class JacksonJsonEnumHelper<E extends Enum<E>> {
             boolean nextCharIsCapitalized = firstLetterCapitalized;
             for (char ch : chars) {
                 if (ch == '_') {
-                    if (camelCased) {
-                        nextCharIsCapitalized = true;
+                    if (preserveUnderscores) {
+                        nameBuf.append(ch);
                     } else {
-                        nameBuf.append(' ');
+                        if (camelCased) {
+                            nextCharIsCapitalized = true;
+                        } else {
+                            nameBuf.append(' ');
+                        }
                     }
                 } else if (nextCharIsCapitalized) {
                     nextCharIsCapitalized = false;

--- a/src/test/resources/org/gitlab4j/api/event.json
+++ b/src/test/resources/org/gitlab4j/api/event.json
@@ -3,7 +3,7 @@
     "project_id": 15,
     "action_name": "pushed",
     "target_id": 830,
-    "target_type": "MergeRequest",
+    "target_type": "Merge_request",
     "author_id": 1,
     "author": {
       "name": "Dmitriy Zaporozhets",


### PR DESCRIPTION
resolves https://github.com/gitlab4j/gitlab4j-api/issues/614