### PR TITLE
Added support for scope attribute to EventsApi

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -463,7 +463,7 @@ public interface Constants {
     /** Enum to use for specifying the event action_type. */
     public enum ActionType {
 
-        CREATED, UPDATED, CLOSED, REOPENED, PUSHED, COMMENTED, MERGED, JOINED, LEFT, DESTROYED, EXPIRED, REMOVED;
+        CREATED, UPDATED, OPENED, CLOSED, REOPENED, PUSHED, COMMENTED, MERGED, JOINED, LEFT, DESTROYED, EXPIRED, REMOVED, DELETED, APPROVED, ACCEPTED;
 
         private static JacksonJsonEnumHelper<ActionType> enumHelper = new JacksonJsonEnumHelper<>(ActionType.class);
 

--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -916,5 +916,27 @@ public interface Constants {
             return (enumHelper.toString(this));
         }
     }
+
+    /** Enum to use for specifying the Event scope. */
+    public enum EventScope {
+        ALL;
+
+        private static JacksonJsonEnumHelper<EventScope> enumHelper = new JacksonJsonEnumHelper<>(EventScope.class);
+
+        @JsonCreator
+        public static EventScope forValue(String value) {
+            return enumHelper.forValue(value);
+        }
+
+        @JsonValue
+        public String toValue() {
+            return (enumHelper.toString(this));
+        }
+
+        @Override
+        public String toString() {
+            return (enumHelper.toString(this));
+        }
+    }
 }
 

