### PR TITLE
Fix delete discussion API

### DIFF
--- a/src/main/java/org/gitlab4j/api/DiscussionsApi.java
+++ b/src/main/java/org/gitlab4j/api/DiscussionsApi.java
@@ -368,7 +368,7 @@ public class DiscussionsApi extends AbstractApi {
     public void deleteMergeRequestDiscussionNote(Object projectIdOrPath, Integer mergeRequestIid,
             String discussionId, Integer noteId)  throws GitLabApiException {
         delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "discussions", noteId);
+                "merge_requests", mergeRequestIid, "discussions", discussionId, "notes", noteId);
     }
 
     /**


### PR DESCRIPTION
https://docs.gitlab.com/ee/api/discussions.html#delete-a-merge-request-thread-note

Fix for https://github.com/gitlab4j/gitlab4j-api/issues/741