### PR TITLE
Add more field to NoteEvent.ObjectAttributes

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
@@ -131,6 +131,8 @@ public class NoteEvent extends AbstractEvent {
 
         private Integer id;
         private String note;
+        private String discussionId;
+        private String type;
         private NoteableType noteableType;
         private Integer authorId;
         private Date createdAt;
@@ -158,6 +160,22 @@ public class NoteEvent extends AbstractEvent {
 
         public void setNote(String note) {
             this.note = note;
+        }
+
+        public String getDiscussionId() {
+            return discussionId;
+        }
+
+        public void setDiscussionId(String discussionId) {
+            this.discussionId = discussionId;
+        }
+
+        public String getType() {
+            return type;
+        }
+
+        public void setType(String type) {
+            this.type = type;
         }
 
         public NoteableType getNoteableType() {

--- a/src/test/resources/org/gitlab4j/api/note-commit-event.json
+++ b/src/test/resources/org/gitlab4j/api/note-commit-event.json
@@ -30,6 +30,8 @@
   "object_attributes": {
     "id": 1243,
     "note": "This is a commit comment. How does this work?",
+    "discussion_id": "56e2b4210419aed077d47ca2dc00551c7c4ac882",
+    "type": "DiscussionNote",
     "noteable_type": "Commit",
     "author_id": 1,
     "created_at": "2015-05-17T18:08:09Z",

--- a/src/test/resources/org/gitlab4j/api/note-issue-event.json
+++ b/src/test/resources/org/gitlab4j/api/note-issue-event.json
@@ -29,6 +29,8 @@
   "object_attributes": {
     "id": 1241,
     "note": "Hello world",
+    "discussion_id": "56e2b4210419aed077d47ca2dc00551c7c4ac882",
+    "type": "DiscussionNote",
     "noteable_type": "Issue",
     "author_id": 1,
     "created_at": "2015-05-17T17:06:40Z",

--- a/src/test/resources/org/gitlab4j/api/note-merge-request-event.json
+++ b/src/test/resources/org/gitlab4j/api/note-merge-request-event.json
@@ -30,6 +30,8 @@
   "object_attributes": {
     "id": 1244,
     "note": "This MR needs work.",
+    "discussion_id": "56e2b4210419aed077d47ca2dc00551c7c4ac882",
+    "type": "DiscussionNote",
     "noteable_type": "MergeRequest",
     "author_id": 1,
     "created_at": "2015-05-17T18:21:36Z",

--- a/src/test/resources/org/gitlab4j/api/note-snippet-event.json
+++ b/src/test/resources/org/gitlab4j/api/note-snippet-event.json
@@ -30,6 +30,8 @@
   "object_attributes": {
     "id": 1245,
     "note": "Is this snippet doing what it's supposed to be doing?",
+    "discussion_id": "56e2b4210419aed077d47ca2dc00551c7c4ac882",
+    "type": "DiscussionNote",
     "noteable_type": "Snippet",
     "author_id": 1,
     "created_at": "2015-05-17T18:35:50Z",


### PR DESCRIPTION
This pull request adds more field to NoteEvent.ObjectAttributes

Currently, the data structure of NoteEvent.ObjectAttributes is consistent with the [offical document](https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#comment-events) ,  but after testing, I found that the actual data structure of NoteEvent.ObjectAttributes has more field, and I need `discussion_id` and `type` field for custom purposes.

```json
"object_attributes": {
    "attachment": null,
    "author_id": 1234,
    "change_position": null,
    "commit_id": null,
    "created_at": "2021-03-16 16:39:18 UTC",
    "discussion_id": "56e2b4210419aed077d47ca2dc00551c7c4ac882",
    "id": 351809,
    "line_code": null,
    "note": "/tbd 12321 12321",
    "noteable_id": 2344,
    "noteable_type": "Issue",
    "original_position": null,
    "position": null,
    "project_id": 2072,
    "resolved_at": null,
    "resolved_by_id": null,
    "resolved_by_push": null,
    "st_diff": null,
    "system": false,
    "type": "DiscussionNote",
    "updated_at": "2021-03-16 16:39:18 UTC",
    "updated_by_id": null,
    "description": "/tbd 12321 12321",
    "url": "http://xx.xx.xx.xx/xyxy/abc/issues/1#note_351809"
  }
```