### PR TITLE
Support larger file sizes by expanding the size type to a Long.

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
+++ b/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
@@ -5,7 +5,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 public class ArtifactsFile {
 
     private String filename;
-    private Integer size;
+    private Long size;
 
     public String getFilename() {
         return filename;
@@ -15,11 +15,11 @@ public class ArtifactsFile {
         this.filename = filename;
     }
 
-    public Integer getSize() {
+    public Long getSize() {
         return size;
     }
 
-    public void setSize(Integer size) {
+    public void setSize(Long size) {
         this.size = size;
     }
 


### PR DESCRIPTION
Tried getting Job and got a deserialization error, I think this will resolve it.

Caused by: com.fasterxml.jackson.databind.JsonMappingException: Numeric value (3328850515) out of range of int (-2147483648 - 2147483647)
 at [Source: (org.glassfish.jersey.message.internal.ReaderInterceptorExecutor$UnCloseableInputStream); line: 1, column: 3915] (through reference chain: java.util.ArrayList[1]->org.gitlab4j.api.models.Job["artifacts_file"]->org.gitlab4j.api.models.ArtifactsFile["size"])