### PR TITLE
Adding groupid to be able to get merge requests by groupId

### DIFF
--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -85,20 +85,22 @@ public class MergeRequestApi extends AbstractApi {
      *
      * @param filter a MergeRequestFilter instance with the filter settings
      * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return all merge requests for the specified project matching the filter
+     * @return all merge requests for the specified project/group matching the filter
      * @throws GitLabApiException if any exception occurs
      */
     public Pager<MergeRequest> getMergeRequests(MergeRequestFilter filter, int itemsPerPage) throws GitLabApiException {
 
         MultivaluedMap<String, String> queryParams = (filter != null ? filter.getQueryParams().asMap() : null);
-        if (filter != null && (filter.getProjectId() != null && filter.getProjectId().intValue() > 0) ||
-                (filter.getIids() != null && filter.getIids().size() > 0)) {
+        if (filter != null && ((filter.getProjectId() != null && filter.getProjectId().intValue() > 0) ||
+                (filter.getIids() != null && filter.getIids().size() > 0))) {
 
             if (filter.getProjectId() == null || filter.getProjectId().intValue() == 0) {
                 throw new RuntimeException("project ID cannot be null or 0");
             }
 
             return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "projects", filter.getProjectId(), "merge_requests"));
+        } else if (filter != null && filter.getGroupId() != null && filter.getGroupId().intValue() > 0) {
+            return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "groups", filter.getGroupId(), "merge_requests"));
         } else {
             return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "merge_requests"));
         }

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 public class MergeRequestFilter {
 
     private Long projectId;
+    private Long groupId;
     private List<Long> iids;
     private MergeRequestState state;
     private MergeRequestOrderBy orderBy;
@@ -313,6 +314,19 @@ public class MergeRequestFilter {
 
     public void setWip(Boolean wip) {
         this.wip = wip;
+    }
+
+    public Long getGroupId() {
+        return groupId;
+    }
+
+    public void setGroupId(Long groupId) {
+        this.groupId = groupId;
+    }
+
+    public MergeRequestFilter withGroupId(Long groupId) {
+        this.groupId = groupId;
+        return (this);
     }
 
     public MergeRequestFilter withWip(Boolean wip) {


### PR DESCRIPTION
Need: I needed all merge requests under one group. Here is the [documentation](https://docs.gitlab.com/ee/api/merge_requests.html#list-group-merge-requests)

MergeRequestApi is configured using projectIdOrPath for getting merge requests. 
* I've added group id in MergeRequestFilter to be able to decide which path we are going to use.(project id / group id).
* I also added paranthesis on filter variable to be able to preventing null pointer exception on existing code.

Example Usage:


`MergeRequestFilter mergeRequestFilter = new MergeRequestFilter();`
`mergeRequestFilter.setGroupId(id);`
`return gitLabApi.getMergeRequestApi().getMergeRequests(mergeRequestFilter);`
