### PR TITLE
Add method to update code_owner_approval_required flag to Protected Branches API

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,6 +26,9 @@ local.properties
 .classpath
 .settings/
 .loadpath
+
+### Visual Studio Code ###
+.vscode
  
 # External tool builders
 .externalToolBuilders/
@@ -45,7 +48,7 @@ target/
 
 # Test properties file for gitlab4j
 test-gitlab4j.properties
-!src/test/resoures/test-gitlab4j.properties
+!src/test/resources/test-gitlab4j.properties
 
 # git-changelog plugin #
 .okhttpcache

--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -273,6 +273,42 @@ public abstract class AbstractApi implements Constants {
     }
 
     /**
+     * Perform an HTTP PATCH call with the specified query parameters and path objects, returning
+     * a ClientResponse instance with the data returned from the endpoint.
+     *
+     * @param expectedStatus the HTTP status that should be returned from the server
+     * @param queryParams multivalue map of request parameters
+     * @param pathArgs variable list of arguments used to build the URI
+     * @return a ClientResponse instance with the data returned from the endpoint
+     * @throws GitLabApiException if any exception occurs during execution
+     */
+    protected Response patch(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
+        try {
+            return validate(getApiClient().patch(queryParams, pathArgs), expectedStatus);
+        } catch (Exception e) {
+            throw handle(e);
+        }
+    }
+
+    /**
+     * Perform an HTTP PATCH call with the specified query parameters and URL, returning
+     * a ClientResponse instance with the data returned from the endpoint.
+     *
+     * @param expectedStatus the HTTP status that should be returned from the server
+     * @param queryParams multivalue map of request parameters
+     * @param url the fully formed path to the GitLab API endpoint
+     * @return a ClientResponse instance with the data returned from the endpoint
+     * @throws GitLabApiException if any exception occurs during execution
+     */
+    protected Response patch(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, URL url) throws GitLabApiException {
+        try {
+            return validate(getApiClient().patch(queryParams, url), expectedStatus);
+        } catch (Exception e) {
+            throw handle(e);
+        }
+    }
+
+    /**
      * Perform an HTTP POST call with the specified form data and path objects, returning
      * a ClientResponse instance with the data returned from the endpoint.
      *

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -471,6 +471,35 @@ public class GitLabApiClient implements AutoCloseable {
     }
 
     /**
+     * Perform an HTTP PATCH call with the specified query parameters and path objects, returning
+     * a ClientResponse instance with the data returned from the endpoint.
+     *
+     * @param queryParams multivalue map of request parameters
+     * @param pathArgs variable list of arguments used to build the URI
+     * @return a ClientResponse instance with the data returned from the endpoint
+     * @throws IOException if an error occurs while constructing the URL
+     */
+    protected Response patch(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
+        URL url = getApiUrl(pathArgs);
+        return (patch(queryParams, url));
+    }
+
+    /**
+     * Perform an HTTP PATCH call with the specified query parameters and URL, returning
+     * a ClientResponse instance with the data returned from the endpoint.
+     *
+     * @param queryParams multivalue map of request parameters
+     * @param url the fully formed path to the GitLab API endpoint
+     * @return a ClientResponse instance with the data returned from the endpoint
+     */
+    protected Response patch(MultivaluedMap<String, String> queryParams, URL url) {
+        Entity<?> empty = Entity.text("");
+        // use "X-HTTP-Method-Override" header on POST to override to unsupported PATCH
+        return (invocation(url, queryParams)
+            .header("X-HTTP-Method-Override", "PATCH").post(empty));
+    }
+
+    /**
      * Perform an HTTP POST call with the specified form data and path objects, returning
      * a ClientResponse instance with the data returned from the endpoint.
      *

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -287,8 +287,8 @@ public class GitLabApiClient implements AutoCloseable {
      * @param readTimeout the per request read timeout in milliseconds, can be null to use default
      */
     void setRequestTimeout(Integer connectTimeout, Integer readTimeout) {
-	this.connectTimeout = connectTimeout;
-	this.readTimeout = readTimeout;
+        this.connectTimeout = connectTimeout;
+        this.readTimeout = readTimeout;
     }
 
     /**
@@ -496,7 +496,7 @@ public class GitLabApiClient implements AutoCloseable {
         Entity<?> empty = Entity.text("");
         // use "X-HTTP-Method-Override" header on POST to override to unsupported PATCH
         return (invocation(url, queryParams)
-            .header("X-HTTP-Method-Override", "PATCH").post(empty));
+                .header("X-HTTP-Method-Override", "PATCH").post(empty));
     }
 
     /**
@@ -947,7 +947,7 @@ public class GitLabApiClient implements AutoCloseable {
         // Ignore differences between given hostname and certificate hostname
         HostnameVerifier hostnameVerifier = new HostnameVerifier() {
             @Override
-			public boolean verify(String hostname, SSLSession session) {
+            public boolean verify(String hostname, SSLSession session) {
                 return true;
             }
         };

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -233,4 +233,27 @@ public class ProtectedBranchesApi extends AbstractApi {
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
     }
+
+    /**
+     * Sets the code_owner_approval_required flag on the specified protected branch.
+     *
+     * <p>NOTE: This method is only available in GitLab Premium or higher.</p>
+     *
+     * <pre><code>GitLab Endpoint: PATCH /projects/:id/protected_branches/:branch_name?code_owner_approval_required=true</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param branchName the name of the branch to protect, can be a wildcard
+     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @return the branch info for the protected branch
+     * @throws GitLabApiException if any exception occurs
+     */
+    public ProtectedBranch setCodeOwnerApprovalRequired(Object projectIdOrPath, String branchName,
+	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            Form formData = new GitLabApiForm()
+                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+
+        Response response = patch(Response.Status.OK, formData.asMap(),
+            "projects", this.getProjectIdOrPath(projectIdOrPath), "protected_branches", urlEncode(branchName));
+        return (response.readEntity(ProtectedBranch.class));
+    }
 }

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -187,7 +187,7 @@ public class ProtectedBranchesApi extends AbstractApi {
 	    Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
 	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
 
-	Form formData = new GitLabApiForm()
+        Form formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
                 .withParam("allowed_to_push[][user_id]", allowedToPushUserId)
                 .withParam("allowed_to_merge[][user_id]", allowedToMergeUserId)
@@ -222,14 +222,14 @@ public class ProtectedBranchesApi extends AbstractApi {
                 .withParam("name", branchName, true)
                 .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
 
-	if (allowedToPush != null)
-	    allowedToPush.getForm(formData, "allowed_to_push");
-	if (allowedToMerge != null)
-	    allowedToMerge.getForm(formData, "allowed_to_merge");
-	if (allowedToUnprotect != null)
-	    allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
+        if (allowedToPush != null)
+            allowedToPush.getForm(formData, "allowed_to_push");
+        if (allowedToMerge != null)
+            allowedToMerge.getForm(formData, "allowed_to_merge");
+        if (allowedToUnprotect != null)
+            allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
 
-	Response response = post(Response.Status.CREATED, formData.asMap(),
+        Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
     }
@@ -249,11 +249,12 @@ public class ProtectedBranchesApi extends AbstractApi {
      */
     public ProtectedBranch setCodeOwnerApprovalRequired(Object projectIdOrPath, String branchName,
 	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
-            Form formData = new GitLabApiForm()
+        Form formData = new GitLabApiForm()
                 .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
 
         Response response = patch(Response.Status.OK, formData.asMap(),
-            "projects", this.getProjectIdOrPath(projectIdOrPath), "protected_branches", urlEncode(branchName));
+                "projects", this.getProjectIdOrPath(projectIdOrPath),
+                "protected_branches", urlEncode(branchName));
         return (response.readEntity(ProtectedBranch.class));
     }
 }

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -243,7 +243,7 @@ public class ProtectedBranchesApi extends AbstractApi {
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param branchName the name of the branch to protect, can be a wildcard
-     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file.
      * @return the branch info for the protected branch
      * @throws GitLabApiException if any exception occurs
      */

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -154,8 +154,8 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-	    AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
-	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
         Form formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
                 .withParam("push_access_level", pushAccessLevel)
@@ -184,8 +184,8 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-	    Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
-	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
 
         Form formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
@@ -215,8 +215,8 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-	    AllowedTo allowedToPush, AllowedTo allowedToMerge, AllowedTo allowedToUnprotect,
-	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            AllowedTo allowedToPush, AllowedTo allowedToMerge, AllowedTo allowedToUnprotect,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
@@ -248,7 +248,7 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch setCodeOwnerApprovalRequired(Object projectIdOrPath, String branchName,
-	    Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
         Form formData = new GitLabApiForm()
                 .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
 

--- a/src/test/java/org/gitlab4j/api/TestProtectedBranchesApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProtectedBranchesApi.java
@@ -47,7 +47,7 @@ public class TestProtectedBranchesApi extends AbstractIntegrationTest {
 
     @BeforeAll
     public static void setup() {
-	// Must setup the connection to the GitLab test server and get the test Project instance
+        // Must setup the connection to the GitLab test server and get the test Project instance
         gitLabApi = baseTestSetup();
         testProject = getTestProject();
     }
@@ -139,8 +139,7 @@ public class TestProtectedBranchesApi extends AbstractIntegrationTest {
 
         // current version returns 404, but will return branch with "code_owner_approval_required = true" with newer Premium
         GitLabApiException gae = assertThrowsExactly(GitLabApiException.class,
-            () -> gitLabApi.getProtectedBranchesApi().setCodeOwnerApprovalRequired(testProject, TEST_BRANCH_NAME, true)
-        );
+                () -> gitLabApi.getProtectedBranchesApi().setCodeOwnerApprovalRequired(testProject, TEST_BRANCH_NAME, true));
         assertTrue(gae.getHttpStatus() == 404);
     }
 }

--- a/src/test/java/org/gitlab4j/api/TestProtectedBranchesApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProtectedBranchesApi.java
@@ -1,7 +1,9 @@
 package org.gitlab4j.api;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrowsExactly;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
@@ -123,5 +125,22 @@ public class TestProtectedBranchesApi extends AbstractIntegrationTest {
         assertNotNull(branches);
         assertTrue(branches.stream()
                 .anyMatch((protectedBranch) -> protectedBranch.getName().equals(TEST_BRANCH_NAME)));
+    }
+
+    @Test
+    public void testSetCodeOwnerApprovalRequired() throws GitLabApiException {
+
+        assumeTrue(testProject != null);
+
+        ProtectedBranch branch = gitLabApi.getProtectedBranchesApi().getProtectedBranch(testProject, TEST_BRANCH_NAME);
+        assertNotNull(branch);
+        // current version returns null, but will return boolean (false) with newer Premium
+        assertFalse(branch.getCodeOwnerApprovalRequired() != null);
+
+        // current version returns 404, but will return branch with "code_owner_approval_required = true" with newer Premium
+        GitLabApiException gae = assertThrowsExactly(GitLabApiException.class,
+            () -> gitLabApi.getProtectedBranchesApi().setCodeOwnerApprovalRequired(testProject, TEST_BRANCH_NAME, true)
+        );
+        assertTrue(gae.getHttpStatus() == 404);
     }
 }


### PR DESCRIPTION
Adds basic support for updating the `code_owner_approval_required` flag on an existing protected branch. See the [GitLab API docs](https://docs.gitlab.com/ee/api/protected_branches.html#require-code-owner-approvals-for-a-single-branch) for intended usage.

Two notes for feedback:
1. The HTTP "PATCH" method isn't supported in the current client so this uses the `X-HTTP-Method-Override: PATCH` header as a workaround. This wires it thru AbstractApi to GitLabApiClient where it's turned into a POST with the override header. Anyone recommend another way?
2. Removed the integration test as it's a Premium or higher feature so can't be tested on the Community Edition image. (EDIT: Added this test back with handling for current version.)

Fixes #869