### PR TITLE
Upload: accept an InputStream besides a File

### DIFF
--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -370,7 +370,7 @@ public abstract class AbstractApi implements Constants {
      * @param expectedStatus the HTTP status that should be returned from the server
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaType unused; will be removed in the next major version
      * @param pathArgs variable list of arguments used to build the URI
      * @return a ClientResponse instance with the data returned from the endpoint
      * @throws GitLabApiException if any exception occurs during execution
@@ -398,7 +398,7 @@ public abstract class AbstractApi implements Constants {
      * @param expectedStatus the HTTP status that should be returned from the server
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaType unused; will be removed in the next major version
      * @param url the fully formed path to the GitLab API endpoint
      * @return a ClientResponse instance with the data returned from the endpoint
      * @throws GitLabApiException if any exception occurs during execution
@@ -418,7 +418,7 @@ public abstract class AbstractApi implements Constants {
      * @param expectedStatus the HTTP status that should be returned from the server
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaType unused; will be removed in the next major version
      * @param formData the Form containing the name/value pairs
      * @param url the fully formed path to the GitLab API endpoint
      * @return a ClientResponse instance with the data returned from the endpoint

--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api;
 
 import java.io.File;
+import java.io.InputStream;
 import java.net.URL;
 
 import javax.ws.rs.NotAuthorizedException;
@@ -377,6 +378,14 @@ public abstract class AbstractApi implements Constants {
     protected Response upload(Response.Status expectedStatus, String name, File fileToUpload, String mediaType, Object... pathArgs) throws GitLabApiException {
         try {
             return validate(getApiClient().upload(name, fileToUpload, mediaType, pathArgs), expectedStatus);
+        } catch (Exception e) {
+            throw handle(e);
+        }
+    }
+
+    protected Response upload(Response.Status expectedStatus, String name, InputStream inputStream, String filename, String mediaType, Object... pathArgs) throws GitLabApiException {
+        try {
+            return validate(getApiClient().upload(name, inputStream, filename, mediaType, pathArgs), expectedStatus);
         } catch (Exception e) {
             throw handle(e);
         }

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -561,7 +561,7 @@ public class GitLabApiClient implements AutoCloseable {
      *
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaTypeString unused; will be removed in the next major version
      * @param pathArgs variable list of arguments used to build the URI
      * @return a ClientResponse instance with the data returned from the endpoint
      * @throws IOException if an error occurs while constructing the URL
@@ -576,7 +576,7 @@ public class GitLabApiClient implements AutoCloseable {
      *
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaTypeString unused; will be removed in the next major version
      * @param formData the Form containing the name/value pairs
      * @param pathArgs variable list of arguments used to build the URI
      * @return a ClientResponse instance with the data returned from the endpoint
@@ -593,17 +593,14 @@ public class GitLabApiClient implements AutoCloseable {
      *
      * @param name the name for the form field that contains the file name
      * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString the content-type of the uploaded file, if null will be determined from fileToUpload
+     * @param mediaTypeString unused; will be removed in the next major version
      * @param formData the Form containing the name/value pairs
      * @param url the fully formed path to the GitLab API endpoint
      * @return a ClientResponse instance with the data returned from the endpoint
      * @throws IOException if an error occurs while constructing the URL
      */
     protected Response upload(String name, File fileToUpload, String mediaTypeString, Form formData, URL url) throws IOException {
-        MediaType mediaType = (mediaTypeString != null ? MediaType.valueOf(mediaTypeString) : null);
-        FileDataBodyPart filePart = mediaType != null ?
-            new FileDataBodyPart(name, fileToUpload, mediaType) :
-            new FileDataBodyPart(name, fileToUpload);
+        FileDataBodyPart filePart = new FileDataBodyPart(name, fileToUpload);
         return upload(filePart, formData, url);
     }
 
@@ -613,10 +610,7 @@ public class GitLabApiClient implements AutoCloseable {
     }
 
     protected Response upload(String name, InputStream inputStream, String filename, String mediaTypeString, Form formData, URL url) throws IOException {
-        MediaType mediaType = (mediaTypeString != null ? MediaType.valueOf(mediaTypeString) : null);
-        StreamDataBodyPart streamDataBodyPart = mediaType != null ?
-            new StreamDataBodyPart(name, inputStream, filename, mediaType) :
-            new StreamDataBodyPart(name, inputStream, filename);
+        StreamDataBodyPart streamDataBodyPart = new StreamDataBodyPart(name, inputStream, filename);
         return upload(streamDataBodyPart, formData, url);
     }
 

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -24,6 +24,7 @@
 package org.gitlab4j.api;
 
 import java.io.File;
+import java.io.InputStream;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
 import java.util.Date;
@@ -32,12 +33,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
-
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AccessRequest;
@@ -2559,6 +2558,23 @@ public class ProjectApi extends AbstractApi implements Constants {
      */
     public FileUpload uploadFile(Object projectIdOrPath, File fileToUpload, String mediaType) throws GitLabApiException {
         Response response = upload(Response.Status.CREATED, "file", fileToUpload, mediaType, "projects", getProjectIdOrPath(projectIdOrPath), "uploads");
+        return (response.readEntity(FileUpload.class));
+    }
+
+    /**
+     * Uploads some data in an {@link InputStream} to the specified project,
+     * to be used in an issue or merge request description, or a comment.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance, required
+     * @param inputStream the data to upload, required
+     * @param mediaType the media type of the file to upload, required
+     * @return a FileUpload instance with information on the just uploaded file
+     * @throws GitLabApiException if any exception occurs
+     */
+    public FileUpload uploadFile(Object projectIdOrPath, InputStream inputStream, String filename, String mediaType) throws GitLabApiException {
+        Response response = upload(Response.Status.CREATED, "file", inputStream, filename, mediaType, "projects", getProjectIdOrPath(projectIdOrPath), "uploads");
         return (response.readEntity(FileUpload.class));
     }
 

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2552,7 +2552,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      *
      * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance, required
      * @param fileToUpload the File instance of the file to upload, required
-     * @param mediaType the media type of the file to upload, optional
+     * @param mediaType unused; will be removed in the next major version
      * @return a FileUpload instance with information on the just uploaded file
      * @throws GitLabApiException if any exception occurs
      */
@@ -2569,7 +2569,6 @@ public class ProjectApi extends AbstractApi implements Constants {
      *
      * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance, required
      * @param inputStream the data to upload, required
-     * @param mediaType the media type of the file to upload, required
      * @return a FileUpload instance with information on the just uploaded file
      * @throws GitLabApiException if any exception occurs
      */

--- a/src/test/java/org/gitlab4j/api/TestUpload.java
+++ b/src/test/java/org/gitlab4j/api/TestUpload.java
@@ -1,12 +1,16 @@
 package org.gitlab4j.api;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.endsWith;
+import static org.hamcrest.Matchers.equalTo;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assume.assumeNotNull;
 import static org.junit.Assume.assumeTrue;
 
 import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
 import java.util.Map;
-
 import org.gitlab4j.api.models.FileUpload;
 import org.gitlab4j.api.models.Project;
 import org.junit.Before;
@@ -18,17 +22,17 @@ import org.junit.runners.MethodSorters;
 
 /**
 * In order for these tests to run you must set the following properties in test-gitlab4j.properties
- * 
+ *
  * TEST_NAMESPACE
  * TEST_PROJECT_NAME
  * TEST_HOST_URL
  * TEST_PRIVATE_TOKEN
- * 
+ *
  * If any of the above are NULL, all tests in this class will be skipped.
  */
 @Category(IntegrationTest.class)
 @FixMethodOrder(MethodSorters.NAME_ASCENDING)
-public class TestFileUpload extends AbstractIntegrationTest {
+public class TestUpload extends AbstractIntegrationTest {
 
     // The following needs to be set to your test repository
     private static final String TEST_PROXY_URI = HelperUtils.getProperty("TEST_PROXY_URI");
@@ -37,7 +41,7 @@ public class TestFileUpload extends AbstractIntegrationTest {
 
     private static GitLabApi gitLabApi;
 
-    public TestFileUpload() {
+    public TestUpload() {
         super();
     }
 
@@ -93,4 +97,21 @@ public class TestFileUpload extends AbstractIntegrationTest {
 
         gitLabApi.close();
     }
+
+    @Test
+    public void testInputStreamUpload() throws GitLabApiException, FileNotFoundException {
+
+        Project project = gitLabApi.getProjectApi().getProject(TEST_NAMESPACE, TEST_PROJECT_NAME);
+        assertNotNull(project);
+
+        String filename = "README.md";
+        File fileToUpload = new File(filename);
+        FileUpload fileUpload = gitLabApi.getProjectApi().uploadFile(
+            project.getId(), new FileInputStream(fileToUpload), filename, null);
+
+        assertNotNull(fileUpload);
+        assertThat(fileUpload.getUrl(), endsWith(filename));
+        assertThat(fileUpload.getAlt(), equalTo(filename));
+    }
+
 }


### PR DESCRIPTION
This makes it possible to stream data coming from another server straight into the POST request to Gitlab, saving an extra, expensive, and useless IO operation on disk.

Use case: integrating Gitlab with another defect management system.