### PR TITLE
Migrate totalSize on RegistryRepositoryTag to support fat images

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
+++ b/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
@@ -12,7 +12,7 @@ public class RegistryRepositoryTag {
     private String shortRevision;
     private String digest;
     private Date createdAt;
-    private Integer totalSize;
+    private Long totalSize;
 
     public String getName() {
         return name;
@@ -70,11 +70,11 @@ public class RegistryRepositoryTag {
         this.createdAt = createdAt;
     }
 
-    public Integer getTotalSize() {
+    public Long getTotalSize() {
         return totalSize;
     }
 
-    public void setTotalSize(Integer totalSize) {
+    public void setTotalSize(Long totalSize) {
         this.totalSize = totalSize;
     }
 


### PR DESCRIPTION
Issue #743 has been opened about this issue.

In this short PR I propose a quick solution to solve it.

It allows a RepositoryTag to be deserialised correctly by Jackson even though a "fat" (>~2GB) docker image is fetched.
