### PR TITLE
Add test for Pager.page

### DIFF
--- a/src/test/java/org/gitlab4j/api/TestEpicDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestEpicDiscussionsApi.java
@@ -1,13 +1,13 @@
 package org.gitlab4j.api;
 
 import static org.gitlab4j.api.JsonUtils.compareJson;
-import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
 import java.util.List;
+import java.util.NoSuchElementException;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
@@ -64,5 +64,16 @@ public class TestEpicDiscussionsApi implements Constants {
         assertNotNull(stream);
         List<Discussion> discussions = stream.collect(Collectors.toList());
         assertTrue(compareJson(discussions, "epic-discussions.json"));
+    }
+
+    @Test
+    public void testPage() throws Exception {
+        try {
+            Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussionsPager(1L, 1L, 20);
+            discussions.page(-1555957071);
+            fail("testPage should have thrown NoSuchElementException");
+        } catch (NoSuchElementException expected) {
+            assertNull(expected.getMessage());
+        }
     }
 }


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `java.util.NoSuchElementException` is thrown when `page` is called with the parameter `pageNumber = -1555957071`.
This tests the method [`Pager.page`](https://github.com/gitlab4j/gitlab4j-api/blob/075ce397bd03ae35acbffdcd4c5cbfaa5cb7075b/src/main/java/org/gitlab4j/api/Pager.java#L307).
This test is based on the test [`testGetEpicDiscussionsByPager`](https://github.com/gitlab4j/gitlab4j-api/blob/075ce397bd03ae35acbffdcd4c5cbfaa5cb7075b/src/test/java/org/gitlab4j/api/TestEpicDiscussionsApi.java#L55).

Curious to hear what you think!

Also, is the description I provided of the test is helping you to answer to this pull request? Why (not)?

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))