### PR TITLE
configure jersey to use jackson over json binding

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -403,12 +403,6 @@
 			<artifactId>jakarta.activation-api</artifactId>
 			<version>${activation.version}</version>
 		</dependency>
-
-		<dependency>
-			<groupId>com.fasterxml.jackson.jaxrs</groupId>
-			<artifactId>jackson-jaxrs-json-provider</artifactId>
-			<version>${jackson.version}</version>
-		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jersey.inject</groupId>
 			<artifactId>jersey-hk2</artifactId>
@@ -427,6 +421,11 @@
 		<dependency>
 			<groupId>org.glassfish.jersey.media</groupId>
 			<artifactId>jersey-media-multipart</artifactId>
+			<version>${jersey.version}</version>
+		</dependency>
+		<dependency>
+			<groupId>org.glassfish.jersey.media</groupId>
+			<artifactId>jersey-media-json-jackson</artifactId>
 			<version>${jersey.version}</version>
 		</dependency>
 		<dependency>

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -38,6 +38,7 @@ import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
 import org.glassfish.jersey.client.ClientConfig;
 import org.glassfish.jersey.client.ClientProperties;
 import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.jackson.JacksonFeature;
 import org.glassfish.jersey.media.multipart.Boundary;
 import org.glassfish.jersey.media.multipart.FormDataMultiPart;
 import org.glassfish.jersey.media.multipart.MultiPart;
@@ -242,6 +243,7 @@ public class GitLabApiClient implements AutoCloseable {
         clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
 
         clientConfig.register(JacksonJson.class);
+        clientConfig.register(JacksonFeature.class);
         clientConfig.register(MultiPartFeature.class);
     }
 
@@ -769,6 +771,7 @@ public class GitLabApiClient implements AutoCloseable {
 
         // Register JacksonJson as the ObjectMapper provider.
         clientBuilder.register(JacksonJson.class);
+        clientBuilder.register(JacksonFeature.class);
 
         if (ignoreCertificateErrors) {
             clientBuilder.sslContext(openSslContext).hostnameVerifier(openHostnameVerifier);

--- a/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
+++ b/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
@@ -16,6 +16,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.ext.ContextResolver;
 
 import org.gitlab4j.api.models.User;
+import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.core.JsonGenerationException;
@@ -37,7 +38,6 @@ import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
 import com.fasterxml.jackson.databind.type.CollectionType;
-import com.fasterxml.jackson.jaxrs.json.JacksonJaxbJsonProvider;
 
 /**
  * Jackson JSON Configuration and utility class.


### PR DESCRIPTION

With the current `gitlab4j-api` (4.19.0), when the `jersey-media-json-binding` is on the classpath, jersey will use jsonb (eclipse yasson) to deserialize the json response, because it implements the `ForcedAutoDiscoverable` interface and always gets registered with a higher priority.

https://github.com/eclipse-ee4j/jersey/blob/master/media/json-binding/src/main/java/org/glassfish/jersey/jsonb/internal/JsonBindingAutoDiscoverable.java

https://github.com/eclipse-ee4j/jersey/blob/9dbc693eaff403e4a1b285cac77361fd96b9b694/core-common/src/main/java/org/glassfish/jersey/internal/spi/ForcedAutoDiscoverable.java

To fix this, we need to register the `JacksonFeature` to force jersey to use jackson over json binding.


Context:

I use 2 plugins in jenkins: the `gitlab-plugin` which uses `jersey` directly and the `gitlab-branch-source` plugin that uses `gitlab4j-api` (packaged in the `gitlab-api` plugin).

Since `gitlab-plugin` has been updated to use a new `jersey2-api` plugin, I had strange `ClassCastException` with `gitlab4j-api` and `jersey`, to fix this I'm modifying the `gitlab-api` plugin to also use the `jersey2-api` plugin instead of packaging its own `jersey` libs. Because the `jersey2-api` plugin contains `jersey-media-json-binding`, it wasn't working until I made the changes to register `JacksonFeature`.
