### PR TITLE
Add SIMILARITY to GroupOrderBy enum

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -248,7 +248,7 @@ public interface Constants {
     /** Enum to use for ordering the results of getGroups() and getSubGroups(). */
     public enum GroupOrderBy {
 
-        NAME, PATH, ID;
+        NAME, PATH, ID, SIMILARITY;
         private static JacksonJsonEnumHelper<GroupOrderBy> enumHelper = new JacksonJsonEnumHelper<>(GroupOrderBy.class);
 
         @JsonCreator


### PR DESCRIPTION
`GET /groups?order_by=similarity` is supported but not available in the
high level API
https://gitlab.com/gitlab-org/gitlab/-/issues/332889