### PR TITLE
Fixed de-serialization of MembershipSourceType by letting the Jackson…

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/MembershipSourceType.java
+++ b/src/main/java/org/gitlab4j/api/models/MembershipSourceType.java
@@ -12,7 +12,7 @@ public enum MembershipSourceType {
     /** Representing a group */
     NAMESPACE;
 
-    private static JacksonJsonEnumHelper<MembershipSourceType> enumHelper = new JacksonJsonEnumHelper<>(MembershipSourceType.class);
+    private static JacksonJsonEnumHelper<MembershipSourceType> enumHelper = new JacksonJsonEnumHelper<>(MembershipSourceType.class, true);
 
     @JsonCreator
     public static MembershipSourceType forValue(String value) {

--- a/src/test/java/org/gitlab4j/api/models/MembershipSourceTypeTest.java
+++ b/src/test/java/org/gitlab4j/api/models/MembershipSourceTypeTest.java
@@ -1,0 +1,21 @@
+package org.gitlab4j.api.models;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static org.junit.Assert.*;
+
+public class MembershipSourceTypeTest {
+
+    @Test
+    public void forValue() {
+        final MembershipSourceType namespace = MembershipSourceType.forValue("Namespace");
+        Assert.assertEquals(MembershipSourceType.NAMESPACE, namespace);
+        Assert.assertEquals("Namespace", namespace.toValue());
+        Assert.assertEquals("Namespace", namespace.toString());
+        final MembershipSourceType project = MembershipSourceType.forValue("Project");
+        Assert.assertEquals(MembershipSourceType.PROJECT, project);
+        Assert.assertEquals("Project", project.toValue());
+        Assert.assertEquals("Project", project.toString());
+    }
+}


### PR DESCRIPTION
…JsonEnumHelper know that the first letter should be capitalized