### PR TITLE
Add support for name in badges

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -1573,26 +1573,23 @@ public class GroupApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public List<Badge> getBadges(Object groupIdOrPath) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "badges");
-	return (response.readEntity(new GenericType<List<Badge>>() {}));
+    return getBadges(groupIdOrPath, null);
     }
 
     /**
-     * Gets a list of a group’s badges, case insensitively filtered on name.
+     * Gets a list of a group’s badges, case-sensitively filtered on bagdeName if non-null.
      *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges</code></pre>
+     * <pre><code>GitLab Endpoint: GET /groups/:id/badges?name=:name</code></pre>
      *
      * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param name The name to filter on
+     * @param badgeName The name to filter on (case-sensitive), ignored if null.
      * @return All badges of the GitLab item, case insensitively filtered on name.
      * @throws GitLabApiException If any problem is encountered
      */
-    public List<Badge> getBadges(Object groupIdOrPath, String name) throws GitLabApiException {
-    List<Badge> result = getBadges(groupIdOrPath);
-    if (name != null && name.length()>0) {
-        return result.stream().filter(b -> b.getName().equalsIgnoreCase(name)).collect(Collectors.toList());
-    }
-    return (result);
+    public List<Badge> getBadges(Object groupIdOrPath, String badgeName) throws GitLabApiException {
+    Form queryParam = new GitLabApiForm().withParam("name", badgeName);
+    Response response = get(Response.Status.OK, queryParam.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "badges");
+    return (response.readEntity(new GenericType<List<Badge>>() {}));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -5,6 +5,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
 import javax.ws.rs.core.Form;
@@ -1577,6 +1578,24 @@ public class GroupApi extends AbstractApi {
     }
 
     /**
+     * Gets a list of a group’s badges, case insensitively filtered on name.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/badges</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
+     * @param name The name to filter on
+     * @return All badges of the GitLab item, case insensitively filtered on name.
+     * @throws GitLabApiException If any problem is encountered
+     */
+    public List<Badge> getBadges(Object groupIdOrPath, String name) throws GitLabApiException {
+    List<Badge> result = getBadges(groupIdOrPath);
+    if (name != null && name.length()>0) {
+        return result.stream().filter(b -> b.getName().equalsIgnoreCase(name)).collect(Collectors.toList());
+    }
+    return (result);
+    }
+
+    /**
      * Gets a badge of a group.
      *
      * <pre><code>GitLab Endpoint: GET /groups/:id/badges/:badge_id</code></pre>
@@ -1620,11 +1639,28 @@ public class GroupApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Badge addBadge(Object groupIdOrPath, String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, true)
-		.withParam("image_url", imageUrl, true);
-	Response response = post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges");
-	return (response.readEntity(Badge.class));
+    return addBadge(groupIdOrPath, null, linkUrl, imageUrl);
+    }
+
+    /**
+     * Add a badge to a group.
+     *
+     * <pre><code>GitLab Endpoint: POST /groups/:id/badges</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
+     * @param name The name to give the badge (may be null)
+     * @param linkUrl the URL of the badge link
+     * @param imageUrl the URL of the image link
+     * @return A Badge instance for the added badge
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Badge addBadge(Object groupIdOrPath, String name, String linkUrl, String imageUrl) throws GitLabApiException {
+    GitLabApiForm formData = new GitLabApiForm()
+        .withParam("name", name, false)
+        .withParam("link_url", linkUrl, true)
+        .withParam("image_url", imageUrl, true);
+    Response response = post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges");
+    return (response.readEntity(Badge.class));
     }
 
     /**
@@ -1640,11 +1676,29 @@ public class GroupApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Badge editBadge(Object groupIdOrPath, Long badgeId, String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, false)
-		.withParam("image_url", imageUrl, false);
-	Response response = putWithFormData(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
-	return (response.readEntity(Badge.class));
+    return (editBadge(groupIdOrPath, badgeId, null, linkUrl, imageUrl));
+    }
+
+    /**
+     * Edit a badge of a group.
+     *
+     * <pre><code>GitLab Endpoint: PUT /groups/:id/badges</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
+     * @param badgeId the ID of the badge to edit
+     * @param name The name of the badge to edit (may be null)
+     * @param linkUrl the URL of the badge link
+     * @param imageUrl the URL of the image link
+     * @return a Badge instance for the edited badge
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Badge editBadge(Object groupIdOrPath, Long badgeId, String name, String linkUrl, String imageUrl) throws GitLabApiException {
+    GitLabApiForm formData = new GitLabApiForm()
+        .withParam("name", name, false)
+        .withParam("link_url", linkUrl, false)
+        .withParam("image_url", imageUrl, false);
+    Response response = putWithFormData(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
+    return (response.readEntity(Badge.class));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -32,7 +32,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
@@ -3311,26 +3310,23 @@ public class ProjectApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs
      */
     public List<Badge> getBadges(Object projectIdOrPath) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "badges");
-	return (response.readEntity(new GenericType<List<Badge>>() {}));
+	return getBadges(projectIdOrPath, null);
     }
 
     /**
-     * Gets a list of a project’s badges and its group badges, case insensitively filtered on name.
+     * Gets a list of a project’s badges and its group badges, case-sensitively filtered on bagdeName if non-null.
      *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges</code></pre>
+     * <pre><code>GitLab Endpoint: GET /projects/:id/badges?name=:name</code></pre>
      *
      * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
-     * @param name The name to filter on
+     * @param bagdeName The name to filter on (case-sensitive), ignored if null.
      * @return All badges of the GitLab item, case insensitively filtered on name.
      * @throws GitLabApiException If any problem is encountered
      */
