### PR TITLE
Add some missing properties to ProjectApi.updateProject and createProject

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1265,7 +1265,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
             .withParam("packages_enabled", project.getPackagesEnabled())
             .withParam("build_git_strategy", project.getBuildGitStrategy())
-            .withParam("build_coverage_regex", project.getBuildCoverageRegex());
+            .withParam("build_coverage_regex", project.getBuildCoverageRegex())
+            .withParam("merge_method", project.getMergeMethod())
 
         if (isApiVersion(ApiVersion.V3)) {
             formData.withParam("visibility_level", project.getVisibilityLevel());

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1022,7 +1022,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("initialize_with_readme", project.getInitializeWithReadme())
             .withParam("packages_enabled", project.getPackagesEnabled())
             .withParam("build_git_strategy", project.getBuildGitStrategy())
-            .withParam("build_coverage_regex", project.getBuildCoverageRegex());
+            .withParam("build_coverage_regex", project.getBuildCoverageRegex())
+            .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
 
         Namespace namespace = project.getNamespace();
         if (namespace != null && namespace.getId() != null) {
@@ -1267,6 +1268,8 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("build_git_strategy", project.getBuildGitStrategy())
             .withParam("build_coverage_regex", project.getBuildCoverageRegex())
             .withParam("merge_method", project.getMergeMethod())
+            .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
+            .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge());
 
         if (isApiVersion(ApiVersion.V3)) {
             formData.withParam("visibility_level", project.getVisibilityLevel());

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1024,6 +1024,7 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("build_git_strategy", project.getBuildGitStrategy())
             .withParam("build_coverage_regex", project.getBuildCoverageRegex())
             .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
+            .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge());
 
         Namespace namespace = project.getNamespace();
         if (namespace != null && namespace.getId() != null) {

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -104,6 +104,7 @@ public class Project {
     private AutoDevopsDeployStrategy autoDevopsDeployStrategy;
     private Boolean autocloseReferencedIssues;
     private Boolean emailsDisabled;
+    private String suggestionCommitMessage;
 
     @JsonSerialize(using = JacksonJson.DateOnlySerializer.class)
     private Date markedForDeletionOn;
@@ -822,5 +823,18 @@ public class Project {
     public Project withEmailsDisabled(Boolean emailsDisabled) {
         this.emailsDisabled = emailsDisabled;
         return this;
+    }
+
+    public String getSuggestionCommitMessage() {
+        return this.suggestionCommitMessage;
+    }
+
+    public Project withSuggestionCommitMessage(String suggestionCommitMessage) {
+        this.suggestionCommitMessage = suggestionCommitMessage;
+        return this;
+    }
+
+    public void setSuggestionCommitMessage(String suggestionCommitMessage) {
+        this.suggestionCommitMessage = suggestionCommitMessage;
     }
 }

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -788,6 +788,11 @@ public class Project {
         this.removeSourceBranchAfterMerge = removeSourceBranchAfterMerge;
     }
 
+    public Project withRemoveSourceBranchAfterMerge(Boolean removeSourceBranchAfterMerge) {
+        this.removeSourceBranchAfterMerge = removeSourceBranchAfterMerge;
+        return this;
+    }
+
     public Boolean getAutoDevopsEnabled() {
         return autoDevopsEnabled;
     }

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -238,6 +238,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
                 .withTagList(Arrays.asList("tag1", "tag2"))
                 .withMergeMethod(Project.MergeMethod.MERGE)
                 .withSuggestionCommitMessage("SuggestionCommitMessageOriginal")
+                .withRemoveSourceBranchAfterMerge(false);
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -251,6 +252,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertTrue(Visibility.PUBLIC == newProject.getVisibility() || Boolean.TRUE == newProject.getPublic());
         assertEquals(Project.MergeMethod.MERGE, newProject.getMergeMethod());
         assertEquals(project.getSuggestionCommitMessage(), newProject.getSuggestionCommitMessage());
+        assertEquals(project.getRemoveSourceBranchAfterMerge(), newProject.getRemoveSourceBranchAfterMerge());
 
         project = new Project()
             .withId(newProject.getId())
@@ -263,6 +265,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
             .withVisibility(Visibility.PRIVATE)
             .withMergeMethod(Project.MergeMethod.REBASE_MERGE)
             .withSuggestionCommitMessage("SuggestionCommitMessageUpdated")
+            .withRemoveSourceBranchAfterMerge(true);
 
         Project updatedProject = gitLabApi.getProjectApi().updateProject(project);
         assertNotNull(updatedProject);
@@ -275,6 +278,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertTrue(Visibility.PRIVATE == updatedProject.getVisibility() || Boolean.FALSE == updatedProject.getPublic());
         assertEquals(Project.MergeMethod.REBASE_MERGE, updatedProject.getMergeMethod());
         assertEquals(project.getSuggestionCommitMessage(), updatedProject.getSuggestionCommitMessage());
+        assertEquals(true, updatedProject.getRemoveSourceBranchAfterMerge());
     }
 
     @Test

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -237,6 +237,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
                 .withVisibility(Visibility.PUBLIC)
                 .withTagList(Arrays.asList("tag1", "tag2"))
                 .withMergeMethod(Project.MergeMethod.MERGE)
+                .withSuggestionCommitMessage("SuggestionCommitMessageOriginal")
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -249,6 +250,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(project.getTagList(), newProject.getTagList());
         assertTrue(Visibility.PUBLIC == newProject.getVisibility() || Boolean.TRUE == newProject.getPublic());
         assertEquals(Project.MergeMethod.MERGE, newProject.getMergeMethod());
+        assertEquals(project.getSuggestionCommitMessage(), newProject.getSuggestionCommitMessage());
 
         project = new Project()
             .withId(newProject.getId())
@@ -260,6 +262,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
             .withSnippetsEnabled(false)
             .withVisibility(Visibility.PRIVATE)
             .withMergeMethod(Project.MergeMethod.REBASE_MERGE)
+            .withSuggestionCommitMessage("SuggestionCommitMessageUpdated")
 
         Project updatedProject = gitLabApi.getProjectApi().updateProject(project);
         assertNotNull(updatedProject);
@@ -271,6 +274,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(project.getSnippetsEnabled(), updatedProject.getSnippetsEnabled());
         assertTrue(Visibility.PRIVATE == updatedProject.getVisibility() || Boolean.FALSE == updatedProject.getPublic());
         assertEquals(Project.MergeMethod.REBASE_MERGE, updatedProject.getMergeMethod());
+        assertEquals(project.getSuggestionCommitMessage(), updatedProject.getSuggestionCommitMessage());
     }
 
     @Test

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -235,7 +235,8 @@ public class TestProjectApi extends AbstractIntegrationTest {
                 .withWikiEnabled(true)
                 .withSnippetsEnabled(true)
                 .withVisibility(Visibility.PUBLIC)
-                .withTagList(Arrays.asList("tag1", "tag2"));
+                .withTagList(Arrays.asList("tag1", "tag2"))
+                .withMergeMethod(Project.MergeMethod.MERGE)
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -247,6 +248,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(project.getSnippetsEnabled(), newProject.getSnippetsEnabled());
         assertEquals(project.getTagList(), newProject.getTagList());
         assertTrue(Visibility.PUBLIC == newProject.getVisibility() || Boolean.TRUE == newProject.getPublic());
+        assertEquals(Project.MergeMethod.MERGE, newProject.getMergeMethod());
 
         project = new Project()
             .withId(newProject.getId())
@@ -256,7 +258,8 @@ public class TestProjectApi extends AbstractIntegrationTest {
             .withMergeRequestsEnabled(false)
             .withWikiEnabled(false)
             .withSnippetsEnabled(false)
-            .withVisibility(Visibility.PRIVATE);
+            .withVisibility(Visibility.PRIVATE)
+            .withMergeMethod(Project.MergeMethod.REBASE_MERGE)
 
         Project updatedProject = gitLabApi.getProjectApi().updateProject(project);
         assertNotNull(updatedProject);
@@ -267,6 +270,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(project.getWikiEnabled(), updatedProject.getWikiEnabled());
         assertEquals(project.getSnippetsEnabled(), updatedProject.getSnippetsEnabled());
         assertTrue(Visibility.PRIVATE == updatedProject.getVisibility() || Boolean.FALSE == updatedProject.getPublic());
+        assertEquals(Project.MergeMethod.REBASE_MERGE, updatedProject.getMergeMethod());
     }
 
     @Test


### PR DESCRIPTION
Add the following properties to the form of ProjectApi.updateProject and createProject methods:

- merge_method
- suggestion_commit_message
- remove_source_branch_after_merge