### PR TITLE
Add getDescendantGroups() methods to GroupApi

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -351,6 +351,50 @@ public class GroupApi extends AbstractApi {
     }
 
     /**
+     * Get a list of visible descendant groups of a given group for the authenticated user using the provided filter.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
+     * @param filter the GroupFilter to match against
+     * @return a List&lt;Group&gt; of the matching groups
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Group> getDescendantGroups(Object groupIdOrPath, GroupFilter filter) throws GitLabApiException {
+        return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).all());
+    }
+
+    /**
+     * Get a Pager of visible descendant groups of a given group for the authenticated user using the provided filter.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
+     * @param filter the GroupFilter to match against
+     * @param itemsPerPage the number of Group instances that will be fetched per page
+     * @return a Pager containing matching Group instances
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Group> getDescendantGroups(Object groupIdOrPath, GroupFilter filter, int itemsPerPage) throws GitLabApiException {
+        GitLabApiForm formData = filter.getQueryParams();
+        return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "descendant_groups"));
+    }
+
+    /**
+     * Get a Stream of visible descendant groups of a given group for the authenticated user using the provided filter.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+     *
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
+     * @param filter the GroupFilter to match against
+     * @return a Stream&lt;Group&gt; of the matching groups
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Stream<Group> getDescendantGroupsStream(Object groupIdOrPath, GroupFilter filter) throws GitLabApiException {
+        return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).stream());
+    }
+
+    /**
      * Get a list of projects belonging to the specified group ID and filter.
      *
      * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>

--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -7,7 +7,7 @@ import org.gitlab4j.api.Constants.SortOrder;
 import org.gitlab4j.api.GitLabApiForm;
 
 /**
- *  This class is used to filter Projects when getting lists of projects for a specified group.
+ *  This class is used to filter Groups when getting lists of groups.
  */
 public class GroupFilter {
 


### PR DESCRIPTION
Add the methods for this endpoint:

```http
GET /groups/:id/descendant_groups
```

Docs: https://docs.gitlab.com/ee/api/groups.html#list-a-groups-descendant-groups

---

This is similar to `getSubGroups()` but it returns all child groups in the tree (subgroups of subgroups recursively) as list.

I do not see the point of having all the methods with the different parameters as it was implemented for `getSubGroups()`, since using a `GroupFilter` with the builder pattern is better to add only the desired parameters to the request.