### PR TITLE
Remove unnesesary runtime charset search

### DIFF
--- a/src/main/java/org/gitlab4j/api/utils/UrlEncoder.java
+++ b/src/main/java/org/gitlab4j/api/utils/UrlEncoder.java
@@ -1,8 +1,7 @@
 package org.gitlab4j.api.utils;
 
 import java.net.URLEncoder;
-
-import org.gitlab4j.api.GitLabApiException;
+import java.nio.charset.StandardCharsets;
 
 public class UrlEncoder {
 
@@ -11,21 +10,16 @@ public class UrlEncoder {
      *
      * @param s the String to URL encode
      * @return the URL encoded strings
-     * @throws GitLabApiException if any exception occurs
      */
-    public static String urlEncode(String s) throws GitLabApiException {
-
-        try {
-            String encoded = URLEncoder.encode(s, "UTF-8");
-            // Since the encode method encodes plus signs as %2B,
-            // we can simply replace the encoded spaces with the correct encoding here 
-            encoded = encoded.replace("+", "%20");
-            encoded = encoded.replace(".", "%2E");
-            encoded = encoded.replace("-", "%2D");
-            encoded = encoded.replace("_", "%5F");
-            return (encoded);
-        } catch (Exception e) {
-            throw new GitLabApiException(e);
-        }
+    public static String urlEncode(String s) {
+  
+        String encoded = URLEncoder.encode(s, StandardCharsets.UTF_8);
+        // Since the encode method encodes plus signs as %2B,
+        // we can simply replace the encoded spaces with the correct encoding here 
+        encoded = encoded.replace("+", "%20");
+        encoded = encoded.replace(".", "%2E");
+        encoded = encoded.replace("-", "%2D");
+        encoded = encoded.replace("_", "%5F");
+        return (encoded);
     }
 }


### PR DESCRIPTION
Use StandardCharsets.UTF_8 (in java, since java 1.7), instead of "UTF-8" string. This removes necessity to throw a checked exception.