### PR TITLE
Adding branches_to_be_notified to SlackService

### DIFF
--- a/src/main/java/org/gitlab4j/api/services/EmailOnPushService.java
+++ b/src/main/java/org/gitlab4j/api/services/EmailOnPushService.java
@@ -9,7 +9,6 @@ public class EmailOnPushService extends NotificationService {
     public static final String RECIPIENT_PROP = "recipients";
     public static final String DISABLE_DIFFS_PROP = "disable_diffs";
     public static final String SEND_FROM_COMMITTER_EMAIL_PROP = "send_from_committer_email";
-    public static final String BRANCHES_TO_BE_NOTIFIED_PROP = "branches_to_be_notified";
 
 	@Override
 	public GitLabApiForm servicePropertiesForm() {

--- a/src/main/java/org/gitlab4j/api/services/NotificationService.java
+++ b/src/main/java/org/gitlab4j/api/services/NotificationService.java
@@ -13,6 +13,7 @@ public abstract class NotificationService {
 
     public static final String NOTIFY_ONLY_BROKEN_PIPELINES_PROP = "notify_only_broken_pipelines";
     public static final String NOTIFY_ONLY_DEFAULT_BRANCH_PROP = "notify_only_default_branch";
+    public static final String BRANCHES_TO_BE_NOTIFIED_PROP = "branches_to_be_notified";
     public static final String PUSH_CHANNEL_PROP = "push_channel";
     public static final String ISSUE_CHANNEL_PROP = "issue_channel";
     public static final String CONFIDENTIAL_ISSUE_CHANNEL_PROP = "confidential_issue_channel";

--- a/src/main/java/org/gitlab4j/api/services/SlackService.java
+++ b/src/main/java/org/gitlab4j/api/services/SlackService.java
@@ -139,17 +139,48 @@ public class SlackService extends NotificationService {
     }
 
     @JsonIgnore
+    @Deprecated
     public Boolean getNotifyOnlyDefaultBranch() {
         return ((Boolean) getProperty(NOTIFY_ONLY_DEFAULT_BRANCH_PROP, Boolean.FALSE));
     }
 
+    /**
+     * @deprecated use {@link SlackService#setBranchesToBeNotified(BranchesToBeNotified)}
+     * @param notifyOnlyDefaultBranch
+     */
+    @Deprecated
     public void setNotifyOnlyDefaultBranch(Boolean notifyOnlyDefaultBranch) {
         setProperty(NOTIFY_ONLY_DEFAULT_BRANCH_PROP, notifyOnlyDefaultBranch);
     }
 
+    /**
+     * @deprecated use {@link SlackService#withBranchesToBeNotified(BranchesToBeNotified)}
+     * @param notifyOnlyDefaultBranch
+     */
+    @Deprecated
     public SlackService withNotifyOnlyDefaultBranch(Boolean notifyOnlyDefaultBranch) {
         setNotifyOnlyDefaultBranch(notifyOnlyDefaultBranch);
         return (this);
+    }
+
+    @JsonIgnore
+    public BranchesToBeNotified getBranchesToBeNotified() {
+        String branchesToBeNotified = getProperty(BRANCHES_TO_BE_NOTIFIED_PROP);
+
+        if (branchesToBeNotified == null || branchesToBeNotified.isEmpty()) {
+            return null;
+        }
+
+        return (BranchesToBeNotified.valueOf(branchesToBeNotified.toUpperCase()));
+    }
+
+    public void setBranchesToBeNotified(BranchesToBeNotified branchesToBeNotified) {
+        setProperty(BRANCHES_TO_BE_NOTIFIED_PROP, branchesToBeNotified.toString());
+    }
+
+    public SlackService withBranchesToBeNotified(BranchesToBeNotified branchesToBeNotified) {
+        setBranchesToBeNotified(branchesToBeNotified);
+        return this;
     }
 
     @JsonIgnore

--- a/src/test/resources/org/gitlab4j/api/slack-notifications.json
+++ b/src/test/resources/org/gitlab4j/api/slack-notifications.json
@@ -18,7 +18,7 @@
         "webhook": "https://hooks.slack.com/services/AAAA1BBB/ABCDEFGHI/aBCdef1Gerer65ere54gdffd",
         "username": "GitLab",
         "notify_only_broken_pipelines": false,
-        "notify_only_default_branch": true,
+        "branches_to_be_notified": "all",
         "push_channel": "pushes",
         "issue_channel": "",
         "confidential_issue_channel": "",


### PR DESCRIPTION
Adding branches_to_be_notified to SlackService and deprecating notify_only_default_branch as per
https://docs.gitlab.com/ee/api/services.html#createedit-slack-service