### PR TITLE
Add top_level_only parameter to GroupFilter

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -20,6 +20,7 @@ public class GroupFilter {
     private Boolean withCustomAttributes;
     private Boolean owned;
     private AccessLevel accessLevel;
+    private Boolean topLevelOnly;
 
     /**
      * Do not include the provided groups IDs.
@@ -29,7 +30,7 @@ public class GroupFilter {
      */
     public GroupFilter withSkipGroups(List<Integer> skipGroups) {
         this.skipGroups = skipGroups;
-        return (this);  
+        return (this);
     }
 
     /**
@@ -41,7 +42,7 @@ public class GroupFilter {
      */
     public GroupFilter withAllAvailabley(Boolean allAvailable) {
         this.allAvailable = allAvailable;
-        return (this);       
+        return (this);
     }
 
     /**
@@ -90,7 +91,7 @@ public class GroupFilter {
 
     /**
      *  Include custom attributes in response (admins only).
-     * 
+     *
      * @param withCustomAttributes if true, include custom attributes in the response
      * @return the reference to this GroupFilter instance
      */
@@ -122,6 +123,17 @@ public class GroupFilter {
     }
 
     /**
+     * Limit by groups which are top level groups
+     *
+     * @param topLevelOnly if true, limit to groups which are top level groups
+     * @return the reference to this GroupFilter instance
+     */
+    public GroupFilter withTopLevelOnly(Boolean topLevelOnly) {
+        this.topLevelOnly = topLevelOnly;
+        return (this);
+    }
+
+    /**
      * Get the query params specified by this filter.
      *
      * @return a GitLabApiForm instance holding the query parameters for this GroupFilter instance
@@ -135,8 +147,9 @@ public class GroupFilter {
             .withParam("sort", sort)
             .withParam("statistics", statistics)
             .withParam("with_custom_attributes", withCustomAttributes)
-            .withParam("owned", owned)  
+            .withParam("owned", owned)
             .withParam("min_access_level", accessLevel)
+            .withParam("top_level_only", topLevelOnly)
         );
     }
 }


### PR DESCRIPTION
Hi,

as described in https://docs.gitlab.com/ee/api/groups.html there is a parameter filter for only top level groups. I added the parameter to the GroupFilter