### PR TITLE
feat: add method for "run a scheduled pipeline immediately"

### DIFF
--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -546,6 +546,11 @@ public class PipelineApi extends AbstractApi implements Constants {
         return (response.readEntity(PipelineSchedule.class));
     }
 
+    public void playPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
+
+        post(Response.Status.CREATED, "", "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
+    }
+
     /**
      * Create a pipeline schedule variable.
      *

--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -5,6 +5,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
+import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 

--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -556,7 +556,7 @@ public class PipelineApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs during execution
      */
     public void playPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-        post(Response.Status.CREATED, "", "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
+        post(Response.Status.CREATED, (Form)null, "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -546,9 +546,17 @@ public class PipelineApi extends AbstractApi implements Constants {
         return (response.readEntity(PipelineSchedule.class));
     }
 
+    /**
+     * Trigger a new scheduled pipeline, which runs immediately.
+     *
+     * <pre><code>POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/play</code></pre>
+     *
+     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
+     * @param pipelineScheduleId the pipelineSchedule instance id which should run immediately
+     * @throws GitLabApiException if any exception occurs during execution
+     */
     public void playPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-
-        post(Response.Status.CREATED, "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
+        post(Response.Status.CREATED, "", "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -548,7 +548,7 @@ public class PipelineApi extends AbstractApi implements Constants {
 
     public void playPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
 
-        post(Response.Status.CREATED, "", "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
+        post(Response.Status.CREATED, "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
     }
 
     /**

--- a/src/test/java/org/gitlab4j/api/TestPipelineApi.java
+++ b/src/test/java/org/gitlab4j/api/TestPipelineApi.java
@@ -147,6 +147,26 @@ public class TestPipelineApi extends AbstractIntegrationTest {
     }
 
     @Test
+    void testPlayScheduledPipeline() throws GitLabApiException {
+        assertNotNull(testProject);
+
+        String scheduleDescription = SCHEDULE_DESCRIPTION + " - test playScheduledPipeline()";
+        PipelineSchedule newPipelineSchedule = new PipelineSchedule();
+        newPipelineSchedule.setDescription(scheduleDescription);
+        newPipelineSchedule.setCron("3 4 * * *");
+        newPipelineSchedule.setRef("master");
+        PipelineSchedule createdPipelineSchedule = gitLabApi.getPipelineApi().createPipelineSchedule(testProject, newPipelineSchedule);
+        assertNotNull(createdPipelineSchedule);
+
+        // Make sure the created schedule is present before playing
+        List<PipelineSchedule> pipelineSchedules = gitLabApi.getPipelineApi().getPipelineSchedules(testProject);
+        assertNotNull(pipelineSchedules);
+        assertTrue(pipelineSchedules.stream().map(PipelineSchedule::getDescription).collect(toList()).contains(scheduleDescription));
+
+        gitLabApi.getPipelineApi().playPipelineSchedule(testProject, createdPipelineSchedule.getId());
+    }
+
+    @Test
     public void testDeleteProjectPipeLineSchedule() throws GitLabApiException {
 
         assertNotNull(testProject);


### PR DESCRIPTION
Resolves #906

Adding an method to call this endpoint:
https://docs.gitlab.com/ee/api/pipeline_schedules.html#run-a-scheduled-pipeline-immediately