### PR TITLE
Added `queued_duration` for Pipelines and Jobs

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -29,6 +29,7 @@ public class Job {
     private Boolean manual;
     private Boolean allowFailure;
     private Float duration;
+    private Float queuedDuration;
     private Project project;
 
     public Long getId() {
@@ -206,11 +207,19 @@ public class Job {
     public void setDuration(Float duration) {
         this.duration = duration;
     }
-    
+
+    public Float getQueuedDuration() {
+        return queuedDuration;
+    }
+
+    public void setQueuedDuration(Float queuedDuration) {
+        this.queuedDuration = queuedDuration;
+    }
+
     public Project getProject() {
         return project;
     }
-    
+
     public void setProject(Project project) {
         this.project = project;
     }
@@ -304,12 +313,17 @@ public class Job {
         this.allowFailure = allowFailure;
         return this;
     }
-    
+
     public Job withDuration(Float duration) {
         this.duration = duration;
         return this;
     }
-    
+
+    public Job withQueuedDuration(Float queuedDuration) {
+        this.queuedDuration = queuedDuration;
+        return this;
+    }
+
     public Job withProject(Project project) {
         this.project = project;
         return this;

--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -219,7 +219,6 @@ public class Job {
     public Project getProject() {
         return project;
     }
-
     public void setProject(Project project) {
         this.project = project;
     }
@@ -313,7 +312,6 @@ public class Job {
         this.allowFailure = allowFailure;
         return this;
     }
-
     public Job withDuration(Float duration) {
         this.duration = duration;
         return this;

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -226,6 +226,14 @@ public class Pipeline {
         this.duration = duration;
     }
 
+    public Float getQueuedDuration() {
+        return queuedDuration;
+    }
+
+    public void setQueuedDuration(Float queuedDuration) {
+        this.queuedDuration = queuedDuration;
+    }
+
     public String getWebUrl() {
         return webUrl;
     }

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -22,6 +22,7 @@ public class Pipeline {
     private Date committedAt;
     private String coverage;
     private Integer duration;
+    private Float queuedDuration;
     private String webUrl;
     private DetailedStatus detailedStatus;
 

--- a/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
@@ -81,6 +81,7 @@ public class PipelineEvent extends AbstractEvent {
         private Date createdAt;
         private Date finishedAt;
         private Integer duration;
+        private Float queuedDuration;
         private List<Variable> variables;
 
         public Long getId() {
@@ -169,6 +170,14 @@ public class PipelineEvent extends AbstractEvent {
 
         public void setDuration(Integer duration) {
             this.duration = duration;
+        }
+
+        public Float getQueuedDuration() {
+            return queuedDuration;
+        }
+
+        public void setQueuedDuration(Float queuedDuration) {
+            this.queuedDuration = queuedDuration;
         }
 
         public List<Variable> getVariables() {

--- a/src/test/resources/org/gitlab4j/api/job.json
+++ b/src/test/resources/org/gitlab4j/api/job.json
@@ -38,6 +38,7 @@
     "web_url": "https://example.com/foo/bar/-/jobs/7",
     "allow_failure": false,
     "duration": 0.465,
+    "queued_duration": 0.010,
     "user": {
       "avatar_url": "http://www.gravatar.com/avatar/e64c7d89f26bd1972efa854d13d7dd61?s=80&d=identicon",
       "created_at": "2015-12-21T13:14:24.077Z",

--- a/src/test/resources/org/gitlab4j/api/pipeline-event.json
+++ b/src/test/resources/org/gitlab4j/api/pipeline-event.json
@@ -16,6 +16,7 @@
       "created_at": "2016-08-12T15:23:28Z",
       "finished_at": "2016-08-12T15:26:29Z",
       "duration": 63,
+      "queued_duration": 0.010,
       "variables": [
         {
           "key": "NESTOR_PROD_ENVIRONMENT",

--- a/src/test/resources/org/gitlab4j/api/pipeline.json
+++ b/src/test/resources/org/gitlab4j/api/pipeline.json
@@ -18,6 +18,7 @@
   "updated_at": "2016-08-11T11:32:35.169Z",
   "finished_at": "2016-08-11T11:32:35.145Z",
   "coverage": "30.0",
+  "queued_duration": 0.010,
   "detailed_status": {
      "icon": "status_pending",
      "text": "pending",


### PR DESCRIPTION
`queued_duration` is a valid field for [Jobs](https://docs.gitlab.com/ee/api/jobs.html) and  [Piplines](https://docs.gitlab.com/ee/api/pipelines.html).