### PR TITLE
Fix #800 Increase max Artifact size from Integer to Long

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Artifact.java
+++ b/src/main/java/org/gitlab4j/api/models/Artifact.java
@@ -30,7 +30,7 @@ public class Artifact {
     }
 
     private FileType fileType;
-    private Integer size;
+    private Long size;
     private String filename;
     private String fileFormat;
 
@@ -42,11 +42,11 @@ public class Artifact {
         this.fileType = fileType;
     }
 
-    public Integer getSize() {
+    public Long getSize() {
         return size;
     }
 
-    public void setSize(Integer size) {
+    public void setSize(Long size) {
         this.size = size;
     }
 

--- a/src/test/resources/org/gitlab4j/api/job.json
+++ b/src/test/resources/org/gitlab4j/api/job.json
@@ -15,6 +15,7 @@
     },
     "artifacts": [
       {"file_type": "archive", "size": 1000, "filename": "artifacts.zip", "file_format": "zip"},
+      {"file_type": "archive", "size": 9223372036854775807 , "filename": "long.max_value.sized.zip", "file_format": "zip"},
       {"file_type": "metadata", "size": 186, "filename": "metadata.gz", "file_format": "gzip"},
       {"file_type": "trace", "size": 1500, "filename": "job.log", "file_format": "raw"},
       {"file_type": "junit", "size": 750, "filename": "junit.xml.gz", "file_format": "gzip"}


### PR DESCRIPTION
As the title says -  `Integer` is too small for big files. Avoid deserialization crash by widening `Artifact`'s `size` to `Long`.

Also edits the example test json to include a testcase.