--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -463,7 +463,7 @@ public interface Constants {
     /** Enum to use for specifying the event action_type. */
     public enum ActionType {
 
-        CREATED, UPDATED, OPENED, CLOSED, REOPENED, PUSHED, COMMENTED, MERGED, JOINED, LEFT, DESTROYED, EXPIRED, REMOVED, DELETED, APPROVED, ACCEPTED;
+        CREATED, UPDATED, OPENED, CLOSED, REOPENED, PUSHED, COMMENTED, MERGED, JOINED, LEFT, DESTROYED, EXPIRED, REMOVED, DELETED, APPROVED, ACCEPTED, IMPORTED;
 
         private static JacksonJsonEnumHelper<ActionType> enumHelper = new JacksonJsonEnumHelper<>(ActionType.class);
 

--- a/src/main/java/org/gitlab4j/api/EventsApi.java
+++ b/src/main/java/org/gitlab4j/api/EventsApi.java
@@ -37,6 +37,24 @@ public class EventsApi extends AbstractApi {
     }
 
     /**
+     * Get a list of all events for the authenticated user, across all of the user's projects.
+     *
+     * <pre><code>GitLab Endpoint: GET /events</code></pre>
+     *
+     * @param action include only events of a particular action type, optional
+     * @param targetType include only events of a particular target type, optional
+     * @param before include only events created before a particular date, optional
+     * @param after include only events created after a particular date, optional
+     * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
+     * @return a list of events for the authenticated user and matching the supplied parameters
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Event> getAllAuthenticatedUserEvents(ActionType action, TargetType targetType,
+            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), EventScope.ALL).all());
+    }
+
+    /**
      * Get a list of events for the authenticated user and in the specified page range.
      *
      * <pre><code>GitLab Endpoint: GET /events</code></pre>
@@ -53,6 +71,27 @@ public class EventsApi extends AbstractApi {
      */
     public List<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType,
             Date before, Date after, SortOrder sortOrder, int page, int perPage) throws GitLabApiException {
+        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, page, perPage, null));
+    }
+
+    /**
+     * Get a list of events for the authenticated user and in the specified page range.
+     *
+     * <pre><code>GitLab Endpoint: GET /events</code></pre>
+     *
+     * @param action include only events of a particular action type, optional
+     * @param targetType include only events of a particular target type, optional
+     * @param before include only events created before a particular date, optional
+     * @param after include only events created after a particular date, optional
+     * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
+     * @param page the page to get
+     * @param perPage the number of projects per page
+     * @param scope include all events across a user’s projects, optional 
+     * @return a list of events for the authenticated user and matching the supplied parameters
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType,
+            Date before, Date after, SortOrder sortOrder, int page, int perPage, EventScope scope) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
@@ -61,7 +100,8 @@ public class EventsApi extends AbstractApi {
                 .withParam("after", after)
                 .withParam("sort", sortOrder)
                 .withParam(PAGE_PARAM,  page)
-                .withParam(PER_PAGE_PARAM, perPage);
+                .withParam(PER_PAGE_PARAM, perPage)
+                .withParam("scope", scope != null ? scope.toValue().toLowerCase() : null);
 
         Response response = get(Response.Status.OK, formData.asMap(), "events");
         return (response.readEntity(new GenericType<List<Event>>() {}));
@@ -83,13 +123,34 @@ public class EventsApi extends AbstractApi {
      */
     public Pager<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType, Date before, Date after,
             SortOrder sortOrder, int itemsPerPage) throws GitLabApiException {
+        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, itemsPerPage, null));
+    }
+
+    /**
+     * Get a list of events for the authenticated user and in the specified page range.
+     *
+     * <pre><code>GitLab Endpoint: GET /events</code></pre>
+     *
+     * @param action include only events of a particular action type, optional
+     * @param targetType include only events of a particular target type, optional
+     * @param before include only events created before a particular date, optional
+     * @param after include only events created after a particular date, optional
+     * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
+     * @param itemsPerPage the number of Event instances that will be fetched per page
+     * @param scope include all events across a user’s projects, optional 
+     * @return a Pager of events for the authenticated user and matching the supplied parameters
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType, Date before, Date after,
+            SortOrder sortOrder, int itemsPerPage, EventScope scope) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
                 .withParam("after", after)
-                .withParam("sort", sortOrder);
+                .withParam("sort", sortOrder)
+                .withParam("scope", scope != null ? scope.toValue().toLowerCase() : null);
 
         return (new Pager<Event>(this, Event.class, itemsPerPage, formData.asMap(), "events"));
     }
@@ -109,7 +170,25 @@ public class EventsApi extends AbstractApi {
      */
     public Stream<Event> getAuthenticatedUserEventsStream(ActionType action, TargetType targetType,
             Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
-        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage()).stream());
+        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), null).stream());
+    }
+
+    /**
+     * Get a Stream of all events for the authenticated user, across all of the user's projects.
+     *
+     * <pre><code>GitLab Endpoint: GET /events</code></pre>
+     *
+     * @param action include only events of a particular action type, optional
+     * @param targetType include only events of a particular target type, optional
+     * @param before include only events created before a particular date, optional
+     * @param after include only events created after a particular date, optional
+     * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
+     * @return a Stream of events for the authenticated user and matching the supplied parameters
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Stream<Event> getAllAuthenticatedUserEventsStream(ActionType action, TargetType targetType,
+            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+        return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), EventScope.ALL).stream());
     }
 
     /**

--- a/src/test/java/org/gitlab4j/api/TestEventsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestEventsApi.java
@@ -66,6 +66,18 @@ public class TestEventsApi extends AbstractIntegrationTest {
     }
 
     @Test
+    public void testGetAuthenticatedUserEventsWithScope() throws GitLabApiException {
+        List<Event> events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, null, null, null, 1, 10, Constants.EventScope.ALL);
+        assertNotNull(events);
+    }
+
+    @Test
+    public void testGetAllAuthenticatedUserEvents() throws GitLabApiException {
+        List<Event> events = gitLabApi.getEventsApi().getAllAuthenticatedUserEvents(null, null, null, null, null);
+        assertNotNull(events);
+    }
+
+    @Test
     public void testGetAuthenticatedUserEventsWithDates() throws GitLabApiException {
         Date after = new Date(0);
         Date now = new Date();
@@ -73,6 +85,18 @@ public class TestEventsApi extends AbstractIntegrationTest {
         assertNotNull(events);
 
         events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, after, null, null);
+        assertNotNull(events);
+        assertEquals(0, events.size());
+    }
+
+    @Test
+    public void testGetAuthenticatedUserEventsWithDatesAndScope() throws GitLabApiException {
+        Date after = new Date(0);
+        Date now = new Date();
+        List<Event> events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, now, after, null, 1, 10, Constants.EventScope.ALL);
+        assertNotNull(events);
+
+        events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, after, null, null, 1, 10, Constants.EventScope.ALL);
         assertNotNull(events);
         assertEquals(0, events.size());
     }
@@ -104,6 +128,12 @@ public class TestEventsApi extends AbstractIntegrationTest {
     @Test
     public void testPagedGetAuthenticatedUserEvents() throws GitLabApiException {
         Pager<Event> events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, null, null, null, 10);
+        assertNotNull(events);
+    }
+
+    @Test
+    public void testPagedGetAuthenticatedUserEventsWithScope() throws GitLabApiException {
+        Pager<Event> events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, null, null, null, 10, Constants.EventScope.ALL);
         assertNotNull(events);
     }
 


### PR DESCRIPTION
A `scope` attribute was added to the Events API that allows retrieval of all events for a user across all the projects that user has access to.  This change adds support for this new attribute.

Fixes #759 