### PR TITLE
feat: add generate changelog api support

### DIFF
--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -18,6 +18,7 @@ import javax.ws.rs.core.Response;
 
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Branch;
+import org.gitlab4j.api.models.ChangelogPayload;
 import org.gitlab4j.api.models.Commit;
 import org.gitlab4j.api.models.CompareResults;
 import org.gitlab4j.api.models.Contributor;
@@ -749,4 +750,32 @@ public class RepositoryApi extends AbstractApi {
         delete(Response.Status.NO_CONTENT, null, "projects",
                 getProjectIdOrPath(projectIdOrPath), "repository", "merged_branches");
     }
+
+    /**
+     * Generate changelog data based on commits in a repository.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param version         the version to generate the changelog for
+     * @throws GitLabApiException if any exception occurs
+     */
+    public void generateChangelog(Object projectIdOrPath, String version) throws GitLabApiException {
+        generateChangelog(projectIdOrPath, new ChangelogPayload(version));
+    }
+
+    /**
+     * Generate changelog data based on commits in a repository.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance
+     * @param payload         the payload to generate the changelog for
+     * @throws GitLabApiException if any exception occurs
+     */
+    public void generateChangelog(Object projectIdOrPath, ChangelogPayload payload) throws GitLabApiException {
+        post(Response.Status.OK, payload.getFormData(), "projects",
+                getProjectIdOrPath(projectIdOrPath), "repository", "changelog");
+    }
+
 }

--- a/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
+++ b/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
@@ -1,0 +1,106 @@
+package org.gitlab4j.api.models;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.gitlab4j.api.GitLabApiForm;
+import org.gitlab4j.api.utils.ISO8601;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.util.Date;
+
+public class ChangelogPayload {
+
+    private String version;
+    private String from;
+    private String to;
+    private Date date;
+    private String branch;
+    private String trailer;
+    private String file;
+    private String message;
+
+    public ChangelogPayload(String version) {
+        this.version = version;
+    }
+
+    @JsonIgnore
+    public GitLabApiForm getFormData() {
+        return new GitLabApiForm()
+                .withParam("version", version, true)
+                .withParam("from", from)
+                .withParam("to", to)
+                .withParam("date", ISO8601.dateOnly(date))
+                .withParam("branch", branch)
+                .withParam("trailer", trailer)
+                .withParam("file", file)
+                .withParam("message", message);
+    }
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getFrom() {
+        return from;
+    }
+
+    public void setFrom(String from) {
+        this.from = from;
+    }
+
+    public String getTo() {
+        return to;
+    }
+
+    public void setTo(String to) {
+        this.to = to;
+    }
+
+    public Date getDate() {
+        return date;
+    }
+
+    public void setDate(Date date) {
+        this.date = date;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    public String getTrailer() {
+        return trailer;
+    }
+
+    public void setTrailer(String trailer) {
+        this.trailer = trailer;
+    }
+
+    public String getFile() {
+        return file;
+    }
+
+    public void setFile(String file) {
+        this.file = file;
+    }
+
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}


### PR DESCRIPTION
This pull request adds support for the changelog generation api: `POST /projects/:id/repository/changelog`

https://docs.gitlab.com/ee/api/repositories.html#generate-changelog-data