### PR TITLE
Add missing object attributes in merge request events

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/EventMergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/webhook/EventMergeRequest.java
@@ -19,6 +19,7 @@ public class EventMergeRequest {
     private Long iid;
     private String mergeCommitSha;
     private String mergeStatus;
+    private String detailedMergeStatus;
     private Long milestoneId;
     private Integer position;
     private Date lockedAt;
@@ -36,8 +37,11 @@ public class EventMergeRequest {
     private EventProject source;
     private EventProject target;
     private EventCommit lastCommit;
+    private Boolean blockingDiscussionsResolved;
     private Boolean workInProgress;
+    private Boolean firstContribution;
     private String url;
+    private List<EventLabel> labels;
     private String action;
     private Assignee assignee;
 
@@ -132,6 +136,14 @@ public class EventMergeRequest {
 
     public void setMergeStatus(String mergeStatus) {
         this.mergeStatus = mergeStatus;
+    }
+
+    public String getDetailedMergeStatus() {
+        return detailedMergeStatus;
+    }
+
+    public void setDetailedMergeStatus(String detailedMergeStatus) {
+        this.detailedMergeStatus = detailedMergeStatus;
     }
 
     public Long getMilestoneId() {
@@ -262,6 +274,14 @@ public class EventMergeRequest {
         this.lastCommit = lastCommit;
     }
 
+    public Boolean getBlockingDiscussionsResolved() {
+        return blockingDiscussionsResolved;
+    }
+
+    public void setBlockingDiscussionsResolved(Boolean blockingDiscussionsResolved) {
+        this.blockingDiscussionsResolved = blockingDiscussionsResolved;
+    }
+
     public Boolean getWorkInProgress() {
         return workInProgress;
     }
@@ -270,12 +290,28 @@ public class EventMergeRequest {
         this.workInProgress = workInProgress;
     }
 
+    public Boolean getFirstContribution() {
+        return firstContribution;
+    }
+
+    public void setFirstContribution(Boolean firstContribution) {
+        this.firstContribution = firstContribution;
+    }
+
     public String getUrl() {
         return url;
     }
 
     public void setUrl(String url) {
         this.url = url;
+    }
+
+    public List<EventLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<EventLabel> labels) {
+        this.labels = labels;
     }
 
     public String getAction() {

--- a/src/test/resources/org/gitlab4j/api/merge-request-event.json
+++ b/src/test/resources/org/gitlab4j/api/merge-request-event.json
@@ -47,8 +47,11 @@
     "title": "MS-Viewport",
     "created_at": "2013-12-03T17:23:34Z",
     "updated_at": "2013-12-03T17:23:34Z",
+    "milestone_id": 1,
     "state": "opened",
+    "blocking_discussions_resolved": true,
     "work_in_progress": false,
+    "first_contribution": true,
     "merge_status": "unchecked",
     "target_project_id": 14,
     "description": "",
@@ -95,7 +98,22 @@
         "email": "gitlabdev@dv6700.(none)"
       }
     },
-    "action": "open"
+    "labels": [
+      {
+        "id": 206,
+        "title": "API",
+        "color": "#ffffff",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "API related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }
+    ],
+    "action": "open",
+    "detailed_merge_status": "mergeable"
   },
   "labels": [
     {


### PR DESCRIPTION
As discussed in https://github.com/gitlab4j/gitlab4j-api/pull/916#issuecomment-1495654880, since @mifitous updated the JSON example of merge request webhook event (that I partially reverted to make the test pass), it makes sense to add the additional missing attributes on the MR Event object.