### PR TITLE
Fix NullPointer on invalid settings

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Setting.java
+++ b/src/main/java/org/gitlab4j/api/models/Setting.java
@@ -1199,9 +1199,14 @@ public enum Setting {
             return;
         }
 
-        StringBuilder shouldBe = new StringBuilder(types[0].getSimpleName());
-        for (int i = 1; i < types.length; i++) {
-            shouldBe.append(" | ").append(types[i].getSimpleName());
+        StringBuilder shouldBe;
+        if (type != null) {
+            shouldBe = new StringBuilder(type.getSimpleName());
+        } else {
+            shouldBe = new StringBuilder(types[0].getSimpleName());
+            for (int i = 1; i < types.length; i++) {
+                shouldBe.append(" | ").append(types[i].getSimpleName());
+            }
         }
 
         String errorMsg = String.format("'%s' value is of incorrect type, is %s, should be %s",


### PR DESCRIPTION
Settings having only a single Type caused a NullPointer when
printing the allowed types.

Improves #818