### PR TITLE
Fix #658 : Pager not working properly

### DIFF
--- a/src/main/java/org/gitlab4j/api/Pager.java
+++ b/src/main/java/org/gitlab4j/api/Pager.java
@@ -306,12 +306,6 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
      */
     public List<T> page(int pageNumber) {
 
-        if (pageNumber > totalPages && pageNumber > kaminariNextPage) {
-            throw new NoSuchElementException();
-        } else if (pageNumber < 1) {
-            throw new NoSuchElementException();
-        }
-
         if (currentPage == 0 && pageNumber == 1) {
             currentPage = 1;
             return (currentItems);
@@ -319,6 +313,12 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
 
         if (currentPage == pageNumber) {
             return (currentItems);
+        }
+
+        if (pageNumber > totalPages && pageNumber > kaminariNextPage) {
+            throw new NoSuchElementException();
+        } else if (pageNumber < 1) {
+            throw new NoSuchElementException();
         }
 
         try {


### PR DESCRIPTION
Since the removal of "X-Total-Pages" and "X-Total" headers, all paginations use the kaminari counter.
In this mode, kaminari counter is reset to -1 during the call of the last page. This part is correct.
Then when we call the `current()` method of the pager to get the current page. This method call the same `page` method than the `next` method. In this method the pager check if there is element before checking if we call for the current page. It throws NoSuchElementException erroneously.

To fix, I change the check sequence. First I check ifthe user call the current page. If so, we return the corresponding items. If not we check if there is such elements and call the API.