### PR TITLE
Add support for release and deployment events in webhooks

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2064,6 +2064,8 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("wiki_events", enabledHooks.getWikiPageEvents(), false)
                 .withParam("enable_ssl_verification", enableSslVerification, false)
                 .withParam("repository_update_events", enabledHooks.getRepositoryUpdateEvents(), false)
+                .withParam("releases_events", enabledHooks.getReleasesEvents(), false)
+                .withParam("deployment_events", enabledHooks.getDeploymentEvents(), false)
                 .withParam("token", secretToken, false);
         Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "hooks");
         return (response.readEntity(ProjectHook.class));
@@ -2133,16 +2135,22 @@ public class ProjectApi extends AbstractApi implements Constants {
     public ProjectHook modifyHook(ProjectHook hook) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
-            .withParam("url", hook.getUrl(), true)
-            .withParam("push_events", hook.getPushEvents(), false)
-            .withParam("issues_events", hook.getIssuesEvents(), false)
-            .withParam("merge_requests_events", hook.getMergeRequestsEvents(), false)
-            .withParam("tag_push_events", hook.getTagPushEvents(), false)
-            .withParam("note_events", hook.getNoteEvents(), false)
-            .withParam("job_events", hook.getJobEvents(), false)
-            .withParam("pipeline_events", hook.getPipelineEvents(), false)
-            .withParam("wiki_events", hook.getWikiPageEvents(), false)
-            .withParam("enable_ssl_verification", hook.getEnableSslVerification(), false)
+                .withParam("url", hook.getUrl(), true)
+                .withParam("push_events", hook.getPushEvents(), false)
+                .withParam("push_events_branch_filter", hook.getPushEventsBranchFilter(), false)
+                .withParam("issues_events", hook.getIssuesEvents(), false)
+                .withParam("confidential_issues_events", hook.getConfidentialIssuesEvents(), false)
+                .withParam("merge_requests_events", hook.getMergeRequestsEvents(), false)
+                .withParam("tag_push_events", hook.getTagPushEvents(), false)
+                .withParam("note_events", hook.getNoteEvents(), false)
+                .withParam("confidential_note_events", hook.getConfidentialNoteEvents(), false)
+                .withParam("job_events", hook.getJobEvents(), false)
+                .withParam("pipeline_events", hook.getPipelineEvents(), false)
+                .withParam("wiki_events", hook.getWikiPageEvents(), false)
+                .withParam("enable_ssl_verification", hook.getEnableSslVerification(), false)
+                .withParam("repository_update_events", hook.getRepositoryUpdateEvents(), false)
+                .withParam("releases_events", hook.getReleasesEvents(), false)
+                .withParam("deployment_events", hook.getDeploymentEvents(), false)
             .withParam("token", hook.getToken(), false);
 
         Response response = put(Response.Status.OK, formData.asMap(), "projects", hook.getProjectId(), "hooks", hook.getId());

--- a/src/main/java/org/gitlab4j/api/models/ProjectHook.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectHook.java
@@ -1,9 +1,9 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
+
+import java.util.Date;
 
 public class ProjectHook {
 
@@ -12,6 +12,8 @@ public class ProjectHook {
     private Boolean enableSslVerification;
     private Integer id;
     private Boolean issuesEvents;
+    private Boolean deploymentEvents;
+    private Boolean releasesEvents;
     private Boolean mergeRequestsEvents;
     private Boolean noteEvents;
     private Boolean jobEvents;
@@ -83,7 +85,7 @@ public class ProjectHook {
     public void setNoteEvents(Boolean noteEvents) {
         this.noteEvents = noteEvents;
     }
-    
+
     public Boolean getJobEvents() {
         return jobEvents;
     }
@@ -123,7 +125,7 @@ public class ProjectHook {
     public void setTagPushEvents(Boolean tagPushEvents) {
         this.tagPushEvents = tagPushEvents;
     }
-    
+
     public String getToken() {
         return token;
     }
@@ -179,7 +181,23 @@ public class ProjectHook {
     public void setPushEventsBranchFilter(String pushEventsBranchFilter) {
         this.pushEventsBranchFilter = pushEventsBranchFilter;
     }
-    
+
+    public Boolean getDeploymentEvents() {
+        return deploymentEvents;
+    }
+
+    public void setDeploymentEvents(Boolean deploymentEvents) {
+        this.deploymentEvents = deploymentEvents;
+    }
+
+    public Boolean getReleasesEvents() {
+        return releasesEvents;
+    }
+
+    public void setReleasesEvents(Boolean releasesEvents) {
+        this.releasesEvents = releasesEvents;
+    }
+
     public ProjectHook withIssuesEvents(Boolean issuesEvents) {
         this.issuesEvents = issuesEvents;
         return (this);
@@ -194,7 +212,7 @@ public class ProjectHook {
         this.noteEvents = noteEvents;
         return (this);
     }
-    
+
     public ProjectHook withJobEvents(Boolean jobEvents) {
         this.jobEvents = jobEvents;
         return (this);
@@ -237,6 +255,16 @@ public class ProjectHook {
 
     public ProjectHook withPushEventsBranchFilter(String pushEventsBranchFilter) {
         this.pushEventsBranchFilter = pushEventsBranchFilter;
+        return (this);
+    }
+
+    public ProjectHook withDeploymentEvents(Boolean deploymentEvents) {
+        this.deploymentEvents = deploymentEvents;
+        return (this);
+    }
+
+    public ProjectHook withReleasesEvents(Boolean releasesEvents) {
+        this.releasesEvents = ProjectHook.this.releasesEvents;
         return (this);
     }
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectHook.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectHook.java
@@ -264,7 +264,7 @@ public class ProjectHook {
     }
 
     public ProjectHook withReleasesEvents(Boolean releasesEvents) {
-        this.releasesEvents = ProjectHook.this.releasesEvents;
+        this.releasesEvents = releasesEvents;
         return (this);
     }
 

--- a/src/main/java/org/gitlab4j/api/webhook/DeploymentEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/DeploymentEvent.java
@@ -1,0 +1,124 @@
+package org.gitlab4j.api.webhook;
+
+import org.gitlab4j.api.models.User;
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class DeploymentEvent extends AbstractEvent {
+
+    public static final String JOB_HOOK_X_GITLAB_EVENT = "Deployment Hook";
+    public static final String OBJECT_KIND = "deployment";
+
+    private String status;
+    private String statusChanged_at;
+    private Integer deployableId;
+    private String deployableUrl;
+    private String environment;
+    private EventProject project;
+    private String shortSha;
+    private User user;
+    private String userUrl;
+    private String commitUrl;
+    private String commitTitle;
+
+    public String getObjectKind() {
+        return (OBJECT_KIND);
+    }
+
+    public void setObjectKind(String objectKind) {
+        if (!OBJECT_KIND.equals(objectKind))
+            throw new RuntimeException("Invalid object_kind (" + objectKind + "), must be '" + OBJECT_KIND + "'");
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public void setStatus(String status) {
+        this.status = status;
+    }
+
+    public String getStatusChanged_at() {
+        return statusChanged_at;
+    }
+
+    public void setStatusChanged_at(String statusChanged_at) {
+        this.statusChanged_at = statusChanged_at;
+    }
+
+    public Integer getDeployableId() {
+        return deployableId;
+    }
+
+    public void setDeployableId(Integer deployableId) {
+        this.deployableId = deployableId;
+    }
+
+    public String getDeployableUrl() {
+        return deployableUrl;
+    }
+
+    public void setDeployableUrl(String deployableUrl) {
+        this.deployableUrl = deployableUrl;
+    }
+
+    public String getEnvironment() {
+        return environment;
+    }
+
+    public void setEnvironment(String environment) {
+        this.environment = environment;
+    }
+
+    public EventProject getProject() {
+        return project;
+    }
+
+    public void setProject(EventProject project) {
+        this.project = project;
+    }
+
+    public String getShortSha() {
+        return shortSha;
+    }
+
+    public void setShortSha(String shortSha) {
+        this.shortSha = shortSha;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public String getUserUrl() {
+        return userUrl;
+    }
+
+    public void setUserUrl(String userUrl) {
+        this.userUrl = userUrl;
+    }
+
+    public String getCommitUrl() {
+        return commitUrl;
+    }
+
+    public void setCommitUrl(String commitUrl) {
+        this.commitUrl = commitUrl;
+    }
+
+    public String getCommitTitle() {
+        return commitTitle;
+    }
+
+    public void setCommitTitle(String commitTitle) {
+        this.commitTitle = commitTitle;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/main/java/org/gitlab4j/api/webhook/Event.java
+++ b/src/main/java/org/gitlab4j/api/webhook/Event.java
@@ -17,7 +17,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(value = PipelineEvent.class, name = PipelineEvent.OBJECT_KIND),
     @JsonSubTypes.Type(value = PushEvent.class, name = PushEvent.OBJECT_KIND),
     @JsonSubTypes.Type(value = TagPushEvent.class, name = TagPushEvent.OBJECT_KIND),
-    @JsonSubTypes.Type(value = WikiPageEvent.class, name = WikiPageEvent.OBJECT_KIND)
+    @JsonSubTypes.Type(value = WikiPageEvent.class, name = WikiPageEvent.OBJECT_KIND),
+    @JsonSubTypes.Type(value = DeploymentEvent.class, name = DeploymentEvent.OBJECT_KIND),
+    @JsonSubTypes.Type(value = ReleaseEvent.class, name = ReleaseEvent.OBJECT_KIND)
 })
 public interface Event {     
     String getObjectKind();

--- a/src/main/java/org/gitlab4j/api/webhook/EventReleaseAssets.java
+++ b/src/main/java/org/gitlab4j/api/webhook/EventReleaseAssets.java
@@ -1,0 +1,41 @@
+package org.gitlab4j.api.webhook;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.util.List;
+
+public class EventReleaseAssets {
+
+    private Integer count;
+    private List<EventReleaseLink> links;
+    private List<EventReleaseSource> sources;
+
+    public Integer getCount() {
+        return count;
+    }
+
+    public void setCount(Integer count) {
+        this.count = count;
+    }
+
+    public List<EventReleaseLink> getLinks() {
+        return links;
+    }
+
+    public void setLinks(List<EventReleaseLink> links) {
+        this.links = links;
+    }
+
+    public List<EventReleaseSource> getSources() {
+        return sources;
+    }
+
+    public void setSources(List<EventReleaseSource> sources) {
+        this.sources = sources;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/main/java/org/gitlab4j/api/webhook/EventReleaseLink.java
+++ b/src/main/java/org/gitlab4j/api/webhook/EventReleaseLink.java
@@ -1,0 +1,56 @@
+package org.gitlab4j.api.webhook;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class EventReleaseLink {
+    private Integer id;
+    private Boolean external;
+    private String linkType;
+    private String name;
+    private String url;
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(final Integer id) {
+        this.id = id;
+    }
+
+    public Boolean getExternal() {
+        return external;
+    }
+
+    public void setExternal(final Boolean external) {
+        this.external = external;
+    }
+
+    public String getLinkType() {
+        return linkType;
+    }
+
+    public void setLinkType(final String linkType) {
+        this.linkType = linkType;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/main/java/org/gitlab4j/api/webhook/EventReleaseSource.java
+++ b/src/main/java/org/gitlab4j/api/webhook/EventReleaseSource.java
@@ -1,0 +1,29 @@
+package org.gitlab4j.api.webhook;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class EventReleaseSource {
+    private String format;
+    private String url;
+
+    public String getFormat() {
+        return format;
+    }
+
+    public void setFormat(final String format) {
+        this.format = format;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/main/java/org/gitlab4j/api/webhook/ReleaseEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/ReleaseEvent.java
@@ -1,0 +1,32 @@
+package org.gitlab4j.api.webhook;
+
+import org.gitlab4j.api.models.User;
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class ReleaseEvent extends AbstractEvent {
+
+    public static final String JOB_HOOK_X_GITLAB_EVENT = "Release Hook";
+    public static final String OBJECT_KIND = "release";
+
+    private String action;
+    private String url;
+    private String name;
+    private String description;
+    private String tag;
+    private String releasedAt;
+    private EventCommit commit;
+
+    public String getObjectKind() {
+        return (OBJECT_KIND);
+    }
+
+    public void setObjectKind(String objectKind) {
+        if (!OBJECT_KIND.equals(objectKind))
+            throw new RuntimeException("Invalid object_kind (" + objectKind + "), must be '" + OBJECT_KIND + "'");
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/main/java/org/gitlab4j/api/webhook/ReleaseEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/ReleaseEvent.java
@@ -1,6 +1,5 @@
 package org.gitlab4j.api.webhook;
 
-import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class ReleaseEvent extends AbstractEvent {
@@ -8,12 +7,16 @@ public class ReleaseEvent extends AbstractEvent {
     public static final String JOB_HOOK_X_GITLAB_EVENT = "Release Hook";
     public static final String OBJECT_KIND = "release";
 
-    private String action;
-    private String url;
-    private String name;
+    private Integer id;
+    private String createdAt;
     private String description;
-    private String tag;
+    private String name;
     private String releasedAt;
+    private String tag;
+    private EventProject project;
+    private String url;
+    private String action;
+    private EventReleaseAssets assets;
     private EventCommit commit;
 
     public String getObjectKind() {
@@ -23,6 +26,94 @@ public class ReleaseEvent extends AbstractEvent {
     public void setObjectKind(String objectKind) {
         if (!OBJECT_KIND.equals(objectKind))
             throw new RuntimeException("Invalid object_kind (" + objectKind + "), must be '" + OBJECT_KIND + "'");
+    }
+
+    public Integer getId() {
+        return id;
+    }
+
+    public void setId(final Integer id) {
+        this.id = id;
+    }
+
+    public String getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(final String createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public String getDescription() {
+        return description;
+    }
+
+    public void setDescription(final String description) {
+        this.description = description;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(final String name) {
+        this.name = name;
+    }
+
+    public String getReleasedAt() {
+        return releasedAt;
+    }
+
+    public void setReleasedAt(final String releasedAt) {
+        this.releasedAt = releasedAt;
+    }
+
+    public String getTag() {
+        return tag;
+    }
+
+    public void setTag(final String tag) {
+        this.tag = tag;
+    }
+
+    public EventProject getProject() {
+        return project;
+    }
+
+    public void setProject(final EventProject project) {
+        this.project = project;
+    }
+
+    public String getUrl() {
+        return url;
+    }
+
+    public void setUrl(final String url) {
+        this.url = url;
+    }
+
+    public String getAction() {
+        return action;
+    }
+
+    public void setAction(final String action) {
+        this.action = action;
+    }
+
+    public EventReleaseAssets getAssets() {
+        return assets;
+    }
+
+    public void setAssets(final EventReleaseAssets assets) {
+        this.assets = assets;
+    }
+
+    public EventCommit getCommit() {
+        return commit;
+    }
+
+    public void setCommit(final EventCommit commit) {
+        this.commit = commit;
     }
 
     @Override

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookListener.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookListener.java
@@ -78,4 +78,23 @@ public interface WebHookListener extends java.util.EventListener {
      */
     default void onWikiPageEvent(WikiPageEvent wikiEvent) {
     }
+
+
+
+    /**
+     * This method is called when a WebHook deployment event has been received.
+     *
+     * @param deploymentEvent the DeploymentEvent instance
+     */
+    default void onDeploymentEvent(DeploymentEvent deploymentEvent) {
+    }
+
+
+    /**
+     * This method is called when a WebHook release event has been received.
+     *
+     * @param releaseEvent the ReleaseEvent instance
+     */
+    default void onReleaseEvent(ReleaseEvent releaseEvent) {
+    }
 }

--- a/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -1,18 +1,17 @@
 
 package org.gitlab4j.api.webhook;
 
+import org.gitlab4j.api.GitLabApiException;
+import org.gitlab4j.api.HookManager;
+import org.gitlab4j.api.utils.HttpRequestUtils;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import javax.servlet.http.HttpServletRequest;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.servlet.http.HttpServletRequest;
-
-import org.gitlab4j.api.GitLabApiException;
-import org.gitlab4j.api.HookManager;
-import org.gitlab4j.api.utils.HttpRequestUtils;
-import org.gitlab4j.api.utils.JacksonJson;
 
 /**
  * This class provides a handler for processing GitLab WebHook callouts.
@@ -36,7 +35,7 @@ public class WebHookManager implements HookManager {
     /**
      * Create a HookManager to handle GitLab webhook events which will be verified
      * against the specified secretToken.
-     * 
+     *
      * @param secretToken the secret token to verify against
      */
     public WebHookManager(String secretToken) {
@@ -64,7 +63,7 @@ public class WebHookManager implements HookManager {
     /**
      * Parses and verifies an Event instance from the HTTP request and
      * fires it off to the registered listeners.
-     * 
+     *
      * @param request the HttpServletRequest to read the Event instance from
      * @throws GitLabApiException if the parsed event is not supported
      */
@@ -98,20 +97,22 @@ public class WebHookManager implements HookManager {
         LOGGER.info("handleEvent: X-Gitlab-Event=" + eventName);
         switch (eventName) {
 
-        case IssueEvent.X_GITLAB_EVENT:
-        case JobEvent.JOB_HOOK_X_GITLAB_EVENT:
-        case MergeRequestEvent.X_GITLAB_EVENT:
-        case NoteEvent.X_GITLAB_EVENT:
-        case PipelineEvent.X_GITLAB_EVENT:
-        case PushEvent.X_GITLAB_EVENT:
-        case TagPushEvent.X_GITLAB_EVENT:
-        case WikiPageEvent.X_GITLAB_EVENT:
-            break;
+            case IssueEvent.X_GITLAB_EVENT:
+            case JobEvent.JOB_HOOK_X_GITLAB_EVENT:
+            case MergeRequestEvent.X_GITLAB_EVENT:
+            case NoteEvent.X_GITLAB_EVENT:
+            case PipelineEvent.X_GITLAB_EVENT:
+            case PushEvent.X_GITLAB_EVENT:
+            case TagPushEvent.X_GITLAB_EVENT:
+            case WikiPageEvent.X_GITLAB_EVENT:
+            case DeploymentEvent.JOB_HOOK_X_GITLAB_EVENT:
+            case ReleaseEvent.JOB_HOOK_X_GITLAB_EVENT:
+                break;
 
-        default:
-            String message = "Unsupported X-Gitlab-Event, event Name=" + eventName;
-            LOGGER.warning(message);
-            throw new GitLabApiException(message);
+            default:
+                String message = "Unsupported X-Gitlab-Event, event Name=" + eventName;
+                LOGGER.warning(message);
+                throw new GitLabApiException(message);
         }
 
         Event event;
@@ -154,7 +155,7 @@ public class WebHookManager implements HookManager {
 
     /**
      * Verifies the provided Event and fires it off to the registered listeners.
-     * 
+     *
      * @param event the Event instance to handle
      * @throws GitLabApiException if the event is not supported
      */
@@ -163,22 +164,23 @@ public class WebHookManager implements HookManager {
         LOGGER.info("handleEvent: object_kind=" + event.getObjectKind());
 
         switch (event.getObjectKind()) {
-        case BuildEvent.OBJECT_KIND:
-        case IssueEvent.OBJECT_KIND:
-        case JobEvent.OBJECT_KIND:
-        case MergeRequestEvent.OBJECT_KIND:
-        case NoteEvent.OBJECT_KIND:
-        case PipelineEvent.OBJECT_KIND:
-        case PushEvent.OBJECT_KIND:
-        case TagPushEvent.OBJECT_KIND:
-        case WikiPageEvent.OBJECT_KIND:
-            fireEvent(event);
-            break;
+            case BuildEvent.OBJECT_KIND:
+            case IssueEvent.OBJECT_KIND:
+            case JobEvent.OBJECT_KIND:
+            case MergeRequestEvent.OBJECT_KIND:
+            case NoteEvent.OBJECT_KIND:
+            case PipelineEvent.OBJECT_KIND:
+            case PushEvent.OBJECT_KIND:
+            case TagPushEvent.OBJECT_KIND:
+            case WikiPageEvent.OBJECT_KIND:
+            case DeploymentEvent.OBJECT_KIND:
+                fireEvent(event);
+                break;
 
-        default:
-            String message = "Unsupported event object_kind, object_kind=" + event.getObjectKind();
-            LOGGER.warning(message);
-            throw new GitLabApiException(message);
+            default:
+                String message = "Unsupported event object_kind, object_kind=" + event.getObjectKind();
+                LOGGER.warning(message);
+                throw new GitLabApiException(message);
         }
     }
 
@@ -205,53 +207,61 @@ public class WebHookManager implements HookManager {
 
     /**
      * Fire the event to the registered listeners.
-     * 
+     *
      * @param event the Event instance to fire to the registered event listeners
      * @throws GitLabApiException if the event is not supported
      */
     public void fireEvent(Event event) throws GitLabApiException {
 
         switch (event.getObjectKind()) {
-        case BuildEvent.OBJECT_KIND:
-            fireBuildEvent((BuildEvent) event);
-            break;
+            case BuildEvent.OBJECT_KIND:
+                fireBuildEvent((BuildEvent) event);
+                break;
 
-        case IssueEvent.OBJECT_KIND:
-            fireIssueEvent((IssueEvent) event);
-            break;
+            case IssueEvent.OBJECT_KIND:
+                fireIssueEvent((IssueEvent) event);
+                break;
 
-        case JobEvent.OBJECT_KIND:
-            fireJobEvent((JobEvent) event);
-            break;
+            case JobEvent.OBJECT_KIND:
+                fireJobEvent((JobEvent) event);
+                break;
 
-        case MergeRequestEvent.OBJECT_KIND:
-            fireMergeRequestEvent((MergeRequestEvent) event);
-            break;
+            case MergeRequestEvent.OBJECT_KIND:
+                fireMergeRequestEvent((MergeRequestEvent) event);
+                break;
 
-        case NoteEvent.OBJECT_KIND:
-            fireNoteEvent((NoteEvent) event);
-            break;
+            case NoteEvent.OBJECT_KIND:
+                fireNoteEvent((NoteEvent) event);
+                break;
 
-        case PipelineEvent.OBJECT_KIND:
-            firePipelineEvent((PipelineEvent) event);
-            break;
+            case PipelineEvent.OBJECT_KIND:
+                firePipelineEvent((PipelineEvent) event);
+                break;
 
-        case PushEvent.OBJECT_KIND:
-            firePushEvent((PushEvent) event);
-            break;
+            case PushEvent.OBJECT_KIND:
+                firePushEvent((PushEvent) event);
+                break;
 
-        case TagPushEvent.OBJECT_KIND:
-            fireTagPushEvent((TagPushEvent) event);
-            break;
+            case TagPushEvent.OBJECT_KIND:
+                fireTagPushEvent((TagPushEvent) event);
+                break;
 
-        case WikiPageEvent.OBJECT_KIND:
-            fireWikiPageEvent((WikiPageEvent) event);
-            break;
+            case WikiPageEvent.OBJECT_KIND:
+                fireWikiPageEvent((WikiPageEvent) event);
+                break;
 
-        default:
-            String message = "Unsupported event object_kind, object_kind=" + event.getObjectKind();
-            LOGGER.warning(message);
-            throw new GitLabApiException(message);
+            case DeploymentEvent.OBJECT_KIND:
+                fireDeploymentEvent((DeploymentEvent) event);
+                break;
+
+            case ReleaseEvent.OBJECT_KIND:
+                fireReleaseEvent((ReleaseEvent) event);
+                break;
+
+            default:
+                String message = "Unsupported event object_kind, object_kind=" + event.getObjectKind();
+                LOGGER.warning(message);
+                throw new GitLabApiException(message);
         }
     }
 
@@ -306,6 +316,18 @@ public class WebHookManager implements HookManager {
     protected void fireWikiPageEvent(WikiPageEvent wikiPageEvent) {
         for (WebHookListener listener : webhookListeners) {
             listener.onWikiPageEvent(wikiPageEvent);
+        }
+    }
+
+    protected void fireDeploymentEvent(DeploymentEvent deploymentEvent) {
+        for (WebHookListener listener : webhookListeners) {
+            listener.onDeploymentEvent(deploymentEvent);
+        }
+    }
+
+    protected void fireReleaseEvent(ReleaseEvent releaseEvent) {
+        for (WebHookListener listener : webhookListeners) {
+            listener.onReleaseEvent(releaseEvent);
         }
     }
 }


### PR DESCRIPTION
I noticed the following webhooks were missing for projects:

- Deployments
- Releases

I need both for my project, so decided to add them here. I have tested them with my own GitLab instance, it works great so far.
There are no integration tests for webhooks currently, so I have not added tests for them. 