### PR TITLE
Add id to ProtectedBranch and BranchAccessLevel

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
+++ b/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
@@ -4,10 +4,19 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class BranchAccessLevel {
 
+    private Long id;
     private AccessLevel accessLevel;
     private String accessLevelDescription;
     private Long userId;
     private Long groupId;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public AccessLevel getAccessLevel() {
         return this.accessLevel;

--- a/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
+++ b/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
@@ -7,11 +7,20 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class ProtectedBranch {
 
+    private Long id;
     private String name;
     private List<BranchAccessLevel> pushAccessLevels;
     private List<BranchAccessLevel> mergeAccessLevels;
     private List<BranchAccessLevel> unprotectAccessLevels;
     private Boolean codeOwnerApprovalRequired;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
 
     public String getName() {
         return this.name;

--- a/src/test/resources/org/gitlab4j/api/protected-branch.json
+++ b/src/test/resources/org/gitlab4j/api/protected-branch.json
@@ -1,7 +1,9 @@
 {
+  "id": 457,
   "name": "develop",
   "push_access_levels": [
     {
+      "id": 123,
       "access_level": 40,
       "access_level_description": "Masters"
     },
@@ -11,6 +13,7 @@
   ],
   "merge_access_levels": [
     {
+      "id": 789,
       "access_level": 40,
       "access_level_description": "Masters"
     },


### PR DESCRIPTION
The protect repository branches API returns `id` attributes in the JSON. See:
https://docs.gitlab.com/ee/api/protected_branches.html#list-protected-branches