### PR TITLE
GroupFilter: fix typo in method name

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -45,7 +45,7 @@ public class GroupFilter {
      * Show all the groups you have access to (defaults to false for authenticated users, true for admin).
      * Attributes owned and min_access_level have precedence
      *
-     * @param allAvailable if true show all avauilable groups
+     * @param allAvailable if true show all available groups
      * @return the reference to this GroupFilter instance
      */
     public GroupFilter withAllAvailable(Boolean allAvailable) {

--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -34,13 +34,21 @@ public class GroupFilter {
     }
 
     /**
+     * @deprecated this method contains a typo, use {@link #withAllAvailable(Boolean)} instead
+     */
+    @Deprecated
+    public GroupFilter withAllAvailabley(Boolean allAvailable) {
+        return withAllAvailable(allAvailable);
+    }
+
+    /**
      * Show all the groups you have access to (defaults to false for authenticated users, true for admin).
      * Attributes owned and min_access_level have precedence
      *
      * @param allAvailable if true show all avauilable groups
      * @return the reference to this GroupFilter instance
      */
-    public GroupFilter withAllAvailabley(Boolean allAvailable) {
+    public GroupFilter withAllAvailable(Boolean allAvailable) {
         this.allAvailable = allAvailable;
         return (this);
     }


### PR DESCRIPTION
The method `withAllAvailabley(Boolean)` should be named `withAllAvailable(Boolean)`

This PR is fixing the typo in a backward compatible way.