### PR TITLE
Update hook project wiki event wqattribute to wiki_page_events

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2066,7 +2066,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("confidential_note_events", enabledHooks.getConfidentialNoteEvents(), false)
                 .withParam("job_events", enabledHooks.getJobEvents(), false)
                 .withParam("pipeline_events", enabledHooks.getPipelineEvents(), false)
-                .withParam("wiki_events", enabledHooks.getWikiPageEvents(), false)
+                .withParam("wiki_page_events", enabledHooks.getWikiPageEvents(), false)
                 .withParam("enable_ssl_verification", enableSslVerification, false)
                 .withParam("repository_update_events", enabledHooks.getRepositoryUpdateEvents(), false)
                 .withParam("token", secretToken, false);
@@ -2146,7 +2146,7 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("note_events", hook.getNoteEvents(), false)
             .withParam("job_events", hook.getJobEvents(), false)
             .withParam("pipeline_events", hook.getPipelineEvents(), false)
-            .withParam("wiki_events", hook.getWikiPageEvents(), false)
+            .withParam("wiki_page_events", hook.getWikiPageEvents(), false)
             .withParam("enable_ssl_verification", hook.getEnableSslVerification(), false)
             .withParam("token", hook.getToken(), false);
 


### PR DESCRIPTION
In GitLab 11.11, the Project Hook Key for wiki events was wiki_events.
We don't support GitLab 11.X anymore. We only support GitLab 12.9.2+.
In new version of GitLab the correct key is `wiki_page_events`.