### PR TITLE
Fix gitlab4j#805 Increase CommitStatus id from Integer to Long

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/CommitStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStatus.java
@@ -13,7 +13,7 @@ public class CommitStatus {
     private Date createdAt;
     private String description;
     private Date finishedAt;
-    private Integer id;
+    private Long id;
     private String name;
     private String ref;
     private String sha;
@@ -69,11 +69,11 @@ public class CommitStatus {
         this.finishedAt = finishedAt;
     }
 
-    public Integer getId() {
+    public Long getId() {
         return id;
     }
 
-    public void setId(Integer id) {
+    public void setId(Long id) {
         this.id = id;
     }
 

--- a/src/test/resources/org/gitlab4j/api/commit-status.json
+++ b/src/test/resources/org/gitlab4j/api/commit-status.json
@@ -16,6 +16,6 @@
     "sha" : "18f3e63d05582537db6d183d9d557be09e1f90c8",
     "target_url" : "https://gitlab.example.com/thedude/gitlab-ce/builds/91",
     "finished_at" :  "2016-01-19T08:40:25.934Z",
-    "id" : 91,
+    "id" : 2148826854,
     "ref" : "master"
  }


### PR DESCRIPTION
Should be a straightforward fix. 
As the title says, bumping the CommitStatus id to Long fixed our issue on Jenkins builds.