-    public List<Badge> getBadges(Object projectIdOrPath, String name) throws GitLabApiException {
-    List<Badge> result = getBadges(projectIdOrPath);
-    if (name != null && name.length()>0) {
-        return result.stream().filter(b -> b.getName().equalsIgnoreCase(name)).collect(Collectors.toList());
-    }
-    return (result);
+    public List<Badge> getBadges(Object projectIdOrPath, String bagdeName) throws GitLabApiException {
+    Form queryParam = new GitLabApiForm().withParam("name", bagdeName);
+    Response response = get(Response.Status.OK, queryParam.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "badges");
+    return (response.readEntity(new GenericType<List<Badge>>() {}));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
@@ -3315,6 +3316,25 @@ public class ProjectApi extends AbstractApi implements Constants {
     }
 
     /**
+     * Gets a list of a project’s badges and its group badges, case insensitively filtered on name.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/badges</code></pre>
+     *
+     * Gets the badges associated with a given project, filtering on name and <b>ignoring case</b>
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param name The name to filter on
+     * @return All badges of the GitLab item
+     * @throws GitLabApiException If any problem is encountered
+     */
+    public List<Badge> getBadges(Object projectIdOrPath, String name) throws GitLabApiException {
+    List<Badge> result = getBadges(projectIdOrPath);
+    if (name != null && name.length()>0) {
+        return result.stream().filter(b -> b.getName().equalsIgnoreCase(name)).collect(Collectors.toList());
+    }
+    return (result);
+    }
+
+    /**
      * Gets a badge of a project.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/badges/:badge_id</code></pre>
@@ -3358,11 +3378,28 @@ public class ProjectApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs
      */
     public Badge addBadge(Object projectIdOrPath, String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, true)
-		.withParam("image_url", imageUrl, true);
-	Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges");
-	return (response.readEntity(Badge.class));
+    return addBadge(projectIdOrPath, null, linkUrl, imageUrl);
+    }
+
+    /**
+     * Add a badge to a project.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/badges</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
+     * @param name The name to give the badge (may be null)
+     * @param linkUrl the URL of the badge link
+     * @param imageUrl the URL of the image link
+     * @return A Badge instance for the added badge
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Badge addBadge(Object projectIdOrPath, String name, String linkUrl, String imageUrl) throws GitLabApiException {
+    GitLabApiForm formData = new GitLabApiForm()
+        .withParam("name", name, false)
+        .withParam("link_url", linkUrl, true)
+        .withParam("image_url", imageUrl, true);
+    Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges");
+    return (response.readEntity(Badge.class));
     }
 
     /**
@@ -3378,11 +3415,29 @@ public class ProjectApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs
      */
     public Badge editBadge(Object projectIdOrPath, Long badgeId, String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, false)
-		.withParam("image_url", imageUrl, false);
-	Response response = putWithFormData(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges", badgeId);
-	return (response.readEntity(Badge.class));
+	return (editBadge(projectIdOrPath, badgeId, null, linkUrl, imageUrl));
+    }
+
+    /**
+     * Edit a badge of a project.
+     *
+     * <pre><code>GitLab Endpoint: PUT /projects/:id/badges</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
+     * @param badgeId the ID of the badge to edit
+     * @param name The name of the badge to edit (may be null)
+     * @param linkUrl the URL of the badge link
+     * @param imageUrl the URL of the image link
+     * @return a Badge instance for the editted badge
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Badge editBadge(Object projectIdOrPath, Long badgeId, String name, String linkUrl, String imageUrl) throws GitLabApiException {
+        GitLabApiForm formData = new GitLabApiForm()
+            .withParam("name", name, false)
+            .withParam("link_url", linkUrl, false)
+            .withParam("image_url", imageUrl, false);
+        Response response = putWithFormData(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges", badgeId);
+        return (response.readEntity(Badge.class));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -3320,10 +3320,9 @@ public class ProjectApi extends AbstractApi implements Constants {
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/badges</code></pre>
      *
-     * Gets the badges associated with a given project, filtering on name and <b>ignoring case</b>
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
      * @param name The name to filter on
-     * @return All badges of the GitLab item
+     * @return All badges of the GitLab item, case insensitively filtered on name.
      * @throws GitLabApiException If any problem is encountered
      */
     public List<Badge> getBadges(Object projectIdOrPath, String name) throws GitLabApiException {

--- a/src/test/resources/org/gitlab4j/api/badges.json
+++ b/src/test/resources/org/gitlab4j/api/badges.json
@@ -1,6 +1,7 @@
 [
   {
     "id": 1,
+    "name": "Badge 1",
     "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
     "image_url": "https://shields.io/my/badge",
     "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",
@@ -9,6 +10,7 @@
   },
   {
     "id": 2,
+    "name": "Badge 2",
     "link_url": "http://example.com/ci_status.svg?project=%{project_path}&ref=%{default_branch}",
     "image_url": "https://shields.io/my/badge",
     "rendered_link_url": "http://example.com/ci_status.svg?project=example-org/example-project&ref=master",


### PR DESCRIPTION
For a recent project I wanted to be able to set badge names and find them again based on that name, as this was simply more convenient than UUID.

To facilitate this, I have added a few methods to `ProjectAPI` and `GroupAPI` and ensured the interface remains backwards compatible.