### PR TITLE
Fix tests relying on "X-Total-Pages" and "X-Total" headers that have been removed

### DIFF
--- a/src/test/java/org/gitlab4j/api/TestCommitsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestCommitsApi.java
@@ -147,7 +147,12 @@ public class TestCommitsApi extends AbstractIntegrationTest {
 
         pager = gitLabApi.getCommitsApi().getCommits(testProject.getId(), null, since, null, 10);
         assertNotNull(pager);
-        assertTrue(pager.getTotalItems() > 0);
+
+        /*
+        Since 13.5 the commits API no longer returns "X-Total-Pages" and "X-Total" headers
+        https://gitlab.com/gitlab-org/gitlab/-/merge_requests/43159
+         */
+//        assertTrue(pager.getTotalItems() > 0);
     }
 
     @Test

--- a/src/test/java/org/gitlab4j/api/TestPager.java
+++ b/src/test/java/org/gitlab4j/api/TestPager.java
@@ -178,16 +178,25 @@ public class TestPager extends AbstractIntegrationTest {
         Pager<Commit> pager = gitLabApi.getCommitsApi().getCommits(project, 1);
         assertNotNull(pager);
         assertEquals(1, pager.getItemsPerPage());
-        assertTrue(0 < pager.getTotalPages());
 
-        int numCommits = pager.getTotalItems();
-        assertTrue(0 < numCommits);
+        /*
+        Since 13.5 the commits API no longer returns "X-Total-Pages" and "X-Total" headers
+        https://gitlab.com/gitlab-org/gitlab/-/merge_requests/43159
+         */
+//        assertTrue(0 < pager.getTotalPages());
+//
+//        int numCommits = pager.getTotalItems();
+//        assertTrue(0 < numCommits);
 
         List<Commit> allCommits = pager.all();
         System.out.println("All commits:");
         allCommits.stream().map(Commit::getId).forEach(System.out::println);
 
-        assertEquals(numCommits, allCommits.size());
+        /*
+        A more deterministic approach, creating a known no. of commits within the scope of this test, is needed if the
+        total no. of commits should be tested
+         */
+//        assertEquals(numCommits, allCommits.size());
     }
 
     @Test
@@ -199,12 +208,23 @@ public class TestPager extends AbstractIntegrationTest {
         Pager<Commit> pager = gitLabApi.getCommitsApi().getCommits(project, 1);
         assertNotNull(pager);
         assertEquals(1, pager.getItemsPerPage());
-        assertTrue(0 < pager.getTotalPages());
 
-        int numCommits = pager.getTotalItems();
-        assertTrue(0 < numCommits);
+        /*
+        Since 13.5 the commits API no longer returns "X-Total-Pages" and "X-Total" headers
+        https://gitlab.com/gitlab-org/gitlab/-/merge_requests/43159
+         */
+//        assertTrue(0 < pager.getTotalPages());
+//
+//        int numCommits = pager.getTotalItems();
+//        assertTrue(0 < numCommits);
 
         System.out.println("Streamed commits:");
-       assertEquals(numCommits, pager.stream().map(Commit::getId).peek(System.out::println).count());
+        pager.stream().map(Commit::getId).peek(System.out::println);
+
+        /*
+        A more deterministic approach, creating a known no. of commits within the scope of this test, is needed if the
+        total no. of commits should be tested
+         */
+//        assertEquals(numCommits, pager.stream().map(Commit::getId).peek(System.out::println).count());
     }
 }


### PR DESCRIPTION
This is part of a set of PRs with the purpose of fixing broken tests for the latest version of GitLab (13.10.2 at time of writing) and so setting the project up for ongoing development with a working suite of tests.

Also see #683 & #684 - with the changes from the three related PRs all tests are passing for me against a gitlab-ee Docker image.

More can be done to improve these tests, as noted in the comments.