### PR TITLE
Adding getContributors sort by asc / desc support

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -311,6 +311,29 @@ public interface Constants {
         }
     }
 
+    /** Enum to use for ordering the results of getContibutors(). */
+    public enum ContributorOrderBy {
+
+        NAME, EMAIL, COMMITS;
+
+        private static JacksonJsonEnumHelper<ContributorOrderBy> enumHelper = new JacksonJsonEnumHelper<>(ContributorOrderBy.class);
+
+        @JsonCreator
+        public static ContributorOrderBy forValue(String value) {
+            return enumHelper.forValue(value);
+        }
+
+        @JsonValue
+        public String toValue() {
+            return (enumHelper.toString(this));
+        }
+
+        @Override
+        public String toString() {
+            return (enumHelper.toString(this));
+        }
+    }
+
     /** Enum to use for specifying the scope when calling getPipelines(). */
     public enum PipelineScope {
 

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -664,6 +664,33 @@ public class RepositoryApi extends AbstractApi {
     }
 
     /**
+     * Get a list of contributors from a project and in the specified page range, sorted by specified param.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param page the page to get
+     * @param perPage the number of projects per page
+     * @param sort optional param to sort the list of contributors by
+     * @return a List containing the contributors for the specified project ID
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Contributor> getContributors(Object projectIdOrPath, int page, int perPage, String sort) throws GitLabApiException {
+        if (sort != null && !(sort.equals("asc") || sort.equals("desc")) ) {
+            throw new RuntimeException("Sort must be asc or desc");
+        }
+
+        GitLabApiForm formData = new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
+        if (sort != null) {
+            formData.withParam("sort", sort, false);
+        }
+
+        Response response = get(Response.Status.OK, formData.asMap(),
+            "projects", getProjectIdOrPath(projectIdOrPath), "repository", "contributors");
+        return (response.readEntity(new GenericType<List<Contributor>>() { }));
+    }
+
+    /**
      * Get a Pager of contributors from a project.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -671,18 +671,19 @@ public class RepositoryApi extends AbstractApi {
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param page the page to get
      * @param perPage the number of projects per page
-     * @param sort optional param to sort the list of contributors by
+     * @param orderBy (optional param) returns contributors ordered by NAME, EMAIL, or COMMITS. Default is COMMITS
+     * @param sortOrder (optional param) returns contributors sorted in ASC or DESC order. Default is ASC
      * @return a List containing the contributors for the specified project ID
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Contributor> getContributors(Object projectIdOrPath, int page, int perPage, String sort) throws GitLabApiException {
-        if (sort != null && !(sort.equals("asc") || sort.equals("desc")) ) {
-            throw new RuntimeException("Sort must be asc or desc");
+    public List<Contributor> getContributors(Object projectIdOrPath, int page, int perPage, ContributorOrderBy orderBy, SortOrder sortOrder) throws GitLabApiException {
+        GitLabApiForm formData = new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
+        if (sortOrder != null) {
+            formData.withParam("sort", sortOrder, false);
         }
 
-        GitLabApiForm formData = new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
-        if (sort != null) {
-            formData.withParam("sort", sort, false);
+        if (orderBy != null) {
+            formData.withParam("order_by", orderBy, false);
         }
 
         Response response = get(Response.Status.OK, formData.asMap(),


### PR DESCRIPTION
Hey guys!
I made a simple addition to the `RepositoryApi`.

I wasn't able to find contribution guidelines for this repo, but I'd be happy to make any requested changes. 

Change Log
- New `getContributors` API, to sort by `desc` or `asc`.

Documentation for this API: https://docs.gitlab.com/ee/api/repositories.html#contributors



