### PR TITLE
Improved IssuesApi 

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -111,14 +111,14 @@ public interface Constants {
     /** Enum to use for ordering the results of getIssues(). */
     public enum IssueOrderBy {
 
-        CREATED_AT, UPDATED_AT;
+        CREATED_AT, DUE_DATE, LABEL_PRIORITY, MILESTONE_DUE, POPULARITY, PRIORITY, RELATIVE_POSITION,relative_position, TITLE, UPDATED_AT, WEIGHT;
 
         private static JacksonJsonEnumHelper<IssueOrderBy> enumHelper = new JacksonJsonEnumHelper<>(IssueOrderBy.class);
 
         @JsonCreator
         public static IssueOrderBy forValue(String value) {
             return enumHelper.forValue(value);
-        }
+        } 
 
         @JsonValue
         public String toValue() {

--- a/src/main/java/org/gitlab4j/api/IssuesApi.java
+++ b/src/main/java/org/gitlab4j/api/IssuesApi.java
@@ -316,9 +316,30 @@ public class IssuesApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs
      */
     public List<Issue> getGroupIssues(Object groupIdOrPath, IssueFilter filter) throws GitLabApiException {
-	return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).all());
+    	return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).all());
     }
 
+    
+    /**
+     * Get a list of a group’s issues.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+     *
+     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+     * @param page the page to get.
+     * @param perPage the number of projects per page.
+     * @return a List of issues for the specified group and filter
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Issue> getGroupIssues(Object groupIdOrPath, IssueFilter filter, int page, int perPage) throws GitLabApiException {
+    	GitLabApiForm formData = filter.getQueryParams(page, perPage);
+        Response response = get(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "issues");
+        return (response.readEntity(new GenericType<List<Issue>>() {}));
+       
+    }
+
+    
     /**
      * Get a list of groups's issues.
      *

--- a/src/main/java/org/gitlab4j/api/IssuesApi.java
+++ b/src/main/java/org/gitlab4j/api/IssuesApi.java
@@ -1071,4 +1071,29 @@ public class IssuesApi extends AbstractApi implements Constants {
         	"projects", this.getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "move");
         return (response.readEntity(Issue.class));
     }
-}
+    
+    
+    /**
+     * <p>Reorders an issue, you can see the results when sorting issues manually.</p>
+     * 
+     * * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid/reorder </code></pre>
+     * 
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
+     * @param issueIid the IID of the issue to move
+     * @param moveAfterIssueId The global ID of a project’s issue that should be placed after this issue
+     * @param moveBeforeIssueId The global ID of a project’s issue that should be placed before this issue
+     * @param groupFullPath the group in the form of an Long(ID), String(path), or Group instance
+     * @throws GitLabApiException
+     */
+    public void reorder(Object projectIdOrPath, Long issueIid, Long moveBeforeIssueId, Long moveAfterIssueId, Object groupFullPath) throws GitLabApiException {
+    	GitLabApiForm formData = new GitLabApiForm()
+    			.withParam("move_before_id", moveBeforeIssueId)
+    			.withParam("move_after_id", moveAfterIssueId)
+    	        .withParam("group_full_path", getGroupIdOrPath(groupFullPath));
+    	
+    	 put(Response.Status.OK, formData.asMap(),
+    	        	"projects", this.getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "reorder");
+    	 
+
+    }
+} 


### PR DESCRIPTION
With this "Pull request" the connector gains the power to order issues and list the issues in the specified order.

Some features were implemented in this PR, namely:
* a `reorder` method was implemented to reorder issues in same project or  group
* Add Items on `IssueOrderBy` Enum, respecting the documentation on [GitLab API documentation](https://docs.gitlab.com/ee/api/issues.html#list-issues) (in my case, I need to use the **relative_position**)
* `getGroupIssues` using `page` and `items per page`

