### PR TITLE
Fixed MembershipSourceType enum, UserApi.getMemberships() and implemented KeysApi

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -95,6 +95,7 @@ public class GitLabApi implements AutoCloseable {
     private TodosApi todosApi;
     private UserApi userApi;
     private WikisApi wikisApi;
+    private KeysApi keysApi;
 
     /**
      * Get the GitLab4J shared Logger instance.
@@ -1673,6 +1674,21 @@ public class GitLabApi implements AutoCloseable {
 
         return wikisApi;
     }
+
+    /**
+     * Gets the KeysApi instance owned by this GitLabApi instance. The KeysApi is used to look up users by their ssh key signatures
+     *
+     * @return the KeysApi instance owned by this GitLabApi instance
+     */
+    public KeysApi getKeysAPI() {
+        synchronized (this) {
+            if (keysApi == null) {
+                keysApi = new KeysApi(this);
+            }
+        }
+        return keysApi;
+    }
+
 
     /**
      * Create and return an Optional instance associated with a GitLabApiException.

--- a/src/main/java/org/gitlab4j/api/KeysApi.java
+++ b/src/main/java/org/gitlab4j/api/KeysApi.java
@@ -1,0 +1,30 @@
+package org.gitlab4j.api;
+
+import org.gitlab4j.api.models.Key;
+
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.MultivaluedMap;
+import javax.ws.rs.core.Response;
+import java.util.Collections;
+
+/**
+ * See:
+ * https://docs.gitlab.com/ee/api/keys.html#get-user-by-fingerprint-of-ssh-key
+ */
+public class KeysApi extends AbstractApi {
+    public KeysApi(GitLabApi gitLabApi) {
+        super(gitLabApi);
+    }
+
+    /**
+     * @param fingerprint The md5 hash of a ssh public key with : separating the bytes Or SHA256:$base64hash
+     * @return The Key which includes the user who owns the key
+     * @throws GitLabApiException If anything goes wrong
+     */
+    public Key getUserBySSHKeyFingerprint(String fingerprint) throws GitLabApiException {
+        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+        queryParams.put("fingerprint", Collections.singletonList(fingerprint));
+        Response response = get(Response.Status.OK, queryParams, "keys");
+        return response.readEntity(Key.class);
+    }
+}

--- a/src/main/java/org/gitlab4j/api/UserApi.java
+++ b/src/main/java/org/gitlab4j/api/UserApi.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.ws.rs.core.Form;
@@ -1306,9 +1307,24 @@ public class UserApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      * @since GitLab 12.8
      */
-    public List<Membership> getMemberships(Integer userId) throws GitLabApiException {
+    public List<Membership> getMemberships(int userId) throws GitLabApiException {
+        return getMembershipsPager(userId).stream().collect(Collectors.toList());
+    }
+
+    /**
+     * Returns a Pager that lists all projects and groups a user is a member of. (admin only)
+     *
+     * This allows lazy-fetching of huge numbers of memberships.
+     *
+     * <pre><code>GitLab Endpoint: GET /users/:id/memberships</code></pre>
+     *
+     * @param userId the ID of the user to get the memberships for
+     * @return the list of memberships of the given user
+     * @throws GitLabApiException if any exception occurs
+     * @since GitLab 12.8
+     */
+    public Pager<Membership> getMembershipsPager(int userId) throws GitLabApiException {
         GitLabApiForm formData = new GitLabApiForm();
-        Response response = get(Response.Status.OK, formData.asMap(), "users", userId, "memberships");
-        return (response.readEntity(new GenericType<List<Membership>>() {}));
+        return (new Pager<>(this, Membership.class, 100, formData.asMap(), "users", userId, "memberships"));
     }
 }

--- a/src/main/java/org/gitlab4j/api/models/MembershipSourceType.java
+++ b/src/main/java/org/gitlab4j/api/models/MembershipSourceType.java
@@ -1,31 +1,38 @@
 package org.gitlab4j.api.models;
 
-import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public enum MembershipSourceType {
+import java.util.Locale;
 
-    PROJECT,
+public enum MembershipSourceType {
+    PROJECT("Project"),
 
     /** Representing a group */
-    NAMESPACE;
+    NAMESPACE("Namespace");
 
-    private static JacksonJsonEnumHelper<MembershipSourceType> enumHelper = new JacksonJsonEnumHelper<>(MembershipSourceType.class);
+    public final String name;
+
+    MembershipSourceType(String name) {
+        this.name = name;
+    }
 
     @JsonCreator
     public static MembershipSourceType forValue(String value) {
-        return enumHelper.forValue(value);
+        if (value == null) {
+            return null;
+        } else {
+            return MembershipSourceType.valueOf(value.toUpperCase(Locale.ROOT));
+        }
     }
 
     @JsonValue
     public String toValue() {
-        return (enumHelper.toString(this));
+        return this.name;
     }
 
     @Override
     public String toString() {
-        return (enumHelper.toString(this));
+        return this.name;
     }
 }

--- a/src/test/java/org/gitlab4j/api/models/MembershipSourceTypeTest.java
+++ b/src/test/java/org/gitlab4j/api/models/MembershipSourceTypeTest.java
@@ -1,0 +1,19 @@
+package org.gitlab4j.api.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MembershipSourceTypeTest {
+
+    @Test
+    public void forValue() {
+        final MembershipSourceType namespace = MembershipSourceType.forValue(MembershipSourceType.NAMESPACE.name);
+        Assert.assertEquals(MembershipSourceType.NAMESPACE, namespace);
+        Assert.assertEquals("Namespace", namespace.name);
+        final MembershipSourceType project = MembershipSourceType.forValue(MembershipSourceType.PROJECT.name);
+        Assert.assertEquals(MembershipSourceType.PROJECT, project);
+        Assert.assertEquals("Project", project.name);
+    }
+}


### PR DESCRIPTION
* User Memberships could not be used due to the MembershipSourceType always being null in the Membership, because Gitlab returns "Namespace" and "Project" rather than "NAMESPACE" and "PROJECT". The fix is to introduce a name field on the enum to have a place to store that string and make it available to users and to uppercase the string before trying to parse it as an enum name.

* Fixed the UserApi.getMemberships() method so it returns all the memberships and added a Pager based method too for lazy fetching.

* Added the KeysApi needed to look up users by ssh key fingerprint.