### PR TITLE
Move markdown call to post with serialized JSON payload

### DIFF
--- a/src/main/java/org/gitlab4j/api/MarkdownApi.java
+++ b/src/main/java/org/gitlab4j/api/MarkdownApi.java
@@ -1,9 +1,10 @@
 package org.gitlab4j.api;
 
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Markdown;
+import org.gitlab4j.api.models.MarkdownRequest;
+
+import javax.ws.rs.core.Response;
 
 /**
  * This class provides an entry point to all the GitLab API markdown calls.
@@ -30,8 +31,26 @@ public class MarkdownApi extends AbstractApi {
             throw new GitLabApiException("Api version must be v4");
         }
 
-        Form formData = new GitLabApiForm().withParam("text", text, true);
-        Response response = post(Response.Status.OK, formData.asMap(), "markdown");
+        return getMarkdown(new MarkdownRequest(text, true));
+    }
+
+    /**
+     * Render an arbitrary Markdown document.
+     *
+     * <pre><code>GitLab Endpoint: POST /api/v4/markdown</code></pre>
+     *
+     * @param markdownRequest a request of markdown transformation
+     * @return a Markdown instance with transformed info
+     * @throws GitLabApiException if any exception occurs
+     * @since GitLab 11.0
+     */
+    public Markdown getMarkdown(MarkdownRequest markdownRequest) throws GitLabApiException {
+
+        if (!isApiVersion(ApiVersion.V4)) {
+            throw new GitLabApiException("Api version must be v4");
+        }
+
+        Response response = post(Response.Status.OK, markdownRequest, "markdown");
         return (response.readEntity(Markdown.class));
     }
 }

--- a/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
@@ -1,0 +1,27 @@
+package org.gitlab4j.api.models;
+
+public class MarkdownRequest {
+    private String text;
+    private boolean gfm;
+
+    public MarkdownRequest(String text, boolean gfm) {
+        this.text = text;
+        this.gfm = gfm;
+    }
+
+    public String getText() {
+        return text;
+    }
+
+    public void setText(String text) {
+        this.text = text;
+    }
+
+    public boolean isGfm() {
+        return gfm;
+    }
+
+    public void setGfm(boolean gfm) {
+        this.gfm = gfm;
+    }
+}

--- a/src/test/java/org/gitlab4j/api/TestMarkdownApi.java
+++ b/src/test/java/org/gitlab4j/api/TestMarkdownApi.java
@@ -1,0 +1,56 @@
+package org.gitlab4j.api;
+
+import org.gitlab4j.api.models.Markdown;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.*;
+import static org.junit.Assume.assumeTrue;
+
+@Category(IntegrationTest.class)
+public class TestMarkdownApi extends AbstractIntegrationTest {
+
+    private static final String EXPECTED_HTML_FOR_SPECIAL = "<p data-sourcepos=\"1:1-1:104\" dir=\"auto\">Hello world! <gl-emoji title=\"party popper\" data-name=\"tada\" data-unicode-version=\"6.0\">🎉</gl-emoji> <code>xml &lt;profiles&gt; &lt;version&gt;${maven-surefire-plugin.version}&lt;/version&gt; &lt;/profiles&gt;</code></p>";
+    public static final String SPECIAL_CHAR_EXAMPLE = "Hello world! :tada: ```xml <profiles> <version>${maven-surefire-plugin.version}</version> </profiles>```";
+
+    public static final String NORMAL_HTML_EXAMPLE = "<h1 data-sourcepos=\"1:1-1:4\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h1\" class=\"anchor\" href=\"#h1\" aria-hidden=\"true\"></a>H1</h1>\n" +
+            "<h2 data-sourcepos=\"2:2-2:6\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h2\" class=\"anchor\" href=\"#h2\" aria-hidden=\"true\"></a>H2</h2>\n" +
+            "<h3 data-sourcepos=\"3:2-3:7\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h3\" class=\"anchor\" href=\"#h3\" aria-hidden=\"true\"></a>H3</h3>\n" +
+            "<h4 data-sourcepos=\"4:2-4:8\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h4\" class=\"anchor\" href=\"#h4\" aria-hidden=\"true\"></a>H4</h4>\n" +
+            "<h5 data-sourcepos=\"5:2-5:9\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h5\" class=\"anchor\" href=\"#h5\" aria-hidden=\"true\"></a>H5</h5>\n" +
+            "<h6 data-sourcepos=\"6:2-6:10\" dir=\"auto\">\n" +
+            "<a id=\"user-content-h6\" class=\"anchor\" href=\"#h6\" aria-hidden=\"true\"></a>H6</h6>";
+
+    private static GitLabApi gitLabApi;
+
+    @BeforeClass
+    public static void setUp() throws Exception {
+        gitLabApi = baseTestSetup();
+    }
+
+    @Before
+    public void beforeMethod() {
+        assumeTrue(gitLabApi != null);
+    }
+
+    @Test
+    public void testMarkdownWithSpecialCharacters() throws GitLabApiException {
+        Markdown markdown = gitLabApi.getMarkdownApi().getMarkdown(SPECIAL_CHAR_EXAMPLE);
+
+        assertEquals(EXPECTED_HTML_FOR_SPECIAL, markdown.getHtml());
+    }
+
+    @Test
+    public void testMarkdownWithNormalText() throws GitLabApiException {
+        Markdown markdown = gitLabApi.getMarkdownApi().getMarkdown("# H1 \n ## H2 \n ### H3 \n #### H4 \n ##### H5 \n ###### H6");
+
+        assertEquals(NORMAL_HTML_EXAMPLE, markdown.getHtml());
+    }
+}


### PR DESCRIPTION
Hi All,

this PR should fix #687, the previous `markdownApi.getMarkdown(text)` with special characters can throw exception due to Form params. I changed the post call with another one that support Json payload serialization. I have also added a new api call with all the necessary parameters defined in the [documentation](https://docs.gitlab.com/ee/api/markdown.html).

Let me know if you need further help.

Giovanni