### PR TITLE
Compatibility with Spring Boot 3.x

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,73 +4,95 @@
 [![Build Status](https://travis-ci.org/gitlab4j/gitlab4j-api.svg?branch=master)](https://travis-ci.org/gitlab4j/gitlab4j-api)
 [![javadoc.io](https://javadoc.io/badge2/org.gitlab4j/gitlab4j-api/javadoc.io.svg)](https://javadoc.io/doc/org.gitlab4j/gitlab4j-api)
 
-
-GitLab4J&trade; API (gitlab4j-api) provides a full featured and easy to consume Java library for working with GitLab repositories via the GitLab REST API.  Additionally, full support for working with GitLab webhooks and system hooks is also provided.
+GitLab4J&trade; API (gitlab4j-api) provides a full featured and easy to consume Java library for
+working with GitLab repositories via the GitLab REST API. Additionally, full support for working
+with GitLab webhooks and system hooks is also provided.
 
 ---
+
 ## Table of Contents
+
 * [GitLab Server Version Support](#gitLab-server-version-support)<br/>
 * [Using GitLab4J-API](#using-gitlab4j-api)<br/>
-  * [Java 8 Requirement](#java-8-requirement)<br/>
-  * [Javadocs](#javadocs)<br/>
-  * [Project Set Up](#project-set-up)<br/>
-  * [Usage Examples](#usage-examples)<br/>
-  * [Setting Request Timeouts](#setting-request-timeouts)<br/>
-  * [Connecting Through a Proxy Server](#connecting-through-a-proxy-server)<br/>
-  * [GitLab API V3 and V4 Support](#gitLab-api-v3-and-v4-support)<br/>
-  * [Logging of API Requests and Responses](#logging-of-api-requests-and-responses)<br/>
-  * [Results Paging](#results-paging)<br/>
-  * [Java 8 Stream Support](#java-8-stream-support)<br/>
-    * [Eager evaluation example usage](#eager-evaluation-example-usage)<br/>
-    * [Lazy evaluation example usage](#lazy%20evaluation-example-usage)<br/>
-  * [Java 8 Optional&lt;T&gt; Support](#java-8-optional-support)<br/>
-  * [Issue Time Estimates](#issue-time-estimates)<br/>
+    * [Java 11 Requirement](#java-11-requirement)<br/>
+    * [Javadocs](#javadocs)<br/>
+    * [Project Set Up](#project-set-up)<br/>
+    * [Usage Examples](#usage-examples)<br/>
+    * [Setting Request Timeouts](#setting-request-timeouts)<br/>
+    * [Connecting Through a Proxy Server](#connecting-through-a-proxy-server)<br/>
+    * [GitLab API V3 and V4 Support](#gitLab-api-v3-and-v4-support)<br/>
+    * [Logging of API Requests and Responses](#logging-of-api-requests-and-responses)<br/>
+    * [Results Paging](#results-paging)<br/>
+    * [Java 8 Stream Support](#java-8-stream-support)<br/>
+        * [Eager evaluation example usage](#eager-evaluation-example-usage)<br/>
+        * [Lazy evaluation example usage](#lazy%20evaluation-example-usage)<br/>
+    * [Java 8 Optional&lt;T&gt; Support](#java-8-optional-support)<br/>
+    * [Issue Time Estimates](#issue-time-estimates)<br/>
 * [Making API Calls](#making-api-calls)<br/>
-  * [Available Sub APIs](#available-sub-apis)
+    * [Available Sub APIs](#available-sub-apis)
 
 ---
+
 ## GitLab Server Version Support
 
-GitLab4J-API supports version 11.0+ of GitLab Community Edition [(gitlab-ce)](https://gitlab.com/gitlab-org/gitlab-ce/) and GitLab Enterprise Edition [(gitlab-ee)](https://gitlab.com/gitlab-org/gitlab-ee/). 
+GitLab4J-API supports version 11.0+ of GitLab Community
+Edition [(gitlab-ce)](https://gitlab.com/gitlab-org/gitlab-ce/) and GitLab Enterprise
+Edition [(gitlab-ee)](https://gitlab.com/gitlab-org/gitlab-ee/).
 
-GitLab released GitLab Version 11.0 in June of 2018 which included many major changes to GitLab.  If you are using GitLab server earlier than version 11.0, it is highly recommended that you either update your GitLab install or use a version of this library that was released around the same time as the version of GitLab you are using. 
+GitLab released GitLab Version 11.0 in June of 2018 which included many major changes to GitLab. If
+you are using GitLab server earlier than version 11.0, it is highly recommended that you either
+update your GitLab install or use a version of this library that was released around the same time
+as the version of GitLab you are using.
 
 **NOTICE**:  
-As of GitLab 11.0 support for the GitLab API v3 has been removed from the GitLab server (see https://about.gitlab.com/2018/06/01/api-v3-removal-impending/). Support for GitLab API v3 will be removed from this library sometime in 2019. If you are utilizing the v3 support, please update your code to use GitLab API v4.
+As of GitLab 11.0 support for the GitLab API v3 has been removed from the GitLab server (
+see https://about.gitlab.com/2018/06/01/api-v3-removal-impending/). Support for GitLab API v3 will
+be removed from this library sometime in 2019. If you are utilizing the v3 support, please update
+your code to use GitLab API v4.
 
 ---
+
 ## Using GitLab4J-API
 
-### **Java 8 Requirement**
-As of GitLab4J-API 4.8.0, Java 8+ is now required to use GitLab4J-API.
+### **Java 11 Requirement**
+
+As of GitLab4J-API 6.0.0, Java 11+ is now required to use GitLab4J-API.
 
 ### **Javadocs**
-Javadocs are available here: [![javadoc.io](https://javadoc.io/badge2/org.gitlab4j/gitlab4j-api/javadoc.io.svg)](https://javadoc.io/doc/org.gitlab4j/gitlab4j-api)
 
+Javadocs are available
+here: [![javadoc.io](https://javadoc.io/badge2/org.gitlab4j/gitlab4j-api/javadoc.io.svg)](https://javadoc.io/doc/org.gitlab4j/gitlab4j-api)
 
 ### **Project Set Up**
-To utilize GitLab4J&trade; API in your Java project, simply add the following dependency to your project's build file:<br /> 
+
+To utilize GitLab4J&trade; API in your Java project, simply add the following dependency to your
+project's build file:<br />
 **Gradle: build.gradle**
+
 ```java
-dependencies {
+dependencies{
     ...
-    compile group: 'org.gitlab4j', name: 'gitlab4j-api', version: '5.1.0'
-}
+    compile group:'org.gitlab4j',name:'gitlab4j-api',version:'6.0.0'
+    }
 ```
 
-**NOTE:** Pulling dependencies may fail when using Gradle prior to 4.5. See [Gradle issue 3065](https://github.com/gradle/gradle/issues/3065#issuecomment-364092456)
+**NOTE:** Pulling dependencies may fail when using Gradle prior to 4.5.
+See [Gradle issue 3065](https://github.com/gradle/gradle/issues/3065#issuecomment-364092456)
 
 **Maven: pom.xml**
+
 ```xml
+
 <dependency>
-    <groupId>org.gitlab4j</groupId>
-    <artifactId>gitlab4j-api</artifactId>
-    <version>5.1.0</version>
+  <groupId>org.gitlab4j</groupId>
+  <artifactId>gitlab4j-api</artifactId>
+  <version>6.0.0</version>
 </dependency>
 ```
 
 **Ivy and SBT**<br/>
-There have been reports of problems resolving some dependencies when using Ivy or SBT, for help resolving those issues see:<br/>
+There have been reports of problems resolving some dependencies when using Ivy or SBT, for help
+resolving those issues see:<br/>
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/571">JAX-RS API Issue #571</a><br/>
 <a href="https://github.com/eclipse-ee4j/jaxrs-api/issues/572">JAX-RS API Issue #572</a>
 
@@ -78,101 +100,131 @@ There have been reports of problems resolving some dependencies when using Ivy o
 
 ### **Usage Examples**
 
-GitLab4J-API is quite simple to use, all you need is the URL to your GitLab server and the Personal Access Token from your GitLab Account Settings page.  Once you have that info it is as simple as:
+GitLab4J-API is quite simple to use, all you need is the URL to your GitLab server and the Personal
+Access Token from your GitLab Account Settings page. Once you have that info it is as simple as:
+
 ```java
 // Create a GitLabApi instance to communicate with your GitLab server
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.server.com", "YOUR_PERSONAL_ACCESS_TOKEN");
+GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.server.com","YOUR_PERSONAL_ACCESS_TOKEN");
 
 // Get the list of projects your account has access to
-List<Project> projects = gitLabApi.getProjectApi().getProjects();
+    List<Project> projects=gitLabApi.getProjectApi().getProjects();
 ```
 
 You can also login to your GitLab server with username, and password:
+
 ```java
 // Log in to the GitLab server using a username and password
-GitLabApi gitLabApi = GitLabApi.oauth2Login("http://your.gitlab.server.com", "username", "password");
+GitLabApi gitLabApi=GitLabApi.oauth2Login("http://your.gitlab.server.com","username","password");
 ```
-As of GitLab4J-API 4.6.6, all API requests support performing the API call as if you were another user, provided you are authenticated as an administrator:
+
+As of GitLab4J-API 4.6.6, all API requests support performing the API call as if you were another
+user, provided you are authenticated as an administrator:
+
 ```java
 // Create a GitLabApi instance to communicate with your GitLab server (must be an administrator)
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.server.com", "YOUR_PERSONAL_ACCESS_TOKEN");
+GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.server.com","YOUR_PERSONAL_ACCESS_TOKEN");
 
 // sudo as as a different user, in this case the user named "johndoe", all future calls will be done as "johndoe"
-gitLabApi.sudo("johndoe")
+    gitLabApi.sudo("johndoe")
 
 // To turn off sudo mode
-gitLabApi.unsudo();
+    gitLabApi.unsudo();
 ```
 
 ---
+
 ### **Setting Request Timeouts**
-As of GitLab4J-API 4.14.21 support has been added for setting the conect and read timeouts for the API client:
+
+As of GitLab4J-API 4.14.21 support has been added for setting the conect and read timeouts for the
+API client:
+
 ```java
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.com", "YOUR_PERSONAL_ACCESS_TOKEN", proxyConfig);
+GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.com","YOUR_PERSONAL_ACCESS_TOKEN",proxyConfig);
 
 // Set the connect timeout to 1 second and the read timeout to 5 seconds
-gitLabApi.setRequestTimeout(1000, 5000);
+    gitLabApi.setRequestTimeout(1000,5000);
 ```
 
 ---
+
 ### **Connecting Through a Proxy Server**
-As of GitLab4J-API 4.8.2 support has been added for connecting to the GitLab server using an HTTP proxy server:
+
+As of GitLab4J-API 4.8.2 support has been added for connecting to the GitLab server using an HTTP
+proxy server:
+
 ```java
 // Log in to the GitLab server using a proxy server (with basic auth on proxy)
-Map<String, Object> proxyConfig = ProxyClientConfig.createProxyClientConfig(
-        "http://your-proxy-server", "proxy-username", "proxy-password");
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.com", "YOUR_PERSONAL_ACCESS_TOKEN", null, proxyConfig);
+Map<String, Object> proxyConfig=ProxyClientConfig.createProxyClientConfig(
+    "http://your-proxy-server","proxy-username","proxy-password");
+    GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.com","YOUR_PERSONAL_ACCESS_TOKEN",null,proxyConfig);
 
 // Log in to the GitLab server using a proxy server (no auth on proxy)
-Map<String, Object> proxyConfig = ProxyClientConfig.createProxyClientConfig("http://your-proxy-server");
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.com", "YOUR_PERSONAL_ACCESS_TOKEN", null, proxyConfig);
+    Map<String, Object> proxyConfig=ProxyClientConfig.createProxyClientConfig("http://your-proxy-server");
+    GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.com","YOUR_PERSONAL_ACCESS_TOKEN",null,proxyConfig);
 
 // Log in to the GitLab server using an NTLM (Windows DC) proxy
-Map<String, Object> ntlmProxyConfig = ProxyClientConfig.createNtlmProxyClientConfig(
-        "http://your-proxy-server", "windows-username", "windows-password", "windows-workstation", "windows-domain");
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.com", "YOUR_PERSONAL_ACCESS_TOKEN", null, ntlmProxyConfig);
+    Map<String, Object> ntlmProxyConfig=ProxyClientConfig.createNtlmProxyClientConfig(
+    "http://your-proxy-server","windows-username","windows-password","windows-workstation","windows-domain");
+    GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.com","YOUR_PERSONAL_ACCESS_TOKEN",null,ntlmProxyConfig);
 ```
-See the Javadoc on the GitLabApi class for a complete list of methods accepting the proxy configuration (clientConfiguration parameter)
+
+See the Javadoc on the GitLabApi class for a complete list of methods accepting the proxy
+configuration (clientConfiguration parameter)
 
 ---
+
 ### **GitLab API V3 and V4 Support**
-As of GitLab4J-API 4.2.0 support has been added for GitLab API V4. If your application requires GitLab API V3,
+
+As of GitLab4J-API 4.2.0 support has been added for GitLab API V4. If your application requires
+GitLab API V3,
 you can still use GitLab4J-API by creating your GitLabApi instance as follows:
+
 ```java
 // Create a GitLabApi instance to communicate with your GitLab server using GitLab API V3
-GitLabApi gitLabApi = new GitLabApi(ApiVersion.V3, "http://your.gitlab.server.com", "YOUR_PRIVATE_TOKEN");
+GitLabApi gitLabApi=new GitLabApi(ApiVersion.V3,"http://your.gitlab.server.com","YOUR_PRIVATE_TOKEN");
 ```
 
 **NOTICE**:  
-As of GitLab 11.0 support for the GitLab API v3 has been removed from the GitLab server (see https://about.gitlab.com/2018/06/01/api-v3-removal-impending/). Support for GitLab API v3 will be removed from this library sometime in 2019. If you are utilizing the v3 support, please update your code to use GitLab API v4.
+As of GitLab 11.0 support for the GitLab API v3 has been removed from the GitLab server (
+see https://about.gitlab.com/2018/06/01/api-v3-removal-impending/). Support for GitLab API v3 will
+be removed from this library sometime in 2019. If you are utilizing the v3 support, please update
+your code to use GitLab API v4.
 
 ---
+
 ### **Logging of API Requests and Responses**
+
 As of GitLab4J-API 4.8.39 support has been added to log the requests to and the responses from the
-GitLab API.  Enable logging using one of the following methods on the GitLabApi instance:
+GitLab API. Enable logging using one of the following methods on the GitLabApi instance:
+
 ```java
-GitLabApi gitLabApi = new GitLabApi("http://your.gitlab.server.com", "YOUR_PERSONAL_ACCESS_TOKEN");
+GitLabApi gitLabApi=new GitLabApi("http://your.gitlab.server.com","YOUR_PERSONAL_ACCESS_TOKEN");
 
 // Log using the shared logger and default level of FINE
-gitLabApi.enableRequestResponseLogging();
+    gitLabApi.enableRequestResponseLogging();
 
 // Log using the shared logger and the INFO level
-gitLabApi.enableRequestResponseLogging(java.util.logging.Level.INFO);
+    gitLabApi.enableRequestResponseLogging(java.util.logging.Level.INFO);
 
 // Log using the specified logger and the INFO level
-gitLabApi.enableRequestResponseLogging(yourLoggerInstance, java.util.logging.Level.INFO);
+    gitLabApi.enableRequestResponseLogging(yourLoggerInstance,java.util.logging.Level.INFO);
 
 // Log using the shared logger, at the INFO level, and include up to 1024 bytes of entity logging
-gitLabApi.enableRequestResponseLogging(java.util.logging.Level.INFO, 1024);
+    gitLabApi.enableRequestResponseLogging(java.util.logging.Level.INFO,1024);
 
 // Log using the specified logger, at the INFO level, and up to 1024 bytes of entity logging
-gitLabApi.enableRequestResponseLogging(yourLoggerInstance, java.util.logging.Level.INFO, 1024);
+    gitLabApi.enableRequestResponseLogging(yourLoggerInstance,java.util.logging.Level.INFO,1024);
 ```
 
 ---
+
 ### **Results Paging**
-GitLab4J-API provides an easy to use paging mechanism to page through lists of results from the GitLab API.
+
+GitLab4J-API provides an easy to use paging mechanism to page through lists of results from the
+GitLab API.
 Here are a couple of examples on how to use the Pager:
+
 ```java
 // Get a Pager instance that will page through the projects with 10 projects per page
 Pager<Project> projectPager = gitLabApi.getProjectApi().getProjects(10);
@@ -182,39 +234,48 @@ while (projectPager.hasNext()) {
     for (Project project : projectPager.next()) {
         System.out.println(project.getName() + " -: " + project.getDescription());
     }
-}
+    }
 ```
 
 As of GitLab4J-API 4.9.2, you can also fetch all the items as a single list using a Pager instance:
+
 ```java
 // Get a Pager instance so we can load all the projects into a single list, 10 items at a time:
-Pager<Project> projectPager = gitlabApi.getProjectsApi().getProjects(10);
-List<Project> allProjects = projectPager.all();
+Pager<Project> projectPager=gitlabApi.getProjectsApi().getProjects(10);
+    List<Project> allProjects=projectPager.all();
 ```
 
 ---
+
 ### **Java 8 Stream Support**
-As of GitLab4J-API 4.9.2, all GitLabJ-API methods that return a List result have a similarlly named method that returns a Java 8 Stream.  The Stream returning methods use the following naming convention:  ```getXxxxxStream()```.
-  
+
+As of GitLab4J-API 4.9.2, all GitLabJ-API methods that return a List result have a similarlly named
+method that returns a Java 8 Stream. The Stream returning methods use the following naming
+convention:  ```getXxxxxStream()```.
 
 **IMPORTANT**  
-The built-in methods that return a Stream do so using ___eager evaluation___, meaning all items are pre-fetched from the GitLab server and a Stream is returned which will stream those items.  **Eager evaluation does NOT support parallel reading of data from ther server, it does however allow for parallel processing of the Stream post data fetch.**
+The built-in methods that return a Stream do so using ___eager evaluation___, meaning all items are
+pre-fetched from the GitLab server and a Stream is returned which will stream those items.  **Eager
+evaluation does NOT support parallel reading of data from ther server, it does however allow for
+parallel processing of the Stream post data fetch.**
 
-To stream using ___lazy evaluation___, use the GitLab4J-API methods that return a ```Pager``` instance, and then call the ```lazyStream()``` method on the ```Pager``` instance to create a lazy evaluation Stream. The Stream utilizes the ```Pager``` instance to page through the available items. **A lazy Stream does NOT support parallel operations or skipping.** 
-
+To stream using ___lazy evaluation___, use the GitLab4J-API methods that return a ```Pager```
+instance, and then call the ```lazyStream()``` method on the ```Pager``` instance to create a lazy
+evaluation Stream. The Stream utilizes the ```Pager``` instance to page through the available items.
+**A lazy Stream does NOT support parallel operations or skipping.**
 
 #### **Eager evaluation example usage:**
 
 ```java
 // Stream the visible projects printing out the project name.
-Stream<Project> projectStream = gitlabApi.getProjectApi().getProjectsStream();
-projectStream.map(Project::getName).forEach(name -> System.out.println(name));
+Stream<Project> projectStream=gitlabApi.getProjectApi().getProjectsStream();
+    projectStream.map(Project::getName).forEach(name->System.out.println(name));
 
 // Operate on the stream in parallel, this example sorts User instances by username
 // NOTE: Fetching of the users is not done in parallel,
 // only the sorting of the users is a parallel operation.
-Stream<User> stream = gitlabApi.getUserApi().getUsersStream();
-List<User> users = stream.parallel().sorted(comparing(User::getUsername)).collect(toList());
+    Stream<User> stream=gitlabApi.getUserApi().getUsersStream();
+    List<User> users=stream.parallel().sorted(comparing(User::getUsername)).collect(toList());
 ```
 
 #### **Lazy evaluation example usage:**
@@ -222,26 +283,31 @@ List<User> users = stream.parallel().sorted(comparing(User::getUsername)).collec
 ```java
 // Get a Pager instance to that will be used to lazily stream Project instances.
 // In this example, 10 Projects per page will be pre-fetched.
-Pager<Project> projectPager = gitlabApi.getProjectApi().getProjects(10);
+Pager<Project> projectPager=gitlabApi.getProjectApi().getProjects(10);
 
 // Lazily stream the Projects, printing out each project name, limit the output to 5 project names
-projectPager.lazyStream().limit(5).map(Project::getName).forEach(name -> System.out.println(name));
+    projectPager.lazyStream().limit(5).map(Project::getName).forEach(name->System.out.println(name));
 ```
 
-
 ---
+
 ### **Java 8 Optional Support**
-GitLab4J-API supports Java 8 Optional&lt;T&gt; for API calls that result in the return of a single item. Here is an example on how to use the Java 8 Optional&lt;T&gt; API calls:
+
+GitLab4J-API supports Java 8 Optional&lt;T&gt; for API calls that result in the return of a single
+item. Here is an example on how to use the Java 8 Optional&lt;T&gt; API calls:
+
 ```java
-Optional<Group> optionalGroup =  gitlabApi.getGroupApi().getOptionalGroup("my-group-path");
-if (optionalGroup.isPresent())
+Optional<Group> optionalGroup=gitlabApi.getGroupApi().getOptionalGroup("my-group-path");
+    if(optionalGroup.isPresent())
     return optionalGroup.get();
 
-return gitlabApi.getGroupApi().addGroup("my-group-name", "my-group-path");
+    return gitlabApi.getGroupApi().addGroup("my-group-name","my-group-path");
 ```
 
 ---
+
 ### **Issue Time Estimates**
+
 GitLab issues allow for time tracking. The following time units are currently available:
 
 * months (mo)
@@ -250,11 +316,16 @@ GitLab issues allow for time tracking. The following time units are currently av
 * hours (h)
 * minutes (m)
 
-Conversion rates are 1mo = 4w, 1w = 5d and 1d = 8h. 
+Conversion rates are 1mo = 4w, 1w = 5d and 1d = 8h.
 
 ---
+
 ## Making API Calls
-The API has been broken up into sub API classes to make it easier to consume and to separate concerns. The GitLab4J sub API classes typically have a one-to-one relationship with the API documentation at [GitLab API](https://docs.gitlab.com/ce/api/). Following is a sample of the GitLab4J sub API class mapping to the GitLab API documentation:
+
+The API has been broken up into sub API classes to make it easier to consume and to separate
+concerns. The GitLab4J sub API classes typically have a one-to-one relationship with the API
+documentation at [GitLab API](https://docs.gitlab.com/ce/api/). Following is a sample of the
+GitLab4J sub API class mapping to the GitLab API documentation:
 
 ```org.gitlab4j.api.GroupApi``` -> https://docs.gitlab.com/ce/api/groups.html<br/>
 ```org.gitlab4j.api.MergeRequestApi``` -> https://docs.gitlab.com/ce/api/merge_requests.html<br/>
@@ -263,7 +334,9 @@ The API has been broken up into sub API classes to make it easier to consume and
 
 ### **Available Sub APIs**
 
-The following is a list of the available sub APIs along with a sample use of each API. See the <a href="https://javadoc.io/doc/org.gitlab4j/gitlab4j-api" target="_top">Javadocs</a> for a complete list of available methods for each sub API.
+The following is a list of the available sub APIs along with a sample use of each API. See
+the <a href="https://javadoc.io/doc/org.gitlab4j/gitlab4j-api" target="_top">Javadocs</a> for a
+complete list of available methods for each sub API.
 
 ---
 &nbsp;&nbsp;[ApplicationsApi](#applicationsapi)<br/>
@@ -314,189 +387,219 @@ The following is a list of the available sub APIs along with a sample use of eac
 
 ### Sub API Examples
 ----------------
+
 #### ApplicationsApi
+
 ```java
 // Add an OAUTH Application to GitLab
-ApplicationScope[] scopes = {ApplicationScope.SUDO, ApplicationScope.PROFILE};
-gitLabApi.getApplicationsApi().createApplication("My OAUTH Application", "https//example.com/myapp/callback", scopes);
+ApplicationScope[]scopes={ApplicationScope.SUDO,ApplicationScope.PROFILE};
+    gitLabApi.getApplicationsApi().createApplication("My OAUTH Application","https//example.com/myapp/callback",scopes);
 ```
 
 #### ApplicationSettingsApi
+
 ```java
 // Get the current GitLab server application settings
-ApplicationSettings appSettings = gitLabApi.getApplicationSettingsApi().getAppliationSettings();
+ApplicationSettings appSettings=gitLabApi.getApplicationSettingsApi().getAppliationSettings();
 ```
 
 #### AuditEventApi
+
 ```java
 // Get the current GitLab server audit events for entity
 // This uses the ISO8601 date utilities the in org.gitlab4j.api.utils.ISO8601 class
-Date since = ISO8601.toDate("2017-01-01T00:00:00Z");
-Date until = new Date(); // now
-List<AuditEvent> auditEvents = gitLabApi.getAuditEventApi().getAuditEvents(since, until, EntityType.USER, 1);
+Date since=ISO8601.toDate("2017-01-01T00:00:00Z");
+    Date until=new Date(); // now
+    List<AuditEvent> auditEvents=gitLabApi.getAuditEventApi().getAuditEvents(since,until,EntityType.USER,1);
 ```
 
 #### AwardEmojiApi
+
 ```java
 // Get a list of AwardEmoji belonging to the specified issue (group ID = 1, issues IID = 1)
-List<AwardEmoji> awardEmojis = gitLabApi.getAwardEmojiApi().getIssuAwardEmojis(1, 1);
+List<AwardEmoji> awardEmojis=gitLabApi.getAwardEmojiApi().getIssuAwardEmojis(1,1);
 ```
 
 #### BoardsApi
+
 ```java
 // Get a list of the Issue Boards belonging to the specified project
-List<Board> boards = gitLabApi.getBoardsApi().getBoards(projectId);
+List<Board> boards=gitLabApi.getBoardsApi().getBoards(projectId);
 ```
 
 #### CommitsApi
+
 ```java
 // Get a list of commits associated with the specified branch that fall within the specified time window
 // This uses the ISO8601 date utilities the in org.gitlab4j.api.utils.ISO8601 class
-Date since = ISO8601.toDate("2017-01-01T00:00:00Z");
-Date until = new Date(); // now
-List<Commit> commits = gitLabApi.getCommitsApi().getCommits(1234, "new-feature", since, until);
+Date since=ISO8601.toDate("2017-01-01T00:00:00Z");
+    Date until=new Date(); // now
+    List<Commit> commits=gitLabApi.getCommitsApi().getCommits(1234,"new-feature",since,until);
 ```
 
 #### ContainerRegistryApi
+
 ```java
 // Get a list of the registry repositories belonging to the specified project
-List<RegistryRepository> registryRepos = gitLabApi.ContainerRegistryApi().getRepositories(projectId);
+List<RegistryRepository> registryRepos=gitLabApi.ContainerRegistryApi().getRepositories(projectId);
 ```
 
 #### DeployKeysApi
+
 ```java
 // Get a list of DeployKeys for the authenticated user
-List<DeployKey> deployKeys = gitLabApi.getDeployKeysApi().getDeployKeys();
+List<DeployKey> deployKeys=gitLabApi.getDeployKeysApi().getDeployKeys();
 ```
 
 #### DiscussionsApi
+
 ```java
 // Get a list of Discussions for the specified merge request
-List<Discussion> discussions = gitLabApi.getDiscussionsApi().getMergeRequestDiscussions(projectId, mergeRequestIid);
+List<Discussion> discussions=gitLabApi.getDiscussionsApi().getMergeRequestDiscussions(projectId,mergeRequestIid);
 ```
 
 #### EnvironmentsApi
+
 ```java
 // Get a list of Environments for the specified project
-List<Environment> environments = gitLabApi.getEnvironmentsApi().getEnvironments(projectId);
+List<Environment> environments=gitLabApi.getEnvironmentsApi().getEnvironments(projectId);
 ```
 
 #### EpicsApi
+
 ```java
 // Get a list epics of the requested group and its subgroups.
-List<Epic> epics = gitLabApi.getEpicsApi().getEpics(1);
+List<Epic> epics=gitLabApi.getEpicsApi().getEpics(1);
 ```
 
 #### EventsApi
+
 ```java
 // Get a list of Events for the authenticated user
-Date after = new Date(0); // After Epoch
-Date before = new Date(); // Before now
-List<Event> events = gitLabApi.getEventsApi().getAuthenticatedUserEvents(null, null, before, after, DESC);
+Date after=new Date(0); // After Epoch
+    Date before=new Date(); // Before now
+    List<Event> events=gitLabApi.getEventsApi().getAuthenticatedUserEvents(null,null,before,after,DESC);
 ```
 
 #### GroupApi
+
 ```java
 // Get a list of groups that you have access to
-List<Group> groups = gitLabApi.getGroupApi().getGroups();
+List<Group> groups=gitLabApi.getGroupApi().getGroups();
 ```
 
 #### HealthCheckApi
+
 ```java
 // Get the liveness endpoint health check results. Assumes ip_whitelisted per:
 // https://docs.gitlab.com/ee/administration/monitoring/ip_whitelist.html
-HealthCheckInfo healthCheck = gitLabApi.getHealthCheckApi().getLiveness();
+HealthCheckInfo healthCheck=gitLabApi.getHealthCheckApi().getLiveness();
 ```
 
 #### ImportExportApi
+
 ```java
 // Schedule a project export for the specified project ID
 gitLabApi.getImportExportApi().scheduleExport(projectId);
 
 // Get the project export status for the specified project ID
-ExportStatus exportStatus = gitLabApi.getImportExportApi().getExportStatus(projectId);
+    ExportStatus exportStatus=gitLabApi.getImportExportApi().getExportStatus(projectId);
 ```
 
 #### IssuesApi
+
 ```java
 // Get a list of issues for the specified project ID
-List<Issue> issues = gitLabApi.getIssuesApi().getIssues(1234);
+List<Issue> issues=gitLabApi.getIssuesApi().getIssues(1234);
 ```
 
 #### JobApi
+
 ```java
 // Get a list of jobs for the specified project ID
-List<Job> jobs = gitLabApi.getJobApi().getJobs(1234);
+List<Job> jobs=gitLabApi.getJobApi().getJobs(1234);
 ```
 
 #### LabelsApi
+
 ```java
 // Get a list of labels for the specified project ID
-List<Label> labels = gitLabApi.getLabelsApi().getLabels(1234);
+List<Label> labels=gitLabApi.getLabelsApi().getLabels(1234);
 ```
 
 #### LicenseApi
+
 ```java
 // Retrieve information about the current license
-License license = gitLabApi.getLicenseApi().getLicense();
+License license=gitLabApi.getLicenseApi().getLicense();
 ```
 
 #### LicenseTemplatesApi
+
 ```java
 // Get a list of open sourcse license templates
-List<LicenseTemplate> licenses = gitLabApi.getLicenseTemplatesApi().getLicenseTemplates();
+List<LicenseTemplate> licenses=gitLabApi.getLicenseTemplatesApi().getLicenseTemplates();
 ```
 
 #### MergeRequestApi
+
 ```java
 // Get a list of the merge requests for the specified project
-List<MergeRequest> mergeRequests = gitLabApi.getMergeRequestApi().getMergeRequests(1234);
+List<MergeRequest> mergeRequests=gitLabApi.getMergeRequestApi().getMergeRequests(1234);
 ```
 
 #### MilestonesApi
+
 ```java
 // Get a list of the milestones for the specified project
-List<Milestone> milestones = gitLabApi.getMilestonesApi().getMilestones(1234);
+List<Milestone> milestones=gitLabApi.getMilestonesApi().getMilestones(1234);
 ```
- 
+
 #### NamespaceApi
+
 ```java
 // Get all namespaces that match "foobar" in their name or path
-List<Namespace> namespaces = gitLabApi.getNamespaceApi().findNamespaces("foobar");
+List<Namespace> namespaces=gitLabApi.getNamespaceApi().findNamespaces("foobar");
 ```
 
 #### NotesApi
+
 ```java
 // Get a list of the issues's notes for project ID 1234, issue IID 1
-List<Note> notes = gitLabApi.getNotesApi().getNotes(1234, 1);
+List<Note> notes=gitLabApi.getNotesApi().getNotes(1234,1);
 ```
 
 #### NotificationSettingsApi
+
 ```java
 // Get the current global notification settings
-NotificationSettings settings = gitLabApi.getNotificationSettingsApi().getGlobalNotificationSettings();
+NotificationSettings settings=gitLabApi.getNotificationSettingsApi().getGlobalNotificationSettings();
 ```
 
 #### PackagesApi
+
 ```java
 // Get all packages for the specified project ID
-List<Packages> packages = gitLabApi.getPackagesApi().getPackages(1234);
+List<Packages> packages=gitLabApi.getPackagesApi().getPackages(1234);
 ```
 
 #### PipelineApi
+
 ```java
 // Get all pipelines for the specified project ID
-List<Pipeline> pipelines = gitLabApi.getPipelineApi().getPipelines(1234);
+List<Pipeline> pipelines=gitLabApi.getPipelineApi().getPipelines(1234);
 ```
 
 #### ProjectApi
+
 ```java
 // Get a list of accessible projects 
-public List<Project> projects = gitLabApi.getProjectApi().getProjects();
+public List<Project> projects=gitLabApi.getProjectApi().getProjects();
 ```
+
 ```java
 // Create a new project
-Project projectSpec = new Project()
+Project projectSpec=new Project()
     .withName("my-project")
     .withDescription("My project for demonstration.")
     .withIssuesEnabled(true)
@@ -505,112 +608,128 @@ Project projectSpec = new Project()
     .withSnippetsEnabled(true)
     .withPublic(true);
 
-Project newProject = gitLabApi.getProjectApi().createProject(projectSpec);
+    Project newProject=gitLabApi.getProjectApi().createProject(projectSpec);
 ```
 
 #### ProtectedBranchesApi
+
 ```java
-List<ProtectedBranch> branches = gitLabApi.getProtectedBranchesApi().getProtectedBranches(project.getId());
+List<ProtectedBranch> branches=gitLabApi.getProtectedBranchesApi().getProtectedBranches(project.getId());
 ```
 
 #### ReleasesApi
+
 ```java
 // Get a list of releases for the specified project
-List<Release> releases = gitLabApi.getReleasesApi().getReleases(projectId);
+List<Release> releases=gitLabApi.getReleasesApi().getReleases(projectId);
 ```
 
 #### RepositoryApi
+
 ```java
 // Get a list of repository branches from a project, sorted by name alphabetically
-List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(projectId);
+List<Branch> branches=gitLabApi.getRepositoryApi().getBranches(projectId);
 ```
+
 ```java
 // Search repository branches from a project, by name
-List<Branch> branches = gitLabApi.getRepositoryApi().getBranches(projectId, searchTerm);
+List<Branch> branches=gitLabApi.getRepositoryApi().getBranches(projectId,searchTerm);
 ```
 
 #### RepositoryFileApi
+
 ```java
 // Get info (name, size, ...) and the content from a file in repository
-RepositoryFile file = gitLabApi.getRepositoryFileApi().getFile("file-path", 1234, "ref");   
+RepositoryFile file=gitLabApi.getRepositoryFileApi().getFile("file-path",1234,"ref");   
 ```
 
 #### ResourceLabelEventsApi
+
 ```java
 // Get the label events for the specified merge request
-List<LabelEvent> labelEvents = gitLabApi.getResourceLabelEventsApi()
-        .getMergeRequestLabelEvents(projectId, mergeRequestIid);
+List<LabelEvent> labelEvents=gitLabApi.getResourceLabelEventsApi()
+    .getMergeRequestLabelEvents(projectId,mergeRequestIid);
 ```
 
 #### RunnersApi
+
 ```java
 // Get All Runners.
-List<Runner> runners = gitLabApi.getRunnersApi().getAllRunners();
+List<Runner> runners=gitLabApi.getRunnersApi().getAllRunners();
 ```
 
 #### SearchApi
+
 ```java
 // Do a global search for Projects
-List<?> projects = gitLabApi.getSearchApi().globalSearch(SearchScope.PROJECTS, "text-to-search-for");
+List<?> projects=gitLabApi.getSearchApi().globalSearch(SearchScope.PROJECTS,"text-to-search-for");
 ```
 
 #### ServicesApi
+
 ```java
 // Activate/Update the Slack Notifications service
-SlackService slackService =  new SlackService()
-        .withMergeRequestsEvents(true)
-        .withWebhook("https://hooks.slack.com/services/ABCDEFGHI/KJLMNOPQR/wetrewq7897HKLH8998wfjjj")
-        .withUsername("GitLab4J");
-gitLabApi.getServicesApi().updateSlackService("project-path", slackService);
+SlackService slackService=new SlackService()
+    .withMergeRequestsEvents(true)
+    .withWebhook("https://hooks.slack.com/services/ABCDEFGHI/KJLMNOPQR/wetrewq7897HKLH8998wfjjj")
+    .withUsername("GitLab4J");
+    gitLabApi.getServicesApi().updateSlackService("project-path",slackService);
 ```
 
 #### SessionApi
+
 ```java
 // Log in to the GitLab server and get the session info
-gitLabApi.getSessionApi().login("your-username", "your-email", "your-password");
+gitLabApi.getSessionApi().login("your-username","your-email","your-password");
 ```
 
 #### SnippetsApi
+
 ```java
 // Get a list of the authenticated user's snippets
-List<Snippet> snippets = gitLabApi.getSnippetsApi().getSnippets();
+List<Snippet> snippets=gitLabApi.getSnippetsApi().getSnippets();
 ```
 
 #### SystemHooksApi
+
 ```java
 // Get a list of installed system hooks
-List<SystemHook> hooks = gitLabApi.getSystemHooksApi().getSystemHooks();
+List<SystemHook> hooks=gitLabApi.getSystemHooksApi().getSystemHooks();
 ```
 
 #### TagsApi
+
 ```java
 // Get a list of tags for the specified project ID
-List<Tag> tags = gitLabApi.getTagsApi().getTags(projectId);
+List<Tag> tags=gitLabApi.getTagsApi().getTags(projectId);
 ```
 
 #### TodosApi
+
 ```java
 // Get a list of all pending todos for the current user
-List<Todo> todos = gitLabApi.getTodosApi().gePendingTodos();
+List<Todo> todos=gitLabApi.getTodosApi().gePendingTodos();
 ```
 
 #### UserApi
+
 ```java
 // Get the User info for user_id 1
-User user = gitLabApi.getUserApi().getUser(1);
+User user=gitLabApi.getUserApi().getUser(1);
 
 // Create a new user with no password who will recieve a reset password email
-User userConfig = new User()
+    User userConfig=new User()
     .withEmail("jdoe@example.com")
     .withName("Jane Doe")
     .withUsername("jdoe");
-String password = null;
-boolean sendResetPasswordEmail = true;
-gitLabApi.getUserApi().createUser(userConfig, password, sendResetPasswordEmail);
+    String password=null;
+    boolean sendResetPasswordEmail=true;
+    gitLabApi.getUserApi().createUser(userConfig,password,sendResetPasswordEmail);
 ```
 
 #### WikisApi
+
 ```java
 // Get a list of pages in project wiki
-List<WikiPage> wikiPages = gitLabApi.getWikisApi().getPages();
+List<WikiPage> wikiPages=gitLabApi.getWikisApi().getPages();
 ```

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api</artifactId>
 	<packaging>jar</packaging>
-	<version>5.1.0</version>
+	<version>6.0.0</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>
@@ -43,21 +43,20 @@
 	</developers>
 
 	<properties>
-		<java.level>8</java.level>
-		<java.source.version>1.8</java.source.version>
-		<java.target.version>1.8</java.target.version>
+		<java.source.version>11</java.source.version>
+		<java.target.version>11</java.target.version>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<jersey.version>2.35</jersey.version>
-		<jackson.version>2.12.4</jackson.version>
-		<servlet.version>4.0.4</servlet.version>
-		<activation.version>1.2.2</activation.version>
+		<jersey.version>3.1.1</jersey.version>
+		<jackson.version>2.14.1</jackson.version>
+		<servlet.version>6.0.0</servlet.version>
+		<activation.version>2.1.1</activation.version>
 
-		<junit.version>5.8.2</junit.version>
+		<junit.version>5.9.2</junit.version>
 		<testcontainers.version>1.15.3</testcontainers.version>
-		<mockito.version>4.4.0</mockito.version>
+		<mockito.version>5.2.0</mockito.version>
 		<hamcrest.version>1.3</hamcrest.version>
 		<systemRules.version>1.19.0</systemRules.version>
 
@@ -258,7 +257,7 @@
 				<configuration>
 					<rules>
 						<enforceBytecodeVersion>
-							<maxJdkVersion>1.8</maxJdkVersion>
+							<maxJdkVersion>11</maxJdkVersion>
 							<ignoreClasses>
 								<ignoreClass>module-info</ignoreClass>
 							</ignoreClasses>
@@ -285,7 +284,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.20</version>
+				<version>1.23</version>
 				<executions>
 					<execution>
 						<goals>
@@ -297,7 +296,8 @@
 				<configuration>
 					<signature>
 						<groupId>org.codehaus.mojo.signature</groupId>
-						<artifactId>java1${java.level}</artifactId>
+						<artifactId>java18</artifactId>
+						<version>1.0</version>
 					</signature>
 				</configuration>
 			</plugin>
@@ -449,7 +449,7 @@
 		<dependency>
 			<groupId>uk.org.webcompere</groupId>
 			<artifactId>system-stubs-jupiter</artifactId>
-			<version>1.2.0</version>
+			<version>2.0.2</version>
 			<scope>test</scope>
 		</dependency>
 	</dependencies>

--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -1,15 +1,13 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.NotAuthorizedException;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.io.InputStream;
 import java.net.URL;
-
-import javax.ws.rs.NotAuthorizedException;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.Label;
@@ -23,742 +21,861 @@ import org.gitlab4j.api.utils.UrlEncoder;
  */
 public abstract class AbstractApi implements Constants {
 
-    protected final GitLabApi gitLabApi;
+  protected final GitLabApi gitLabApi;
 
-    public AbstractApi(GitLabApi gitLabApi) {
-        this.gitLabApi = gitLabApi;
+  public AbstractApi(final GitLabApi gitLabApi) {
+    this.gitLabApi = gitLabApi;
+  }
+
+  /**
+   * Returns the project ID or path from the provided Integer, String, or Project instance.
+   *
+   * @param obj the object to determine the ID or path from
+   * @return the project ID or path from the provided Long, String, or Project instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Object getProjectIdOrPath(final Object obj) throws GitLabApiException {
+
+    if (obj == null) {
+      throw (new RuntimeException("Cannot determine ID or path from null object"));
+    } else if (obj instanceof Long) {
+      return (obj);
+    } else if (obj instanceof String) {
+      return (urlEncode(((String) obj).trim()));
+    } else if (obj instanceof Project) {
+
+      final Long id = ((Project) obj).getId();
+      if (id != null && id.longValue() > 0) {
+        return (id);
+      }
+
+      final String path = ((Project) obj).getPathWithNamespace();
+      if (path != null && path.trim().length() > 0) {
+        return (urlEncode(path.trim()));
+      }
+
+      throw (new RuntimeException("Cannot determine ID or path from provided Project instance"));
+
+    } else {
+      throw (new RuntimeException(
+          "Cannot determine ID or path from provided "
+              + obj.getClass().getSimpleName()
+              + " instance, must be Long, String, or a Project instance"));
+    }
+  }
+
+  /**
+   * Returns the group ID or path from the provided Integer, String, or Group instance.
+   *
+   * @param obj the object to determine the ID or path from
+   * @return the group ID or path from the provided Long, String, or Group instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Object getGroupIdOrPath(final Object obj) throws GitLabApiException {
+
+    if (obj == null) {
+      throw (new RuntimeException("Cannot determine ID or path from null object"));
+    } else if (obj instanceof Long) {
+      return (obj);
+    } else if (obj instanceof String) {
+      return (urlEncode(((String) obj).trim()));
+    } else if (obj instanceof Group) {
+
+      final Long id = ((Group) obj).getId();
+      if (id != null && id.longValue() > 0) {
+        return (id);
+      }
+
+      final String path = ((Group) obj).getFullPath();
+      if (path != null && path.trim().length() > 0) {
+        return (urlEncode(path.trim()));
+      }
+
+      throw (new RuntimeException("Cannot determine ID or path from provided Group instance"));
+
+    } else {
+      throw (new RuntimeException(
+          "Cannot determine ID or path from provided "
+              + obj.getClass().getSimpleName()
+              + " instance, must be Long, String, or a Group instance"));
+    }
+  }
+
+  /**
+   * Returns the user ID or path from the provided Integer, String, or User instance.
+   *
+   * @param obj the object to determine the ID or username from
+   * @return the user ID or username from the provided Integer, String, or User instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Object getUserIdOrUsername(final Object obj) throws GitLabApiException {
+
+    if (obj == null) {
+      throw (new RuntimeException("Cannot determine ID or username from null object"));
+    } else if (obj instanceof Long) {
+      return (obj);
+    } else if (obj instanceof String) {
+      return (urlEncode(((String) obj).trim()));
+    } else if (obj instanceof User) {
+
+      final Long id = ((User) obj).getId();
+      if (id != null && id.longValue() > 0) {
+        return (id);
+      }
+
+      final String username = ((User) obj).getUsername();
+      if (username != null && username.trim().length() > 0) {
+        return (urlEncode(username.trim()));
+      }
+
+      throw (new RuntimeException("Cannot determine ID or username from provided User instance"));
+
+    } else {
+      throw (new RuntimeException(
+          "Cannot determine ID or username from provided "
+              + obj.getClass().getSimpleName()
+              + " instance, must be Integer, String, or a User instance"));
+    }
+  }
+
+  /**
+   * Returns the label ID or name from the provided Integer, String, or Label instance.
+   *
+   * @param obj the object to determine the ID or name from
+   * @return the user ID or name from the provided Integer, String, or Label instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Object getLabelIdOrName(final Object obj) throws GitLabApiException {
+
+    if (obj == null) {
+      throw (new RuntimeException("Cannot determine ID or name from null object"));
+    } else if (obj instanceof Long) {
+      return (obj);
+    } else if (obj instanceof String) {
+      return (urlEncode(((String) obj).trim()));
+    } else if (obj instanceof Label) {
+
+      final Long id = ((Label) obj).getId();
+      if (id != null && id.longValue() > 0) {
+        return (id);
+      }
+
+      final String name = ((Label) obj).getName();
+      if (name != null && name.trim().length() > 0) {
+        return (urlEncode(name.trim()));
+      }
+
+      throw (new RuntimeException("Cannot determine ID or name from provided Label instance"));
+
+    } else {
+      throw (new RuntimeException(
+          "Cannot determine ID or name from provided "
+              + obj.getClass().getSimpleName()
+              + " instance, must be Integer, String, or a Label instance"));
+    }
+  }
+
+  protected ApiVersion getApiVersion() {
+    return (gitLabApi.getApiVersion());
+  }
+
+  protected boolean isApiVersion(final ApiVersion apiVersion) {
+    return (gitLabApi.getApiVersion() == apiVersion);
+  }
+
+  protected int getDefaultPerPage() {
+    return (gitLabApi.getDefaultPerPage());
+  }
+
+  protected GitLabApiClient getApiClient() {
+    return (gitLabApi.getApiClient());
+  }
+
+  /**
+   * Encode a string to be used as in-path argument for a gitlab api request.
+   *
+   * <p>Standard URL encoding changes spaces to plus signs, but for arguments that are part of the
+   * path, like the :file_path in a "Get raw file" request, gitlab expects spaces to be encoded with
+   * %20.
+   *
+   * @param s the string to encode
+   * @return encoded version of s with spaces encoded as %2F
+   * @throws GitLabApiException if encoding throws an exception
+   */
+  protected String urlEncode(final String s) throws GitLabApiException {
+    return (UrlEncoder.urlEncode(s));
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response get(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().get(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param accepts if non-empty will set the Accepts header to this value
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response getWithAccepts(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final String accepts,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(
+          getApiClient().getWithAccepts(queryParams, accepts, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response get(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().get(queryParams, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP HEAD call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response head(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().head(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PATCH call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response patch(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().patch(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PATCH call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response patch(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().patch(queryParams, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param formData the Form containing the name/value pairs for the POST data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response post(
+      final Response.Status expectedStatus, final Form formData, final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().post(formData, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified payload object and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param payload the object instance that will be serialized to JSON and used as the POST data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response post(
+      final Response.Status expectedStatus, final Object payload, final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().post(payload, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified payload object and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param stream the StreamingOutput that will be used for the POST data
+   * @param mediaType the content-type for the streamed data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response post(
+      final Response.Status expectedStatus,
+      final StreamingOutput stream,
+      final String mediaType,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().post(stream, mediaType, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response post(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().post(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param formData the Form containing the name/value pairs for the POST data
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response post(final Response.Status expectedStatus, final Form formData, final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().post(formData, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform a file upload with the specified File instance and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaType unused; will be removed in the next major version
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response upload(
+      final Response.Status expectedStatus,
+      final String name,
+      final File fileToUpload,
+      final String mediaType,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(
+          getApiClient().upload(name, fileToUpload, mediaType, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  protected Response upload(
+      final Response.Status expectedStatus,
+      final String name,
+      final InputStream inputStream,
+      final String filename,
+      final String mediaType,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(
+          getApiClient().upload(name, inputStream, filename, mediaType, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform a file upload with the specified File instance and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaType unused; will be removed in the next major version
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response upload(
+      final Response.Status expectedStatus,
+      final String name,
+      final File fileToUpload,
+      final String mediaType,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().upload(name, fileToUpload, mediaType, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform a file upload with the specified File instance and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaType unused; will be removed in the next major version
+   * @param formData the Form containing the name/value pairs
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response upload(
+      final Response.Status expectedStatus,
+      final String name,
+      final File fileToUpload,
+      final String mediaType,
+      final Form formData,
+      final URL url)
+      throws GitLabApiException {
+
+    try {
+      return validate(
+          getApiClient().upload(name, fileToUpload, mediaType, formData, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response put(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().put(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response put(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().put(queryParams, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified payload object and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param payload the object instance that will be serialized to JSON and used as the PUT data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response put(
+      final Response.Status expectedStatus, final Object payload, final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().put(payload, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param formData the Form containing the name/value pairs for the POST data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response putWithFormData(
+      final Response.Status expectedStatus, final Form formData, final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().put(formData, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform a file upload using the HTTP PUT method with the specified File instance and path
+   * objects, returning a ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response putUpload(
+      final Response.Status expectedStatus,
+      final String name,
+      final File fileToUpload,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().putUpload(name, fileToUpload, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform a file upload using the HTTP PUT method with the specified File instance and path
+   * objects, returning a ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response putUpload(
+      final Response.Status expectedStatus,
+      final String name,
+      final File fileToUpload,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().putUpload(name, fileToUpload, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP DELETE call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response delete(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().delete(queryParams, pathArgs), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Perform an HTTP DELETE call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param expectedStatus the HTTP status that should be returned from the server
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  protected Response delete(
+      final Response.Status expectedStatus,
+      final MultivaluedMap<String, String> queryParams,
+      final URL url)
+      throws GitLabApiException {
+    try {
+      return validate(getApiClient().delete(queryParams, url), expectedStatus);
+    } catch (final Exception e) {
+      throw handle(e);
+    }
+  }
+
+  /**
+   * Convenience method for adding query and form parameters to a get() or post() call.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param name the name of the field/attribute to add
+   * @param value the value of the field/attribute to add
+   */
+  protected void addFormParam(final Form formData, final String name, final Object value)
+      throws IllegalArgumentException {
+    addFormParam(formData, name, value, false);
+  }
+
+  /**
+   * Convenience method for adding query and form parameters to a get() or post() call. If required
+   * is true and value is null, will throw an IllegalArgumentException.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param name the name of the field/attribute to add
+   * @param value the value of the field/attribute to add
+   * @param required the field is required flag
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  protected void addFormParam(
+      final Form formData, final String name, final Object value, final boolean required)
+      throws IllegalArgumentException {
+
+    if (value == null) {
+
+      if (required) {
+        throw new IllegalArgumentException(name + " cannot be empty or null");
+      }
+
+      return;
     }
 
-    /**
-     * Returns the project ID or path from the provided Integer, String, or Project instance.
-     *
-     * @param obj the object to determine the ID or path from
-     * @return the project ID or path from the provided Long, String, or Project instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Object getProjectIdOrPath(Object obj) throws GitLabApiException {
-
-        if (obj == null) {
-            throw (new RuntimeException("Cannot determine ID or path from null object"));
-        } else if (obj instanceof Long) {
-            return (obj);
-        } else if (obj instanceof String) {
-            return (urlEncode(((String) obj).trim()));
-        } else if (obj instanceof Project) {
-
-            Long id = ((Project) obj).getId();
-            if (id != null && id.longValue() > 0) {
-                return (id);
-            }
-
-            String path = ((Project) obj).getPathWithNamespace();
-            if (path != null && path.trim().length() > 0) {
-                return (urlEncode(path.trim()));
-            }
-
-            throw (new RuntimeException("Cannot determine ID or path from provided Project instance"));
-
-        } else {
-            throw (new RuntimeException("Cannot determine ID or path from provided " + obj.getClass().getSimpleName() +
-                    " instance, must be Long, String, or a Project instance"));
-        }
+    final String stringValue = value.toString();
+    if (required && stringValue.trim().length() == 0) {
+      throw new IllegalArgumentException(name + " cannot be empty or null");
     }
 
-    /**
-     * Returns the group ID or path from the provided Integer, String, or Group instance.
-     *
-     * @param obj the object to determine the ID or path from
-     * @return the group ID or path from the provided Long, String, or Group instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Object getGroupIdOrPath(Object obj) throws GitLabApiException {
+    formData.param(name, stringValue);
+  }
 
-        if (obj == null) {
-            throw (new RuntimeException("Cannot determine ID or path from null object"));
-        } else if (obj instanceof Long) {
-            return (obj);
-        } else if (obj instanceof String) {
-            return (urlEncode(((String) obj).trim()));
-        } else if (obj instanceof Group) {
+  /**
+   * Validates response the response from the server against the expected HTTP status and the
+   * returned secret token, if either is not correct will throw a GitLabApiException.
+   *
+   * @param response response
+   * @param expected expected response status
+   * @return original response if the response status is expected
+   * @throws GitLabApiException if HTTP status is not as expected, or the secret token doesn't match
+   */
+  protected Response validate(final Response response, final Response.Status expected)
+      throws GitLabApiException {
 
-            Long id = ((Group) obj).getId();
-            if (id != null && id.longValue() > 0) {
-                return (id);
-            }
+    final int responseCode = response.getStatus();
+    final int expectedResponseCode = expected.getStatusCode();
 
-            String path = ((Group) obj).getFullPath();
-            if (path != null && path.trim().length() > 0) {
-                return (urlEncode(path.trim()));
-            }
+    if (responseCode != expectedResponseCode) {
 
-            throw (new RuntimeException("Cannot determine ID or path from provided Group instance"));
-
-        } else {
-            throw (new RuntimeException("Cannot determine ID or path from provided " + obj.getClass().getSimpleName() +
-                    " instance, must be Long, String, or a Group instance"));
-        }
+      // If the expected code is 200-204 and the response code is 200-204 it is OK.  We do this
+      // because
+      // GitLab is constantly changing the expected code in the 200 to 204 range
+      if (expectedResponseCode > 204
+          || responseCode > 204
+          || expectedResponseCode < 200
+          || responseCode < 200) throw new GitLabApiException(response);
     }
 
-    /**
-     * Returns the user ID or path from the provided Integer, String, or User instance.
-     *
-     * @param obj the object to determine the ID or username from
-     * @return the user ID or username from the provided Integer, String, or User instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Object getUserIdOrUsername(Object obj) throws GitLabApiException {
-
-        if (obj == null) {
-            throw (new RuntimeException("Cannot determine ID or username from null object"));
-        } else if (obj instanceof Long) {
-            return (obj);
-        } else if (obj instanceof String) {
-            return (urlEncode(((String) obj).trim()));
-        } else if (obj instanceof User) {
-
-            Long id = ((User) obj).getId();
-            if (id != null && id.longValue() > 0) {
-                return (id);
-            }
-
-            String username = ((User) obj).getUsername();
-            if (username != null && username.trim().length() > 0) {
-                return (urlEncode(username.trim()));
-            }
-
-            throw (new RuntimeException("Cannot determine ID or username from provided User instance"));
-
-        } else {
-            throw (new RuntimeException("Cannot determine ID or username from provided " + obj.getClass().getSimpleName() +
-                    " instance, must be Integer, String, or a User instance"));
-        }
+    if (!getApiClient().validateSecretToken(response)) {
+      throw new GitLabApiException(new NotAuthorizedException("Invalid secret token in response."));
     }
 
-    /**
-     * Returns the label ID or name from the provided Integer, String, or Label instance.
-     *
-     * @param obj the object to determine the ID or name from
-     * @return the user ID or name from the provided Integer, String, or Label instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Object getLabelIdOrName(Object obj) throws GitLabApiException {
+    return (response);
+  }
 
-        if (obj == null) {
-            throw (new RuntimeException("Cannot determine ID or name from null object"));
-        } else if (obj instanceof Long) {
-            return (obj);
-        } else if (obj instanceof String) {
-            return (urlEncode(((String) obj).trim()));
-        } else if (obj instanceof Label) {
+  /**
+   * Wraps an exception in a GitLabApiException if needed.
+   *
+   * @param thrown the exception that should be wrapped
+   * @return either the untouched GitLabApiException or a new GitLabApiExceptin wrapping a
+   *     non-GitLabApiException
+   */
+  protected GitLabApiException handle(final Exception thrown) {
 
-            Long id = ((Label) obj).getId();
-            if (id != null && id.longValue() > 0) {
-                return (id);
-            }
-
-            String name = ((Label) obj).getName();
-            if (name != null && name.trim().length() > 0) {
-                return (urlEncode(name.trim()));
-            }
-
-            throw (new RuntimeException("Cannot determine ID or name from provided Label instance"));
-
-        } else {
-            throw (new RuntimeException("Cannot determine ID or name from provided " + obj.getClass().getSimpleName() +
-                    " instance, must be Integer, String, or a Label instance"));
-        }
+    if (thrown instanceof GitLabApiException) {
+      return ((GitLabApiException) thrown);
     }
 
-    protected ApiVersion getApiVersion() {
-        return (gitLabApi.getApiVersion());
-    }
+    return (new GitLabApiException(thrown));
+  }
 
-    protected boolean isApiVersion(ApiVersion apiVersion) {
-        return (gitLabApi.getApiVersion() == apiVersion);
-    }
+  /**
+   * Creates a MultivaluedMap instance containing the "per_page" param.
+   *
+   * @param perPage the number of projects per page
+   * @return a MultivaluedMap instance containing the "per_page" param
+   */
+  protected MultivaluedMap<String, String> getPerPageQueryParam(final int perPage) {
+    return (new GitLabApiForm().withParam(PER_PAGE_PARAM, perPage).asMap());
+  }
 
-    protected int getDefaultPerPage() {
-        return (gitLabApi.getDefaultPerPage());
-    }
+  /**
+   * Creates a MultivaluedMap instance containing "page" and "per_page" params.
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a MultivaluedMap instance containing "page" and "per_page" params
+   */
+  protected MultivaluedMap<String, String> getPageQueryParams(final int page, final int perPage) {
+    return (new GitLabApiForm()
+        .withParam(PAGE_PARAM, page)
+        .withParam(PER_PAGE_PARAM, perPage)
+        .asMap());
+  }
 
-    protected GitLabApiClient getApiClient() {
-        return (gitLabApi.getApiClient());
-    }
+  /**
+   * Creates a MultivaluedMap instance containing "page" and "per_page" params.
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @param customAttributesEnabled enables customAttributes for this query
+   * @return a MultivaluedMap instance containing "page" and "per_page" params
+   */
+  protected MultivaluedMap<String, String> getPageQueryParams(
+      final int page, final int perPage, final boolean customAttributesEnabled) {
 
-    /**
-     * Encode a string to be used as in-path argument for a gitlab api request.
-     *
-     * Standard URL encoding changes spaces to plus signs, but for arguments that are part of the path,
-     * like the :file_path in a "Get raw file" request, gitlab expects spaces to be encoded with %20.
-     *
-     * @param s the string to encode
-     * @return encoded version of s with spaces encoded as %2F
-     * @throws GitLabApiException if encoding throws an exception
-     */
-    protected String urlEncode(String s) throws GitLabApiException {
-        return (UrlEncoder.urlEncode(s));
-    }
+    final GitLabApiForm form =
+        new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
+    if (customAttributesEnabled) return (form.withParam("with_custom_attributes", true).asMap());
 
-    /**
-     * Perform an HTTP GET call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response get(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().get(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
+    return (form.asMap());
+  }
 
-    /**
-     * Perform an HTTP GET call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param accepts if non-empty will set the Accepts header to this value
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response getWithAccepts(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, String accepts, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().getWithAccepts(queryParams, accepts, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
+  /**
+   * Creates a MultivaluedMap instance containing the "per_page" param with the default value.
+   *
+   * @return a MultivaluedMap instance containing the "per_page" param with the default value
+   */
+  protected MultivaluedMap<String, String> getDefaultPerPageParam() {
+    return (new GitLabApiForm().withParam(PER_PAGE_PARAM, getDefaultPerPage()).asMap());
+  }
 
-    /**
-     * Perform an HTTP GET call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response get(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().get(queryParams, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
+  /**
+   * Creates a MultivaluedMap instance containing the "per_page" param with the default value.
+   *
+   * @param customAttributesEnabled enables customAttributes for this query
+   * @return a MultivaluedMap instance containing the "per_page" param with the default value
+   */
+  protected MultivaluedMap<String, String> getDefaultPerPageParam(
+      final boolean customAttributesEnabled) {
 
-    /**
-     * Perform an HTTP HEAD call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response head(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().head(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
+    final GitLabApiForm form = new GitLabApiForm().withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    if (customAttributesEnabled) return (form.withParam("with_custom_attributes", true).asMap());
 
-    /**
-     * Perform an HTTP PATCH call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response patch(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().patch(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP PATCH call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response patch(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().patch(queryParams, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param formData the Form containing the name/value pairs for the POST data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response post(Response.Status expectedStatus, Form formData, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().post(formData, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified payload object and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param payload the object instance that will be serialized to JSON and used as the POST data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response post(Response.Status expectedStatus, Object payload, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().post(payload, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified payload object and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param stream the StreamingOutput that will be used for the POST data
-     * @param mediaType the content-type for the streamed data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response post(Response.Status expectedStatus, StreamingOutput stream, String mediaType, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().post(stream, mediaType, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response post(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().post(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param formData the Form containing the name/value pairs for the POST data
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response post(Response.Status expectedStatus, Form formData, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().post(formData, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform a file upload with the specified File instance and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType unused; will be removed in the next major version
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response upload(Response.Status expectedStatus, String name, File fileToUpload, String mediaType, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().upload(name, fileToUpload, mediaType, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    protected Response upload(Response.Status expectedStatus, String name, InputStream inputStream, String filename, String mediaType, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().upload(name, inputStream, filename, mediaType, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform a file upload with the specified File instance and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType unused; will be removed in the next major version
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response upload(Response.Status expectedStatus, String name, File fileToUpload, String mediaType, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().upload(name, fileToUpload, mediaType, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform a file upload with the specified File instance and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaType unused; will be removed in the next major version
-     * @param formData the Form containing the name/value pairs
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response upload(Response.Status expectedStatus, String name, File fileToUpload, String mediaType, Form formData, URL url) throws GitLabApiException {
-
-        try {
-            return validate(getApiClient().upload(name, fileToUpload, mediaType, formData, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP PUT call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response put(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().put(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP PUT call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response put(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().put(queryParams, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP PUT call with the specified payload object and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param payload the object instance that will be serialized to JSON and used as the PUT data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response put(Response.Status expectedStatus, Object payload, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().put(payload, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP PUT call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param formData the Form containing the name/value pairs for the POST data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response putWithFormData(Response.Status expectedStatus, Form formData, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().put(formData, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-
-    /**
-     * Perform a file upload using the HTTP PUT method with the specified File instance and path objects,
-     * returning a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response putUpload(Response.Status expectedStatus, String name, File fileToUpload, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().putUpload(name, fileToUpload, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform a file upload using the HTTP PUT method with the specified File instance and path objects,
-     * returning a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response putUpload(Response.Status expectedStatus, String name, File fileToUpload, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().putUpload(name, fileToUpload, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP DELETE call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response delete(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
-        try {
-            return validate(getApiClient().delete(queryParams, pathArgs), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Perform an HTTP DELETE call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param expectedStatus the HTTP status that should be returned from the server
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    protected Response delete(Response.Status expectedStatus, MultivaluedMap<String, String> queryParams, URL url) throws GitLabApiException {
-        try {
-            return validate(getApiClient().delete(queryParams, url), expectedStatus);
-        } catch (Exception e) {
-            throw handle(e);
-        }
-    }
-
-    /**
-     * Convenience method for adding query and form parameters to a get() or post() call.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param name the name of the field/attribute to add
-     * @param value the value of the field/attribute to add
-     */
-    protected void addFormParam(Form formData, String name, Object value) throws IllegalArgumentException {
-        addFormParam(formData, name, value, false);
-    }
-
-    /**
-     * Convenience method for adding query and form parameters to a get() or post() call.
-     * If required is true and value is null, will throw an IllegalArgumentException.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param name the name of the field/attribute to add
-     * @param value the value of the field/attribute to add
-     * @param required the field is required flag
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    protected void addFormParam(Form formData, String name, Object value, boolean required) throws IllegalArgumentException {
-
-        if (value == null) {
-
-            if (required) {
-                throw new IllegalArgumentException(name + " cannot be empty or null");
-            }
-
-            return;
-        }
-
-        String stringValue = value.toString();
-        if (required && stringValue.trim().length() == 0) {
-            throw new IllegalArgumentException(name + " cannot be empty or null");
-        }
-
-        formData.param(name, stringValue);
-    }
-
-    /**
-     * Validates response the response from the server against the expected HTTP status and
-     * the returned secret token, if either is not correct will throw a GitLabApiException.
-     *
-     * @param response response
-     * @param expected expected response status
-     * @return original response if the response status is expected
-     * @throws GitLabApiException if HTTP status is not as expected, or the secret token doesn't match
-     */
-    protected Response validate(Response response, Response.Status expected) throws GitLabApiException {
-
-        int responseCode = response.getStatus();
-        int expectedResponseCode = expected.getStatusCode();
-
-        if (responseCode != expectedResponseCode) {
-
-            // If the expected code is 200-204 and the response code is 200-204 it is OK.  We do this because
-            // GitLab is constantly changing the expected code in the 200 to 204 range
-            if (expectedResponseCode > 204 || responseCode > 204 || expectedResponseCode < 200 || responseCode < 200)
-                throw new GitLabApiException(response);
-        }
-
-        if (!getApiClient().validateSecretToken(response)) {
-            throw new GitLabApiException(new NotAuthorizedException("Invalid secret token in response."));
-        }
-
-        return (response);
-    }
-
-    /**
-     * Wraps an exception in a GitLabApiException if needed.
-     *
-     * @param thrown the exception that should be wrapped
-     * @return either the untouched GitLabApiException or a new GitLabApiExceptin wrapping a non-GitLabApiException
-     */
-    protected GitLabApiException handle(Exception thrown) {
-
-        if (thrown instanceof GitLabApiException) {
-            return ((GitLabApiException) thrown);
-        }
-
-        return (new GitLabApiException(thrown));
-    }
-
-    /**
-     * Creates a MultivaluedMap instance containing the "per_page" param.
-     *
-     * @param perPage the number of projects per page
-     * @return a MultivaluedMap instance containing the "per_page" param
-     */
-    protected MultivaluedMap<String, String> getPerPageQueryParam(int perPage) {
-        return (new GitLabApiForm().withParam(PER_PAGE_PARAM, perPage).asMap());
-    }
-
-    /**
-     * Creates a MultivaluedMap instance containing "page" and "per_page" params.
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a MultivaluedMap instance containing "page" and "per_page" params
-     */
-    protected MultivaluedMap<String, String> getPageQueryParams(int page, int perPage) {
-        return (new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage).asMap());
-    }
-
-    /**
-     * Creates a MultivaluedMap instance containing "page" and "per_page" params.
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @param customAttributesEnabled enables customAttributes for this query
-     * @return a MultivaluedMap instance containing "page" and "per_page" params
-     */
-    protected MultivaluedMap<String, String> getPageQueryParams(int page, int perPage, boolean customAttributesEnabled) {
-
-        GitLabApiForm form = new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
-        if (customAttributesEnabled)
-            return (form.withParam("with_custom_attributes", true).asMap());
-
-       return (form.asMap());
-    }
-
-    /**
-     * Creates a MultivaluedMap instance containing the "per_page" param with the default value.
-     *
-     * @return a MultivaluedMap instance containing the "per_page" param with the default value
-     */
-    protected MultivaluedMap<String, String> getDefaultPerPageParam() {
-       return (new GitLabApiForm().withParam(PER_PAGE_PARAM, getDefaultPerPage()).asMap());
-    }
-
-    /**
-     * Creates a MultivaluedMap instance containing the "per_page" param with the default value.
-     *
-     * @param customAttributesEnabled enables customAttributes for this query
-     * @return a MultivaluedMap instance containing the "per_page" param with the default value
-     */
-    protected MultivaluedMap<String, String> getDefaultPerPageParam(boolean customAttributesEnabled) {
-
-        GitLabApiForm form = new GitLabApiForm().withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        if (customAttributesEnabled)
-            return (form.withParam("with_custom_attributes", true).asMap());
-
-        return (form.asMap());
-    }
+    return (form.asMap());
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ApplicationSettingsApi.java
+++ b/src/main/java/org/gitlab4j/api/ApplicationSettingsApi.java
@@ -1,15 +1,12 @@
 package org.gitlab4j.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.ws.rs.core.Response;
 import java.text.ParseException;
 import java.util.Iterator;
-
-import javax.ws.rs.core.Response;
-
-import org.gitlab4j.api.models.Setting;
 import org.gitlab4j.api.models.ApplicationSettings;
+import org.gitlab4j.api.models.Setting;
 import org.gitlab4j.api.utils.ISO8601;
-
-import com.fasterxml.jackson.databind.JsonNode;
 
 /**
  * This class implements the client side API for the GitLab Application Settings API.
@@ -17,7 +14,7 @@ import com.fasterxml.jackson.databind.JsonNode;
  */
 public class ApplicationSettingsApi extends AbstractApi {
 
-    public ApplicationSettingsApi(GitLabApi gitLabApi) {
+    public ApplicationSettingsApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -31,8 +28,8 @@ public class ApplicationSettingsApi extends AbstractApi {
      */
     public ApplicationSettings getApplicationSettings() throws GitLabApiException {
 
-        Response response = get(Response.Status.OK, null, "application", "settings");
-        JsonNode root = response.readEntity(JsonNode.class);
+        final Response response = get(Response.Status.OK, null, "application", "settings");
+        final JsonNode root = response.readEntity(JsonNode.class);
         return (parseApplicationSettings(root));
     }
 
@@ -46,7 +43,7 @@ public class ApplicationSettingsApi extends AbstractApi {
      * @return the updated application settings in an ApplicationSettings instance
      * @throws GitLabApiException if any exception occurs
      */
-    public ApplicationSettings updateApplicationSettings(ApplicationSettings appSettings) throws GitLabApiException {
+    public ApplicationSettings updateApplicationSettings(final ApplicationSettings appSettings) throws GitLabApiException {
 
         if (appSettings == null || appSettings.getSettings().isEmpty()) {
             throw new GitLabApiException("ApplicationSettings cannot be null or empty.");
@@ -54,8 +51,8 @@ public class ApplicationSettingsApi extends AbstractApi {
 
         final GitLabApiForm form = new GitLabApiForm();
         appSettings.getSettings().forEach((s, v) -> form.withParam(s,  v));
-        Response response = put(Response.Status.OK, form.asMap(), "application", "settings");
-        JsonNode root = response.readEntity(JsonNode.class);
+        final Response response = put(Response.Status.OK, form.asMap(), "application", "settings");
+        final JsonNode root = response.readEntity(JsonNode.class);
         return (parseApplicationSettings(root));
     }
 
@@ -69,7 +66,7 @@ public class ApplicationSettingsApi extends AbstractApi {
      * @return the updated application settings in an ApplicationSettings instance
      * @throws GitLabApiException if any exception occurs
      */
-    public ApplicationSettings updateApplicationSetting(Setting setting, Object value) throws GitLabApiException {
+    public ApplicationSettings updateApplicationSetting(final Setting setting, final Object value) throws GitLabApiException {
 
         if (setting == null) {
             throw new GitLabApiException("setting cannot be null.");
@@ -88,15 +85,15 @@ public class ApplicationSettingsApi extends AbstractApi {
      * @return the updated application settings in an ApplicationSettings instance
      * @throws GitLabApiException if any exception occurs
      */
-    public ApplicationSettings updateApplicationSetting(String setting, Object value) throws GitLabApiException {
+    public ApplicationSettings updateApplicationSetting(final String setting, final Object value) throws GitLabApiException {
 
         if (setting == null || setting.trim().isEmpty()) {
             throw new GitLabApiException("setting cannot be null or empty.");
         }
 
-        GitLabApiForm form = new GitLabApiForm().withParam(setting, value);
-        Response response = put(Response.Status.OK, form.asMap(), "application", "settings");
-        JsonNode root = response.readEntity(JsonNode.class);
+        final GitLabApiForm form = new GitLabApiForm().withParam(setting, value);
+        final Response response = put(Response.Status.OK, form.asMap(), "application", "settings");
+        final JsonNode root = response.readEntity(JsonNode.class);
         return (parseApplicationSettings(root));
     }
 
@@ -107,14 +104,14 @@ public class ApplicationSettingsApi extends AbstractApi {
      * @return the populated ApplicationSettings instance
      * @throws GitLabApiException if any error occurs
      */
-    public static final ApplicationSettings parseApplicationSettings(JsonNode root) throws GitLabApiException {
+    public static final ApplicationSettings parseApplicationSettings(final JsonNode root) throws GitLabApiException {
 
-        ApplicationSettings appSettings = new ApplicationSettings();
+        final ApplicationSettings appSettings = new ApplicationSettings();
 
-        Iterator<String> fieldNames = root.fieldNames();
+        final Iterator<String> fieldNames = root.fieldNames();
         while (fieldNames.hasNext()) {
 
-            String fieldName = fieldNames.next();
+            final String fieldName = fieldNames.next();
             switch (fieldName) {
             case "id":
                 appSettings.setId(root.path(fieldName).asLong());
@@ -122,25 +119,25 @@ public class ApplicationSettingsApi extends AbstractApi {
 
             case "created_at":
                 try {
-                    String value = root.path(fieldName).asText();
+                    final String value = root.path(fieldName).asText();
                     appSettings.setCreatedAt(ISO8601.toDate(value));
-                } catch (ParseException pe) {
+                } catch (final ParseException pe) {
                     throw new GitLabApiException(pe);
                 }
                 break;
 
             case "updated_at":
                 try {
-                    String value = root.path(fieldName).asText();
+                    final String value = root.path(fieldName).asText();
                     appSettings.setUpdatedAt(ISO8601.toDate(value));
-                } catch (ParseException pe) {
+                } catch (final ParseException pe) {
                     throw new GitLabApiException(pe);
                 }
                 break;
 
             default:
 
-                Setting setting = Setting.forValue(fieldName);
+                final Setting setting = Setting.forValue(fieldName);
                 if (setting != null) {
                     appSettings.addSetting(setting, root.path(fieldName));
                 } else {

--- a/src/main/java/org/gitlab4j/api/ApplicationsApi.java
+++ b/src/main/java/org/gitlab4j/api/ApplicationsApi.java
@@ -1,132 +1,144 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.models.Application;
 
 /**
- * This class implements the client side API for the GitLab Applications API.
- * See <a href="https://docs.gitlab.com/ce/api/applications.html">Applications API at GitLab</a> for more information.
+ * This class implements the client side API for the GitLab Applications API. See <a
+ * href="https://docs.gitlab.com/ce/api/applications.html">Applications API at GitLab</a> for more
+ * information.
  */
 public class ApplicationsApi extends AbstractApi {
 
-    public ApplicationsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ApplicationsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get all OATH applications.
+   *
+   * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
+   *
+   * @return a List of OAUTH Application instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Application> getApplications() throws GitLabApiException {
+    return (getApplications(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all OAUTH applications using the specified page and per page setting
+   *
+   * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of items per page
+   * @return a list of OAUTH Applications in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Application> getApplications(final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            jakarta.ws.rs.core.Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "applications");
+    return (response.readEntity(new GenericType<List<Application>>() {}));
+  }
+
+  /**
+   * Get a Pager of all OAUTH applications.
+   *
+   * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
+   *
+   * @param itemsPerPage the number of items per page
+   * @return a Pager of Application instances in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Application> getApplications(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<Application>(this, Application.class, itemsPerPage, null, "applications"));
+  }
+
+  /**
+   * Get a Stream of all OAUTH Application instances.
+   *
+   * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
+   *
+   * @return a Stream of OAUTH Application instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Application> getApplicationsStream() throws GitLabApiException {
+    return (getApplications(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Create an OAUTH Application.
+   *
+   * <pre><code>GitLab Endpoint: POST /api/v4/applications</code></pre>
+   *
+   * @param name the name for the OAUTH Application
+   * @param redirectUri the redirect URI for the OAUTH Application
+   * @param scopes the scopes of the application (api, read_user, sudo, read_repository, openid,
+   *     profile, email)
+   * @return the created Application instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Application createApplication(
+      final String name, final String redirectUri, final ApplicationScope[] scopes)
+      throws GitLabApiException {
+
+    if (scopes == null || scopes.length == 0) {
+      throw new GitLabApiException("scopes cannot be null or empty");
     }
 
-    /**
-     * Get all OATH applications.
-     *
-     * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
-     *
-     * @return a List of OAUTH Application instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Application> getApplications() throws GitLabApiException {
-        return (getApplications(getDefaultPerPage()).all());
+    return (createApplication(name, redirectUri, Arrays.asList(scopes)));
+  }
+
+  /**
+   * Create an OAUTH Application.
+   *
+   * <pre><code>GitLab Endpoint: POST /api/v4/applications</code></pre>
+   *
+   * @param name the name for the OAUTH Application
+   * @param redirectUri the redirect URI for the OAUTH Application
+   * @param scopes the scopes of the application (api, read_user, sudo, read_repository, openid,
+   *     profile, email)
+   * @return the created Application instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Application createApplication(
+      final String name, final String redirectUri, final List<ApplicationScope> scopes)
+      throws GitLabApiException {
+
+    if (scopes == null || scopes.isEmpty()) {
+      throw new GitLabApiException("scopes cannot be null or empty");
     }
 
-    /**
-     * Get all OAUTH applications using the specified page and per page setting
-     *
-     * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of items per page
-     * @return a list of OAUTH Applications in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Application> getApplications(int page, int perPage) throws GitLabApiException {
-        Response response = get(javax.ws.rs.core.Response.Status.OK, getPageQueryParams(page, perPage), "applications");
-        return (response.readEntity(new GenericType<List<Application>>() {}));
-    }
+    final String scopesString =
+        scopes.stream().map(ApplicationScope::toString).collect(Collectors.joining(","));
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("redirect_uri", redirectUri, true)
+            .withParam("scopes", scopesString, true);
+    final Response response = post(Response.Status.CREATED, formData, "applications");
+    return (response.readEntity(Application.class));
+  }
 
-    /**
-     * Get a Pager of all OAUTH applications.
-     *
-     * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
-     *
-     * @param itemsPerPage the number of items per page
-     * @return a Pager of Application instances in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Application> getApplications(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Application>(this, Application.class, itemsPerPage, null, "applications"));
-    }
-
-    /**
-     * Get a Stream of all OAUTH Application instances.
-     *
-     * <pre><code>GitLab Endpoint: GET /api/v4/applications</code></pre>
-     *
-     * @return a Stream of OAUTH Application instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Application> getApplicationsStream() throws GitLabApiException {
-        return (getApplications(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Create an OAUTH Application.
-     *
-     * <pre><code>GitLab Endpoint: POST /api/v4/applications</code></pre>
-     *
-     * @param name the name for the OAUTH Application
-     * @param redirectUri the redirect URI for the OAUTH Application
-     * @param scopes the scopes of the application (api, read_user, sudo, read_repository, openid, profile, email)
-     * @return the created Application instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Application createApplication(String name, String redirectUri, ApplicationScope[] scopes) throws GitLabApiException {
-
-        if (scopes == null || scopes.length == 0) {
-            throw new GitLabApiException("scopes cannot be null or empty");
-        }
-
-        return (createApplication(name, redirectUri, Arrays.asList(scopes)));
-    }
-
-    /**
-     * Create an OAUTH Application.
-     *
-     * <pre><code>GitLab Endpoint: POST /api/v4/applications</code></pre>
-     *
-     * @param name the name for the OAUTH Application
-     * @param redirectUri the redirect URI for the OAUTH Application
-     * @param scopes the scopes of the application (api, read_user, sudo, read_repository, openid, profile, email)
-     * @return the created Application instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Application createApplication(String name, String redirectUri, List<ApplicationScope> scopes) throws GitLabApiException {
-
-        if (scopes == null || scopes.isEmpty()) {
-            throw new GitLabApiException("scopes cannot be null or empty");
-        }
-
-        String scopesString = scopes.stream().map(ApplicationScope::toString).collect(Collectors.joining(","));
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("redirect_uri", redirectUri, true)
-                .withParam("scopes",  scopesString, true);
-        Response response = post(Response.Status.CREATED, formData, "applications");
-        return (response.readEntity(Application.class));
-    }
-
-    /**
-     * Delete the specified OAUTH Application.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /api/v4/applications/:applicationId</code></pre>
-     *
-     * @param applicationId the ID of the OUAUTH Application to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteApplication(Long applicationId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "applications", applicationId);
-    }
+  /**
+   * Delete the specified OAUTH Application.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /api/v4/applications/:applicationId</code></pre>
+   *
+   * @param applicationId the ID of the OUAUTH Application to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteApplication(final Long applicationId) throws GitLabApiException {
+    delete(Response.Status.NO_CONTENT, null, "applications", applicationId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/AuditEventApi.java
+++ b/src/main/java/org/gitlab4j/api/AuditEventApi.java
@@ -1,12 +1,10 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.models.AuditEvent;
 import org.gitlab4j.api.utils.ISO8601;
 
@@ -16,7 +14,7 @@ import org.gitlab4j.api.utils.ISO8601;
  */
 public class AuditEventApi extends AbstractApi {
 
-    public AuditEventApi(GitLabApi gitLabApi) {
+    public AuditEventApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -32,7 +30,7 @@ public class AuditEventApi extends AbstractApi {
      * @return a List of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public List<AuditEvent> getAuditEvents(Date created_after, Date created_before, String entityType, Long entityId) throws GitLabApiException {
+    public List<AuditEvent> getAuditEvents(final Date created_after, final Date created_before, final String entityType, final Long entityId) throws GitLabApiException {
         return (getAuditEvents(created_after, created_before, entityType, entityId, getDefaultPerPage()).all());
     }
 
@@ -49,8 +47,8 @@ public class AuditEventApi extends AbstractApi {
      * @return a Pager of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<AuditEvent> getAuditEvents(Date created_after, Date created_before, String entityType, Long entityId, int itemsPerPage) throws GitLabApiException {
-        Form form = new GitLabApiForm()
+    public Pager<AuditEvent> getAuditEvents(final Date created_after, final Date created_before, final String entityType, final Long entityId, final int itemsPerPage) throws GitLabApiException {
+        final Form form = new GitLabApiForm()
                 .withParam("created_before", ISO8601.toString(created_before, false))
                 .withParam("created_after", ISO8601.toString(created_after, false))
                 .withParam("entity_type", entityType)
@@ -70,7 +68,7 @@ public class AuditEventApi extends AbstractApi {
      * @return a Stream of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<AuditEvent> getAuditEventsStream(Date created_after, Date created_before, String entityType, Long entityId) throws GitLabApiException {
+    public Stream<AuditEvent> getAuditEventsStream(final Date created_after, final Date created_before, final String entityType, final Long entityId) throws GitLabApiException {
         return (getAuditEvents(created_after, created_before, entityType, entityId, getDefaultPerPage()).stream());
     }
 
@@ -83,8 +81,8 @@ public class AuditEventApi extends AbstractApi {
      * @return the group Audit event
      * @throws GitLabApiException if any exception occurs
      */
-    public AuditEvent getAuditEvent(Long auditEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "audit_events", auditEventId);
+    public AuditEvent getAuditEvent(final Long auditEventId) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, null, "audit_events", auditEventId);
         return (response.readEntity(AuditEvent.class));
     }
 }

--- a/src/main/java/org/gitlab4j/api/AwardEmojiApi.java
+++ b/src/main/java/org/gitlab4j/api/AwardEmojiApi.java
@@ -1,427 +1,702 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.util.List;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.models.AwardEmoji;
 
 /**
  * This class implements the client side API for the GitLab Award Emoji API calls.
  *
- * @see <a href="https://docs.gitlab.com/ce/api/award_emoji.html">GitLab Award Emoji API Documentaion</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/award_emoji.html">GitLab Award Emoji API
+ *     Documentaion</a>
  * @since v4.8.31
  */
 public class AwardEmojiApi extends AbstractApi {
 
-    public AwardEmojiApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public AwardEmojiApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Get a list of award emoji for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID to get the award emojis for
-     * @return a list of AwardEmoji for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getIssueAwardEmojis(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "award_emoji");
-        return response.readEntity(new GenericType<List<AwardEmoji>>() {});
-    }
+  /**
+   * Get a list of award emoji for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/award_emoji</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID to get the award emojis for
+   * @return a list of AwardEmoji for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getIssueAwardEmojis(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "award_emoji");
+    return response.readEntity(new GenericType<List<AwardEmoji>>() {});
+  }
 
-    /**
-     *  Get a list of award emoji for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the award emojis for
-     * @return a list of AwardEmoji for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getMergeRequestAwardEmojis(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "award_emoji");
-        return response.readEntity(new GenericType<List<AwardEmoji>>() {});
-    }
+  /**
+   * Get a list of award emoji for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the award emojis for
+   * @return a list of AwardEmoji for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getMergeRequestAwardEmojis(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "award_emoji");
+    return response.readEntity(new GenericType<List<AwardEmoji>>() {});
+  }
 
-    /**
-     *  Get a list of award emoji for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param snippetId the snippet ID to get the award emojis for
-     * @return a list of AwardEmoji for the specified snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getSnippetAwardEmojis(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "award_emoji");
-        return response.readEntity(new GenericType<List<AwardEmoji>>() {});
-    }
+  /**
+   * Get a list of award emoji for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/award_emoji</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param snippetId the snippet ID to get the award emojis for
+   * @return a list of AwardEmoji for the specified snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getSnippetAwardEmojis(final Object projectIdOrPath, final Long snippetId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId,
+            "award_emoji");
+    return response.readEntity(new GenericType<List<AwardEmoji>>() {});
+  }
 
-    /**
-     * Get a list of award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to get the award emojis for
-     * @return a list of AwardEmoji for the specified note
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getIssueNoteAwardEmojis(Object projectIdOrPath, Long issueIid, Long noteId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-            "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId, "award_emoji");
-        return response.readEntity(new GenericType<List<AwardEmoji>>() {});
-    }
+  /**
+   * Get a list of award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to get the award emojis for
+   * @return a list of AwardEmoji for the specified note
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getIssueNoteAwardEmojis(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes",
+            noteId,
+            "award_emoji");
+    return response.readEntity(new GenericType<List<AwardEmoji>>() {});
+  }
 
-    /**
-     * Get a list of award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to get the award emojis for
-     * @return a list of AwardEmoji for the specified note
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getNoteAwardEmojis(Object projectIdOrPath, Long issueIid, Long noteId) throws GitLabApiException {
-        return getIssueNoteAwardEmojis(projectIdOrPath, issueIid, noteId);
-    }
+  /**
+   * Get a list of award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to get the award emojis for
+   * @return a list of AwardEmoji for the specified note
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getNoteAwardEmojis(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId)
+      throws GitLabApiException {
+    return getIssueNoteAwardEmojis(projectIdOrPath, issueIid, noteId);
+  }
 
-    /**
-     * Get a list of award emoji for the specified merge request note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID of the merge request that owns the note
-     * @param noteId the note ID to get the award emojis for
-     * @return a list of AwardEmoji for the specified note
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AwardEmoji> getMergeRequestNoteAwardEmojis(Object projectIdOrPath, Long mergeRequestIid, Long noteId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId, "award_emoji");
-        return response.readEntity(new GenericType<List<AwardEmoji>>() {});
-    }
+  /**
+   * Get a list of award emoji for the specified merge request note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID of the merge request that owns the note
+   * @param noteId the note ID to get the award emojis for
+   * @return a list of AwardEmoji for the specified note
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AwardEmoji> getMergeRequestNoteAwardEmojis(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long noteId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes",
+            noteId,
+            "award_emoji");
+    return response.readEntity(new GenericType<List<AwardEmoji>>() {});
+  }
 
-    /**
-     * Get the specified award emoji for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID to get the award emoji for
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji getIssueAwardEmoji(Object projectIdOrPath, Long issueIid, Long awardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "award_emoji", awardId);
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Get the specified award emoji for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID to get the award emoji for
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji getIssueAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long awardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "award_emoji",
+            awardId);
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Get the specified award emoji for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the award emoji for
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji getMergeRequestAwardEmoji(Object projectIdOrPath, Long mergeRequestIid, Long awardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "award_emoji", awardId);
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Get the specified award emoji for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the award emoji for
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji getMergeRequestAwardEmoji(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long awardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "award_emoji",
+            awardId);
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     *  Get the specified award emoji for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param snippetId the snippet ID to get the award emoji for
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji getSnippetAwardEmoji(Object projectIdOrPath, Long snippetId, Long awardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-                "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "award_emoji", awardId);
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Get the specified award emoji for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param snippetId the snippet ID to get the award emoji for
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji getSnippetAwardEmoji(
+      final Object projectIdOrPath, final Long snippetId, final Long awardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId,
+            "award_emoji",
+            awardId);
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Get the specified award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to get the award emoji from
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji getIssueNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, Long awardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-            "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId, "award_emoji", awardId);
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Get the specified award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to get the award emoji from
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji getIssueNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final Long awardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes",
+            noteId,
+            "award_emoji",
+            awardId);
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Get the specified award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to get the award emoji from
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated use {@link #getIssueNoteAwardEmoji(Object, Long, Long, Long)} instead
-     */
-    @Deprecated
-    public AwardEmoji getNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, Long awardId) throws GitLabApiException {
-    	return getIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, awardId);
-    }
+  /**
+   * Get the specified award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to get the award emoji from
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated use {@link #getIssueNoteAwardEmoji(Object, Long, Long, Long)} instead
+   */
+  @Deprecated
+  public AwardEmoji getNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final Long awardId)
+      throws GitLabApiException {
+    return getIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, awardId);
+  }
 
-    /**
-     * Get the specified award emoji for the specified merge request note.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID of the merge request that owns the note
-     * @param noteId the note ID to get the award emoji from
-     * @param awardId the ID of the award emoji to get
-     * @return an AwardEmoji instance for the specified award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji getMergeRequestNoteAwardEmoji(Object projectIdOrPath, Long mergeRequestIid, Long noteId, Long awardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(1, getDefaultPerPage()),
-            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId, "award_emoji", awardId);
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Get the specified award emoji for the specified merge request note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID of the merge request that owns the note
+   * @param noteId the note ID to get the award emoji from
+   * @param awardId the ID of the award emoji to get
+   * @return an AwardEmoji instance for the specified award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji getMergeRequestNoteAwardEmoji(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Long noteId,
+      final Long awardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(1, getDefaultPerPage()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes",
+            noteId,
+            "award_emoji",
+            awardId);
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Add an award emoji for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji addIssueAwardEmoji(Object projectIdOrPath, Long issueIid, String name) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("name",  name, true);
-        Response response = post(Response.Status.CREATED, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "award_emoji");
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Add an award emoji for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/award_emoji</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji addIssueAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm form = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "award_emoji");
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Add an award emoji to the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji addMergeRequestAwardEmoji(Object projectIdOrPath, Long mergeRequestIid, String name) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("name",  name, true);
-        Response response = post(Response.Status.CREATED, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "award_emoji");
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Add an award emoji to the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji addMergeRequestAwardEmoji(
+      final Object projectIdOrPath, final Long mergeRequestIid, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm form = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "award_emoji");
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     *  Add an award emoji to the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/snippets/:snippet_id/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param snippetId the snippet ID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji addSnippetAwardEmoji(Object projectIdOrPath, Long snippetId, String name) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("name",  name, true);
-        Response response = post(Response.Status.CREATED, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "award_emoji");
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Add an award emoji to the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/snippets/:snippet_id/award_emoji</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param snippetId the snippet ID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji addSnippetAwardEmoji(
+      final Object projectIdOrPath, final Long snippetId, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm form = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId,
+            "award_emoji");
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Add an award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:noteId/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji addIssueNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, String name) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("name",  name, true);
-        Response response = post(Response.Status.CREATED, form.asMap(),
-            "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId, "award_emoji");
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Add an award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:noteId/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji addIssueNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm form = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes",
+            noteId,
+            "award_emoji");
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Add an award emoji for the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:noteId/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID of the issue that owns the note
-     * @param noteId the note ID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated use {@link #addIssueNoteAwardEmoji(Object, Long, Long, String)}
-     */
-    @Deprecated
-    public AwardEmoji addNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, String name) throws GitLabApiException {
-        return addIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, name);
-    }
+  /**
+   * Add an award emoji for the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:noteId/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID of the issue that owns the note
+   * @param noteId the note ID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated use {@link #addIssueNoteAwardEmoji(Object, Long, Long, String)}
+   */
+  @Deprecated
+  public AwardEmoji addNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final String name)
+      throws GitLabApiException {
+    return addIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, name);
+  }
 
-    /**
-     * Add an award emoji for the specified merge request note.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/notes/:noteId/award_emoji</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID of the merge request that owns the note
-     * @param noteId the note ID to add the award emoji to
-     * @param name the name of the award emoji to add
-     * @return an AwardEmoji instance for the added award emoji
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AwardEmoji addMergeRequestAwardEmoji(Object projectIdOrPath, Integer mergeRequestIid, Integer noteId, String name) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("name",  name, true);
-        Response response = post(Response.Status.CREATED, form.asMap(),
-            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId, "award_emoji");
-        return (response.readEntity(AwardEmoji.class));
-    }
+  /**
+   * Add an award emoji for the specified merge request note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/notes/:noteId/award_emoji</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID of the merge request that owns the note
+   * @param noteId the note ID to add the award emoji to
+   * @param name the name of the award emoji to add
+   * @return an AwardEmoji instance for the added award emoji
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AwardEmoji addMergeRequestAwardEmoji(
+      final Object projectIdOrPath,
+      final Integer mergeRequestIid,
+      final Integer noteId,
+      final String name)
+      throws GitLabApiException {
+    final GitLabApiForm form = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes",
+            noteId,
+            "award_emoji");
+    return (response.readEntity(AwardEmoji.class));
+  }
 
-    /**
-     * Delete an award emoji from the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteIssueAwardEmoji(Object projectIdOrPath, Long issueIid, Long awardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "award_emoji", awardId);
-    }
+  /**
+   * Delete an award emoji from the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteIssueAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long awardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "award_emoji",
+        awardId);
+  }
 
-    /**
-     * Delete an award emoji from the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMergeRequestAwardEmoji(Object projectIdOrPath, Long mergeRequestIid, Long awardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "award_emoji", awardId);
-    }
+  /**
+   * Delete an award emoji from the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMergeRequestAwardEmoji(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long awardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "award_emoji",
+        awardId);
+  }
 
-    /**
-     *  Delete an award emoji from the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/snippets/:snippet_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param snippetId the snippet ID to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteSnippetAwardEmoji(Object projectIdOrPath, Long snippetId, Long awardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "award_emoji", awardId);
-    }
+  /**
+   * Delete an award emoji from the specified snippet.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/snippets/:snippet_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param snippetId the snippet ID to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteSnippetAwardEmoji(
+      final Object projectIdOrPath, final Long snippetId, final Long awardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "snippets",
+        snippetId,
+        "award_emoji",
+        awardId);
+  }
 
-    /**
-     *  Delete an award emoji from the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID that owns the note
-     * @param noteId the note ID of the note to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteIssueNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, Long awardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-            "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId, "award_emoji", awardId);
-    }
+  /**
+   * Delete an award emoji from the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID that owns the note
+   * @param noteId the note ID of the note to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteIssueNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final Long awardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "notes",
+        noteId,
+        "award_emoji",
+        awardId);
+  }
 
-    /**
-     *  Delete an award emoji from the specified issue note.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the issue IID that owns the note
-     * @param noteId the note ID of the note to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated use {@link #deleteIssueNoteAwardEmoji(Object, Long, Long, Long)} instead
-     */
-    @Deprecated
-    public void deleteNoteAwardEmoji(Object projectIdOrPath, Long issueIid, Long noteId, Long awardId) throws GitLabApiException {
-        deleteIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, awardId);
-    }
+  /**
+   * Delete an award emoji from the specified issue note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the issue IID that owns the note
+   * @param noteId the note ID of the note to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated use {@link #deleteIssueNoteAwardEmoji(Object, Long, Long, Long)} instead
+   */
+  @Deprecated
+  public void deleteNoteAwardEmoji(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final Long awardId)
+      throws GitLabApiException {
+    deleteIssueNoteAwardEmoji(projectIdOrPath, issueIid, noteId, awardId);
+  }
 
-    /**
-     *  Delete an award emoji from the specified merge request note.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji/:award_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID of the merge request that owns the note
-     * @param noteId the note ID of the note to delete the award emoji from
-     * @param awardId the ID of the award emoji to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMergeRequestNoteAwardEmoji(Object projectIdOrPath, Long mergeRequestIid, Long noteId, Long awardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId, "award_emoji", awardId);
-    }
+  /**
+   * Delete an award emoji from the specified merge request note.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/notes/:note_id/award_emoji/:award_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID of the merge request that owns the note
+   * @param noteId the note ID of the note to delete the award emoji from
+   * @param awardId the ID of the award emoji to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMergeRequestNoteAwardEmoji(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Long noteId,
+      final Long awardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "notes",
+        noteId,
+        "award_emoji",
+        awardId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/BoardsApi.java
+++ b/src/main/java/org/gitlab4j/api/BoardsApi.java
@@ -3,327 +3,453 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Board;
 import org.gitlab4j.api.models.BoardList;
 
 /**
  * This class implements the client side API for the GitLab Issue Boards API calls.
  *
- * NOTE: If a user is not a member of a group and the group is private,
- *       a GET request on that group will result to a 404 status code.
+ * <p>NOTE: If a user is not a member of a group and the group is private, a GET request on that
+ * group will result to a 404 status code.
  *
- * @see <a href="https://docs.gitlab.com/ce/api/boards.html">GitLab Issue Boards API Documentaion</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/boards.html">GitLab Issue Boards API
+ *     Documentaion</a>
  */
 public class BoardsApi extends AbstractApi {
 
-    public BoardsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public BoardsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Lists Issue Boards in the given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's issue boards
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Board> getBoards(Object projectIdOrPath) throws GitLabApiException {
-        return (getBoards(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Lists Issue Boards in the given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's issue boards
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Board> getBoards(final Object projectIdOrPath) throws GitLabApiException {
+    return (getBoards(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get all issue boards for the specified project using the specified page and per page setting
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of items per page
-     * @return a list of project's Boards in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Board> getBoards(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(javax.ws.rs.core.Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards");
-        return (response.readEntity(new GenericType<List<Board>>() {}));
-    }
+  /**
+   * Get all issue boards for the specified project using the specified page and per page setting
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of items per page
+   * @return a list of project's Boards in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Board> getBoards(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            jakarta.ws.rs.core.Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards");
+    return (response.readEntity(new GenericType<List<Board>>() {}));
+  }
 
-    /**
-     * Get a Pager of all issue boards for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of items per page
-     * @return a Pager of project's issue boards
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Board> getBoards(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Board>(this, Board.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards"));
-    }
+  /**
+   * Get a Pager of all issue boards for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of items per page
+   * @return a Pager of project's issue boards
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Board> getBoards(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Board>(
+        this,
+        Board.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "boards"));
+  }
 
-    /**
-     * Get a Stream of all issue boards for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's issue boards
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Board> getBoardsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getBoards(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of all issue boards for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's issue boards
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Board> getBoardsStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getBoards(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get a single issue board.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @return a Board instance for the specified board ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Board getBoard(Object projectIdOrPath, Long boardId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId);
-        return (response.readEntity(Board.class));
-    }
+  /**
+   * Get a single issue board.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @return a Board instance for the specified board ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Board getBoard(final Object projectIdOrPath, final Long boardId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId);
+    return (response.readEntity(Board.class));
+  }
 
-    /**
-     * Get an issue board as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @return the Board instance for the specified board ID as an Optional instance
-     */
-    public Optional<Board> getOptionalBoard(Object projectIdOrPath, Long boardId) {
-        try {
-            return (Optional.ofNullable(getBoard(projectIdOrPath, boardId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+  /**
+   * Get an issue board as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @return the Board instance for the specified board ID as an Optional instance
+   */
+  public Optional<Board> getOptionalBoard(final Object projectIdOrPath, final Long boardId) {
+    try {
+      return (Optional.ofNullable(getBoard(projectIdOrPath, boardId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Creates a new Issue Board.
-     *
-     * <p>NOTE: This is only available in GitLab EE</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/boards</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the new board
-     * @return the created Board instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Board createBoard(Object projectIdOrPath, String name) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("name", name, true);
-        Response response = post(Response.Status.CREATED, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "boards");
-        return (response.readEntity(Board.class));
-    }
+  /**
+   * Creates a new Issue Board.
+   *
+   * <p>NOTE: This is only available in GitLab EE
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/boards</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the new board
+   * @return the created Board instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Board createBoard(final Object projectIdOrPath, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("name", name, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards");
+    return (response.readEntity(Board.class));
+  }
 
-    /**
-     * Updates an existing Issue Board.
-     *
-     * <p>NOTE: This is only available in GitLab EE</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/boards/:board_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param boardId the ID of the board, required
-     * @param name the new name of the board, optional (can be null)
-     * @param assigneeId the assignee the board should be scoped to, optional (can be null)
-     * @param milestoneId the milestone the board should be scoped to, optional (can be null)
-     * @param labels a comma-separated list of label names which the board should be scoped to, optional (can be null)
-     * @param weight the weight range from 0 to 9, to which the board should be scoped to, optional (can be null)
-     * @return the updated Board instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BoardList updateBoard(Object projectIdOrPath, Long boardId, String name,
-            Long assigneeId, Long milestoneId, String labels, Integer weight) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name)
-                .withParam("assignee_id", assigneeId)
-                .withParam("milestone_id", milestoneId)
-                .withParam("labels", labels)
-                .withParam("weight", weight);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId);
-        return (response.readEntity(BoardList.class));
-    }
+  /**
+   * Updates an existing Issue Board.
+   *
+   * <p>NOTE: This is only available in GitLab EE
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/boards/:board_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param boardId the ID of the board, required
+   * @param name the new name of the board, optional (can be null)
+   * @param assigneeId the assignee the board should be scoped to, optional (can be null)
+   * @param milestoneId the milestone the board should be scoped to, optional (can be null)
+   * @param labels a comma-separated list of label names which the board should be scoped to,
+   *     optional (can be null)
+   * @param weight the weight range from 0 to 9, to which the board should be scoped to, optional
+   *     (can be null)
+   * @return the updated Board instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BoardList updateBoard(
+      final Object projectIdOrPath,
+      final Long boardId,
+      final String name,
+      final Long assigneeId,
+      final Long milestoneId,
+      final String labels,
+      final Integer weight)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name)
+            .withParam("assignee_id", assigneeId)
+            .withParam("milestone_id", milestoneId)
+            .withParam("labels", labels)
+            .withParam("weight", weight);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId);
+    return (response.readEntity(BoardList.class));
+  }
 
-    /**
-     * Soft deletes an existing Issue Board.
-     *
-     * <p>NOTE: This is only available in GitLab EE</p>
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/boards/:board_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteBoard(Object projectIdOrPath, Long boardId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId);
-    }
+  /**
+   * Soft deletes an existing Issue Board.
+   *
+   * <p>NOTE: This is only available in GitLab EE
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/boards/:board_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteBoard(final Object projectIdOrPath, final Long boardId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "boards",
+        boardId);
+  }
 
-    /**
-     * Get a list of the board’s lists. Does not include open and closed lists.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @return a list of the issue board's lists
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<BoardList> getBoardLists(Object projectIdOrPath, Long boardId) throws GitLabApiException {
-        return (getBoardLists(projectIdOrPath, boardId, getDefaultPerPage()).all());
-    }
+  /**
+   * Get a list of the board’s lists. Does not include open and closed lists.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @return a list of the issue board's lists
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<BoardList> getBoardLists(final Object projectIdOrPath, final Long boardId)
+      throws GitLabApiException {
+    return (getBoardLists(projectIdOrPath, boardId, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a list of the board’s lists for the specified project to using the specified page and per page setting.
-     * Does not include open and closed lists.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param page the page to get
-     * @param perPage the number of Boards per page
-     * @return a list of the issue board's lists in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<BoardList> getBoardLists(Object projectIdOrPath, Long boardId, int page, int perPage) throws GitLabApiException {
-        Response response = get(javax.ws.rs.core.Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists");
-        return (response.readEntity(new GenericType<List<BoardList>>() {}));
-    }
+  /**
+   * Get a list of the board’s lists for the specified project to using the specified page and per
+   * page setting. Does not include open and closed lists.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param page the page to get
+   * @param perPage the number of Boards per page
+   * @return a list of the issue board's lists in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<BoardList> getBoardLists(
+      final Object projectIdOrPath, final Long boardId, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            jakarta.ws.rs.core.Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId,
+            "lists");
+    return (response.readEntity(new GenericType<List<BoardList>>() {}));
+  }
 
-    /**
-     * Get a Pager of the board’s lists. Does not include open and closed lists.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param itemsPerPage the number of Board instances that will be fetched per page
-     * @return a Pager of the issue board's lists
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<BoardList> getBoardLists(Object projectIdOrPath, Long boardId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<BoardList>(this, BoardList.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists"));
-    }
+  /**
+   * Get a Pager of the board’s lists. Does not include open and closed lists.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param itemsPerPage the number of Board instances that will be fetched per page
+   * @return a Pager of the issue board's lists
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<BoardList> getBoardLists(
+      final Object projectIdOrPath, final Long boardId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<BoardList>(
+        this,
+        BoardList.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "boards",
+        boardId,
+        "lists"));
+  }
 
-    /**
-     * Get a Stream of the board’s lists. Does not include open and closed lists.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @return a Stream of the issue board's lists
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<BoardList> getBoardsListsStream(Object projectIdOrPath, Long boardId) throws GitLabApiException {
-        return (getBoardLists(projectIdOrPath, boardId, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of the board’s lists. Does not include open and closed lists.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @return a Stream of the issue board's lists
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<BoardList> getBoardsListsStream(final Object projectIdOrPath, final Long boardId)
+      throws GitLabApiException {
+    return (getBoardLists(projectIdOrPath, boardId, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get a single issue board list.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists/:list_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param listId the ID of the board lists to get
-     * @return a BoardList instance for the specified board ID and list ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BoardList getBoardList(Object projectIdOrPath, Long boardId, Long listId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists", listId);
-        return (response.readEntity(BoardList.class));
-    }
+  /**
+   * Get a single issue board list.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists/:list_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param listId the ID of the board lists to get
+   * @return a BoardList instance for the specified board ID and list ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BoardList getBoardList(final Object projectIdOrPath, final Long boardId, final Long listId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId,
+            "lists",
+            listId);
+    return (response.readEntity(BoardList.class));
+  }
 
-    /**
-     * Get a single issue board list as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists/:list_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param listId the ID of the board lists to get
-     * @return a BoardList instance for the specified board ID and list ID as an Optional instance
-     */
-    public Optional<BoardList> getOptionalBoardList(Object projectIdOrPath, Long boardId, Long listId) {
-        try {
-            return (Optional.ofNullable(getBoardList(projectIdOrPath, boardId, listId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+  /**
+   * Get a single issue board list as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/boards/:board_id/lists/:list_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param listId the ID of the board lists to get
+   * @return a BoardList instance for the specified board ID and list ID as an Optional instance
+   */
+  public Optional<BoardList> getOptionalBoardList(
+      final Object projectIdOrPath, final Long boardId, final Long listId) {
+    try {
+      return (Optional.ofNullable(getBoardList(projectIdOrPath, boardId, listId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Creates a new Issue Board list.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/boards/:board_id/lists</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param labelId the ID of the label
-     * @return the created BoardList instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BoardList createBoardList(Object projectIdOrPath, Long boardId, Long labelId) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("label_id", labelId, true);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists");
-        return (response.readEntity(BoardList.class));
-    }
+  /**
+   * Creates a new Issue Board list.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/boards/:board_id/lists</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param labelId the ID of the label
+   * @return the created BoardList instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BoardList createBoardList(
+      final Object projectIdOrPath, final Long boardId, final Long labelId)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("label_id", labelId, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId,
+            "lists");
+    return (response.readEntity(BoardList.class));
+  }
 
-    /**
-     * Updates an existing Issue Board list. This call is used to change list position.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/boards/:board_id/lists/:list_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param listId the ID of the list
-     * @param position the new position for the list
-     * @return the updated BoardList instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BoardList updateBoardList(Object projectIdOrPath, Long boardId, Long listId, Integer position) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("position", position, true);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists", listId);
-        return (response.readEntity(BoardList.class));
-    }
+  /**
+   * Updates an existing Issue Board list. This call is used to change list position.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/boards/:board_id/lists/:list_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param listId the ID of the list
+   * @param position the new position for the list
+   * @return the updated BoardList instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BoardList updateBoardList(
+      final Object projectIdOrPath, final Long boardId, final Long listId, final Integer position)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("position", position, true);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "boards",
+            boardId,
+            "lists",
+            listId);
+    return (response.readEntity(BoardList.class));
+  }
 
-    /**
-     * Soft deletes an existing Issue Board list. Only for admins and project owners.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/boards/:board_id/lists/:list_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param boardId the ID of the board
-     * @param listId the ID of the list
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteBoardList(Object projectIdOrPath, Long boardId, Long listId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "boards", boardId, "lists", listId);
-    }
+  /**
+   * Soft deletes an existing Issue Board list. Only for admins and project owners.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/boards/:board_id/lists/:list_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param boardId the ID of the board
+   * @param listId the ID of the list
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteBoardList(final Object projectIdOrPath, final Long boardId, final Long listId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "boards",
+        boardId,
+        "lists",
+        listId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/CommitsApi.java
+++ b/src/main/java/org/gitlab4j/api/CommitsApi.java
@@ -1,16 +1,14 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.models.Comment;
 import org.gitlab4j.api.models.Commit;
 import org.gitlab4j.api.models.CommitAction;
@@ -26,940 +24,1324 @@ import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.utils.ISO8601;
 
 /**
- * This class implements the client side API for the GitLab commits calls.
- * See <a href="https://docs.gitlab.com/ce/api/commits.html">Commits API at GitLab</a> for more information.
+ * This class implements the client side API for the GitLab commits calls. See <a
+ * href="https://docs.gitlab.com/ce/api/commits.html">Commits API at GitLab</a> for more
+ * information.
  */
 public class CommitsApi extends AbstractApi {
 
-    public CommitsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public CommitsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of all repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(final Object projectIdOrPath) throws GitLabApiException {
+    return (getCommits(
+            projectIdOrPath, null, null, null, null, true, null, null, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of commits per page
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @deprecated
+   */
+  @Deprecated
+  public List<Commit> getCommits(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, null, null, null, page, perPage));
+  }
+
+  /**
+   * Get a Pager of all repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Commit> getCommits(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, null, null, null, null, true, null, null, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of all repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Commit> getCommitStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getCommits(
+        projectIdOrPath, null, null, null, null, true, null, null, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a list of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path)
+      throws GitLabApiException {
+    return (getCommits(
+            projectIdOrPath, ref, since, until, path, null, null, null, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of file commits in a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits?path=:file_path</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param path the path to file of a project
+   * @return a list containing the commits for the specified project ID and file
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(final Object projectIdOrPath, final String ref, final String path)
+      throws GitLabApiException {
+    return (getCommits(
+            projectIdOrPath, ref, null, null, path, null, null, null, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(
+      final Object projectIdOrPath, final String ref, final Date since, final Date until)
+      throws GitLabApiException {
+    return (getCommits(
+            projectIdOrPath, ref, since, until, null, null, null, null, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param page the page to get
+   * @param perPage the number of commits per page
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @deprecated
+   */
+  @Deprecated
+  public List<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, ref, since, until, null, page, perPage));
+  }
+
+  /**
+   * Get a Stream of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @return a Stream containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Commit> getCommitsStream(
+      final Object projectIdOrPath, final String ref, final Date since, final Date until)
+      throws GitLabApiException {
+    return (getCommits(
+        projectIdOrPath, ref, since, until, null, null, null, null, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a Stream of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @return a Stream containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Commit> getCommitsStream(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path)
+      throws GitLabApiException {
+    return (getCommits(
+        projectIdOrPath, ref, since, until, path, null, null, null, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a list of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @param page the page to get
+   * @param perPage the number of commits per page
+   * @return a list containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @deprecated
+   */
+  @Deprecated
+  public List<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("ref_name", ref)
+            .withParam("since", ISO8601.toString(since, false))
+            .withParam("until", ISO8601.toString(until, false))
+            .withParam("path", (path == null ? null : urlEncode(path)))
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits");
+    return (response.readEntity(new GenericType<List<Commit>>() {}));
+  }
+
+  /**
+   * Get a Pager of repository commits in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    return getCommits(projectIdOrPath, ref, since, until, null, null, null, null, itemsPerPage);
+  }
+
+  /**
+   * Get a Pager of repository commits in a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @param path the path to file of a project
+   * @return a Pager containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, ref, since, until, path, null, null, null, itemsPerPage));
+  }
+
+  /**
+   * Get a List of the specified repository commits in a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @param all retrieve every commit from the repository
+   * @param withStats stats about each commit will be added to the response
+   * @param firstParent follow only the first parent commit upon seeing a merge commit
+   * @return a Pager containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path,
+      final Boolean all,
+      final Boolean withStats,
+      final Boolean firstParent)
+      throws GitLabApiException {
+    return (getCommits(
+            projectIdOrPath,
+            ref,
+            since,
+            until,
+            path,
+            all,
+            withStats,
+            firstParent,
+            getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a Pager of the specified repository commits in a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @param all retrieve every commit from the repository
+   * @param withStats stats about each commit will be added to the response
+   * @param firstParent follow only the first parent commit upon seeing a merge commit
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Commit> getCommits(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path,
+      final Boolean all,
+      final Boolean withStats,
+      final Boolean firstParent,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("ref_name", ref)
+            .withParam("since", ISO8601.toString(since, false))
+            .withParam("until", ISO8601.toString(until, false))
+            .withParam("path", (path == null ? null : urlEncode(path)))
+            .withParam("all", all)
+            .withParam("with_stats", withStats)
+            .withParam("first_parent", firstParent);
+    return (new Pager<Commit>(
+        this,
+        Commit.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits"));
+  }
+
+  /**
+   * Get a Stream of the specified repository commits in a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the name of a repository branch or tag or if not given the default branch
+   * @param since only commits after or on this date will be returned
+   * @param until only commits before or on this date will be returned
+   * @param path the path to file of a project
+   * @param all retrieve every commit from the repository
+   * @param withStats stats about each commit will be added to the response
+   * @param firstParent follow only the first parent commit upon seeing a merge commit
+   * @return a Stream containing the commits for the specified project ID
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Commit> getCommitsStream(
+      final Object projectIdOrPath,
+      final String ref,
+      final Date since,
+      final Date until,
+      final String path,
+      final Boolean all,
+      final Boolean withStats,
+      final Boolean firstParent)
+      throws GitLabApiException {
+    return (getCommits(
+        projectIdOrPath, ref, since, until, path, all, withStats, firstParent, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a specific commit identified by the commit hash or name of a branch or tag.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return the Commit instance for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Commit getCommit(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            urlEncode(sha));
+    return (response.readEntity(Commit.class));
+  }
+
+  /**
+   * Get a specific commit identified by the commit hash or name of a branch or tag as an Optional
+   * instance
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return the Commit for the specified project ID/sha pair as an Optional instance
+   */
+  public Optional<Commit> getOptionalCommit(final Object projectIdOrPath, final String sha) {
+    try {
+      return (Optional.ofNullable(getCommit(projectIdOrPath, sha)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a List of all references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a List of all references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public List<CommitRef> getCommitRefs(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager of references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public Pager<CommitRef> getCommitRefs(
+      final Object projectIdOrPath, final String sha, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of all references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a Stream of all references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public Stream<CommitRef> getCommitRefsStream(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a List of all references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
+   * @return a List of all references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public List<CommitRef> getCommitRefs(
+      final Object projectIdOrPath, final String sha, final RefType refType)
+      throws GitLabApiException {
+    return (getCommitRefs(projectIdOrPath, sha, refType, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager of references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public Pager<CommitRef> getCommitRefs(
+      final Object projectIdOrPath,
+      final String sha,
+      final CommitRef.RefType refType,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form form = new GitLabApiForm().withParam("type", refType);
+    return (new Pager<CommitRef>(
+        this,
+        CommitRef.class,
+        itemsPerPage,
+        form.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        urlEncode(sha),
+        "refs"));
+  }
+
+  /**
+   * Get a Stream of all references (from branches or tags) a commit is pushed to.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
+   * @return a Stream of all references (from branches or tags) a commit is pushed to
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   * @since Gitlab 10.6
+   */
+  public Stream<CommitRef> getCommitRefsStream(
+      final Object projectIdOrPath, final String sha, final RefType refType)
+      throws GitLabApiException {
+    return (getCommitRefs(projectIdOrPath, sha, refType, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of repository commit statuses that meet the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA
+   * @param filter the commit statuses file, contains ref, stage, name, all
+   * @return a List containing the commit statuses for the specified project and sha that meet the
+   *     provided filter
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<CommitStatus> getCommitStatuses(
+      final Object projectIdOrPath, final String sha, final CommitStatusFilter filter)
+      throws GitLabApiException {
+    return (getCommitStatuses(projectIdOrPath, sha, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of repository commit statuses that meet the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA
+   * @param filter the commit statuses file, contains ref, stage, name, all
+   * @param page the page to get
+   * @param perPage the number of commits statuses per page
+   * @return a List containing the commit statuses for the specified project and sha that meet the
+   *     provided filter
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<CommitStatus> getCommitStatuses(
+      final Object projectIdOrPath,
+      final String sha,
+      final CommitStatusFilter filter,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+
+    if (projectIdOrPath == null) {
+      throw new RuntimeException("projectIdOrPath cannot be null");
     }
 
-    /**
-     * Get a list of all repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, null, null, null, null, true, null, null, getDefaultPerPage()).all());
+    if (sha == null || sha.trim().isEmpty()) {
+      throw new RuntimeException("sha cannot be null");
     }
 
-    /**
-     * Get a list of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of commits per page
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @deprecated
-     */
-    @Deprecated
-    public List<Commit> getCommits(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, null, null, null, page, perPage));
+    final MultivaluedMap<String, String> queryParams =
+        (filter != null
+            ? filter.getQueryParams(page, perPage).asMap()
+            : getPageQueryParams(page, perPage));
+    final Response response =
+        get(
+            Response.Status.OK,
+            queryParams,
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            sha,
+            "statuses");
+    return (response.readEntity(new GenericType<List<CommitStatus>>() {}));
+  }
+
+  /**
+   * Get a Pager of repository commit statuses that meet the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA
+   * @param filter the commit statuses file, contains ref, stage, name, all
+   * @param itemsPerPage the number of CommitStatus instances that will be fetched per page
+   * @return a Pager containing the commit statuses for the specified project and sha that meet the
+   *     provided filter
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<CommitStatus> getCommitStatuses(
+      final Object projectIdOrPath,
+      final String sha,
+      final CommitStatusFilter filter,
+      final int itemsPerPage)
+      throws GitLabApiException {
+
+    if (projectIdOrPath == null) {
+      throw new RuntimeException("projectIdOrPath cannot be null");
     }
 
-    /**
-     * Get a Pager of all repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Commit> getCommits(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, null, null, null, null, true, null, null, itemsPerPage));
+    if (sha == null || sha.trim().isEmpty()) {
+      throw new RuntimeException("sha cannot be null");
     }
 
-    /**
-     * Get a Stream of all repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Commit> getCommitStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, null, null, null,null, true, null, null, getDefaultPerPage()).stream());
+    final MultivaluedMap<String, String> queryParams =
+        (filter != null ? filter.getQueryParams().asMap() : null);
+    return (new Pager<CommitStatus>(
+        this,
+        CommitStatus.class,
+        itemsPerPage,
+        queryParams,
+        "projects",
+        this.getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        sha,
+        "statuses"));
+  }
+
+  /**
+   * Get a Stream of repository commit statuses that meet the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA
+   * @param filter the commit statuses file, contains ref, stage, name, all
+   * @return a Stream containing the commit statuses for the specified project and sha that meet the
+   *     provided filter
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<CommitStatus> getCommitStatusesStream(
+      final Object projectIdOrPath, final String sha, final CommitStatusFilter filter)
+      throws GitLabApiException {
+    return (getCommitStatuses(projectIdOrPath, sha, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Add or update the build status of a commit. The following fluent methods are available on the
+   * CommitStatus instance for setting up the status:
+   *
+   * <pre><code>
+   * withCoverage(Float)
+   * withDescription(String)
+   * withName(String)
+   * withRef(String)
+   * withTargetUrl(String)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/statuses/:sha</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance (required)
+   * @param sha a commit SHA (required)
+   * @param state the state of the status. Can be one of the following: PENDING, RUNNING, SUCCESS,
+   *     FAILED, CANCELED (required)
+   * @param status the CommitSatus instance hoilding the optional parms: ref, name, target_url,
+   *     description, and coverage
+   * @return a CommitStatus instance with the updated info
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public CommitStatus addCommitStatus(
+      final Object projectIdOrPath,
+      final String sha,
+      final CommitBuildState state,
+      final CommitStatus status)
+      throws GitLabApiException {
+    return addCommitStatus(projectIdOrPath, sha, state, null, status);
+  }
+
+  /**
+   * Add or update the build status of a commit. The following fluent methods are available on the
+   * CommitStatus instance for setting up the status:
+   *
+   * <pre><code>
+   * withCoverage(Float)
+   * withDescription(String)
+   * withName(String)
+   * withRef(String)
+   * withTargetUrl(String)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/statuses/:sha</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance (required)
+   * @param sha a commit SHA (required)
+   * @param state the state of the status. Can be one of the following: PENDING, RUNNING, SUCCESS,
+   *     FAILED, CANCELED (required)
+   * @param pipelineId The ID of the pipeline to set status. Use in case of several pipeline on same
+   *     SHA (optional)
+   * @param status the CommitSatus instance hoilding the optional parms: ref, name, target_url,
+   *     description, and coverage
+   * @return a CommitStatus instance with the updated info
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public CommitStatus addCommitStatus(
+      final Object projectIdOrPath,
+      final String sha,
+      final CommitBuildState state,
+      final Long pipelineId,
+      final CommitStatus status)
+      throws GitLabApiException {
+
+    if (projectIdOrPath == null) {
+      throw new RuntimeException("projectIdOrPath cannot be null");
     }
 
-    /**
-     * Get a list of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until, String path) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, path, null, null, null, getDefaultPerPage()).all());
+    if (sha == null || sha.trim().isEmpty()) {
+      throw new RuntimeException("sha cannot be null");
     }
 
-    /**
-     * Get a list of file commits in a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits?path=:file_path</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param path the path to file of a project
-     * @return a list containing the commits for the specified project ID and file
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, String path) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, null, null, path, null, null, null, getDefaultPerPage()).all());
+    final GitLabApiForm formData = new GitLabApiForm().withParam("state", state, true);
+    if (status != null) {
+      formData
+          .withParam("ref", status.getRef())
+          .withParam("name", status.getName())
+          .withParam("target_url", status.getTargetUrl())
+          .withParam("description", status.getDescription())
+          .withParam("coverage", status.getCoverage());
     }
 
-    /**
-     * Get a list of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, null, null, null, null, getDefaultPerPage()).all());
+    if (pipelineId != null) {
+      formData.withParam("pipeline_id", pipelineId);
     }
 
-    /**
-     * Get a list of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param page the page to get
-     * @param perPage the number of commits per page
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @deprecated
-     */
-    @Deprecated
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until, int page, int perPage) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, null, page, perPage));
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "statuses",
+            sha);
+    return (response.readEntity(CommitStatus.class));
+  }
+
+  /**
+   * Get the list of diffs of a commit in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a List of Diff instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Diff> getDiff(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getDiff(projectIdOrPath, sha, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get the Pager of diffs of a commit in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param itemsPerPage the number of Diff instances that will be fetched per page
+   * @return a Pager of Diff instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Diff> getDiff(final Object projectIdOrPath, final String sha, final int itemsPerPage)
+      throws GitLabApiException {
+
+    if (projectIdOrPath == null) {
+      throw new RuntimeException("projectIdOrPath cannot be null");
     }
 
-    /**
-     * Get a Stream of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @return a Stream containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Commit> getCommitsStream(Object projectIdOrPath, String ref, Date since, Date until) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, null, null, null, null, getDefaultPerPage()).stream());
+    if (sha == null || sha.trim().isEmpty()) {
+      throw new RuntimeException("sha cannot be null");
     }
 
-    /**
-     * Get a Stream of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @return a Stream containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Commit> getCommitsStream(Object projectIdOrPath, String ref, Date since, Date until, String path) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, path, null, null, null, getDefaultPerPage()).stream());
+    return (new Pager<Diff>(
+        this,
+        Diff.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        sha,
+        "diff"));
+  }
+
+  /**
+   * Get the Diff of diffs of a commit in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a Stream of Diff instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Diff> getDiffStream(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getDiff(projectIdOrPath, sha, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the comments of a commit in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a List of Comment instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Comment> getComments(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getComments(projectIdOrPath, sha, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of the comments of a commit in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param itemsPerPage the number of Comment instances that will be fetched per page
+   * @return a List of Comment instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Comment> getComments(
+      final Object projectIdOrPath, final String sha, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Comment>(
+        this,
+        Comment.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        sha,
+        "comments");
+  }
+
+  /**
+   * Get the comments of a commit in a project as a Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return a Stream of Comment instances for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Comment> getCommentsStream(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getComments(projectIdOrPath, sha, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Add a comment to a commit. In order to post a comment in a particular line of a particular
+   * file, you must specify the full commit SHA, the path, the line and lineType should be NEW.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/comments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param note the text of the comment, required
+   * @param path the file path relative to the repository, optional
+   * @param line the line number where the comment should be placed, optional
+   * @param lineType the line type, optional
+   * @return a Comment instance for the posted comment
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Comment addComment(
+      final Object projectIdOrPath,
+      final String sha,
+      final String note,
+      final String path,
+      final Integer line,
+      final LineType lineType)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("note", note, true)
+            .withParam("path", path)
+            .withParam("line", line)
+            .withParam("line_type", lineType);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            sha,
+            "comments");
+    return (response.readEntity(Comment.class));
+  }
+
+  /**
+   * Add a comment to a commit.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/comments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @param note the text of the comment, required
+   * @return a Comment instance for the posted comment
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Comment addComment(final Object projectIdOrPath, final String sha, final String note)
+      throws GitLabApiException {
+    return (addComment(projectIdOrPath, sha, note, null, null, null));
+  }
+
+  /**
+   * Create a commit with single file and action.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branch tame of the branch to commit into. To create a new branch, also provide
+   *     startBranch
+   * @param commitMessage the commit message
+   * @param startBranch the name of the branch to start the new commit from
+   * @param authorEmail the commit author's email address
+   * @param authorName the commit author's name
+   * @param action the CommitAction to commit
+   * @return the created Commit instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Commit createCommit(
+      final Object projectIdOrPath,
+      final String branch,
+      final String commitMessage,
+      final String startBranch,
+      final String authorEmail,
+      final String authorName,
+      final CommitAction action)
+      throws GitLabApiException {
+
+    // Validate the action
+    if (action == null) {
+      throw new GitLabApiException("action cannot be null or empty.");
     }
 
-    /**
-     * Get a list of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @param page the page to get
-     * @param perPage the number of commits per page
-     * @return a list containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @deprecated
-     */
-    @Deprecated
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until, String path, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("ref_name", ref)
-                .withParam("since", ISO8601.toString(since, false))
-                .withParam("until", ISO8601.toString(until, false))
-                .withParam("path", (path == null ? null : urlEncode(path)))
-                .withParam(PAGE_PARAM,  page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits");
-        return (response.readEntity(new GenericType<List<Commit>>() {}));
+    return (createCommit(
+        projectIdOrPath,
+        branch,
+        commitMessage,
+        startBranch,
+        authorEmail,
+        authorName,
+        Arrays.asList(action)));
+  }
+
+  /**
+   * Create a commit with multiple files and actions.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branch tame of the branch to commit into. To create a new branch, also provide
+   *     startBranch
+   * @param commitMessage the commit message
+   * @param startBranch the name of the branch to start the new commit from
+   * @param authorEmail the commit author's email address
+   * @param authorName the commit author's name
+   * @param actions the array of CommitAction to commit as a batch
+   * @return the created Commit instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Commit createCommit(
+      final Object projectIdOrPath,
+      final String branch,
+      final String commitMessage,
+      final String startBranch,
+      final String authorEmail,
+      final String authorName,
+      final List<CommitAction> actions)
+      throws GitLabApiException {
+
+    final CommitPayload payload =
+        new CommitPayload()
+            .withBranch(branch)
+            .withStartBranch(startBranch)
+            .withCommitMessage(commitMessage)
+            .withAuthorEmail(authorEmail)
+            .withAuthorName(authorName)
+            .withActions(actions);
+    return (createCommit(projectIdOrPath, payload));
+  }
+
+  /**
+   * Create a commit with multiple files and actions.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param payload a CommitPayload instance holding the parameters for the commit
+   * @return the created Commit instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Commit createCommit(final Object projectIdOrPath, final CommitPayload payload)
+      throws GitLabApiException {
+
+    // Validate the actions
+    final List<CommitAction> actions = payload.getActions();
+    if (actions == null || actions.isEmpty()) {
+      throw new GitLabApiException("actions cannot be null or empty.");
     }
 
-    /**
-     * Get a Pager of repository commits in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until, int itemsPerPage) throws GitLabApiException {
-        return getCommits(projectIdOrPath, ref, since, until, null, null, null, null, itemsPerPage);
-    }
+    for (final CommitAction action : actions) {
 
-    /**
-     * Get a Pager of repository commits in a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @param path the path to file of a project
-     * @return a Pager containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until, String path, int itemsPerPage) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, path, null, null, null, itemsPerPage));
-    }
-
-    /**
-     * Get a List of the specified repository commits in a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @param all retrieve every commit from the repository
-     * @param withStats stats about each commit will be added to the response
-     * @param firstParent follow only the first parent commit upon seeing a merge commit
-     * @return a Pager containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until,
-            String path, Boolean all, Boolean withStats, Boolean firstParent) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, path, all, withStats, firstParent, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the specified repository commits in a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @param all retrieve every commit from the repository
-     * @param withStats stats about each commit will be added to the response
-     * @param firstParent follow only the first parent commit upon seeing a merge commit
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Commit> getCommits(Object projectIdOrPath, String ref, Date since, Date until,
-            String path, Boolean all, Boolean withStats, Boolean firstParent, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("ref_name", ref)
-                .withParam("since", ISO8601.toString(since, false))
-                .withParam("until", ISO8601.toString(until, false))
-                .withParam("path", (path == null ? null : urlEncode(path)))
-                .withParam("all", all)
-                .withParam("with_stats", withStats)
-                .withParam("first_parent", firstParent);
-        return (new Pager<Commit>(this, Commit.class, itemsPerPage, formData.asMap(),  "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits"));
-    }
-
-    /**
-     * Get a Stream of the specified repository commits in a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the name of a repository branch or tag or if not given the default branch
-     * @param since only commits after or on this date will be returned
-     * @param until only commits before or on this date will be returned
-     * @param path the path to file of a project
-     * @param all retrieve every commit from the repository
-     * @param withStats stats about each commit will be added to the response
-     * @param firstParent follow only the first parent commit upon seeing a merge commit
-     * @return a Stream containing the commits for the specified project ID
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Commit> getCommitsStream(Object projectIdOrPath, String ref, Date since, Date until,
-            String path, Boolean all, Boolean withStats, Boolean firstParent) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, ref, since, until, path, all, withStats, firstParent, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific commit identified by the commit hash or name of a branch or tag.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return the Commit instance for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Commit getCommit(Object projectIdOrPath, String sha) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha));
-        return (response.readEntity(Commit.class));
-    }
-
-    /**
-     * Get a specific commit identified by the commit hash or name of a branch or tag as an Optional instance
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return the Commit for the specified project ID/sha pair as an Optional instance
-     */
-    public Optional<Commit> getOptionalCommit(Object projectIdOrPath, String sha) {
-        try {
-            return (Optional.ofNullable(getCommit(projectIdOrPath, sha)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
+      // File content is required for create and update
+      final Action actionType = action.getAction();
+      if (actionType == Action.CREATE || actionType == Action.UPDATE) {
+        final String content = action.getContent();
+        if (content == null) {
+          throw new GitLabApiException("Content cannot be null for create or update actions.");
         }
+      }
     }
 
-    /**
-     * Get a List of all references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a List of all references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public List<CommitRef> getCommitRefs(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, getDefaultPerPage()).all());
+    if (payload.getStartProject() != null) {
+      payload.setStartProject(getProjectIdOrPath(payload.getStartProject()));
     }
 
-    /**
-     * Get a Pager of references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager of references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public Pager<CommitRef> getCommitRefs(Object projectIdOrPath, String sha, int itemsPerPage) throws GitLabApiException {
-        return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, itemsPerPage));
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            payload,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits");
+    return (response.readEntity(Commit.class));
+  }
+
+  /**
+   * Reverts a commit in a given branch.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/revert</code></pre>
+   *
+   * @since GitLab 11.5
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA to revert
+   * @param branch the target branch to revert the commit on
+   * @return a Commit instance holding the reverted commit
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Commit revertCommit(final Object projectIdOrPath, final String sha, final String branch)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            sha,
+            "revert");
+    return (response.readEntity(Commit.class));
+  }
+
+  /**
+   * Cherry picks a commit in a given branch.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/cherry_pick</code></pre>
+   *
+   * @since GitLab 8.15
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA to cherry pick
+   * @param branch the target branch to cherry pick the commit on
+   * @return a Commit instance holding the cherry picked commit
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Commit cherryPickCommit(
+      final Object projectIdOrPath, final String sha, final String branch)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            sha,
+            "cherry_pick");
+    return (response.readEntity(Commit.class));
+  }
+
+  /**
+   * Get a list of Merge Requests related to the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA to get merge requests for
+   * @return a list containing the MergeRequest instances for the specified project/SHA
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<MergeRequest> getMergeRequests(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, sha, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of Merge Requests related to the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA to get merge requests for
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the MergeRequest instances for the specified project/SHA
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath, final String sha, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<MergeRequest>(
+        this,
+        MergeRequest.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        urlEncode(sha),
+        "merge_requests"));
+  }
+
+  /**
+   * Get a Stream of Merge Requests related to the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the commit SHA to get merge requests for
+   * @return a Stream containing the MergeRequest instances for the specified project/SHA
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<MergeRequest> getMergeRequestsStream(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, sha, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the GPG signature from a commit, if it is signed. For unsigned commits, it results in a 404
+   * response.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/signature</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return the GpgSignature instance for the specified project ID/sha pair
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public GpgSignature getGpgSignature(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            urlEncode(sha),
+            "signature");
+    return (response.readEntity(GpgSignature.class));
+  }
+
+  /**
+   * Get the GPG signature from a commit as an Optional instance
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/signature</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha a commit hash or name of a branch or tag
+   * @return the GpgSignature for the specified project ID/sha pair as an Optional instance
+   */
+  public Optional<GpgSignature> getOptionalGpgSignature(
+      final Object projectIdOrPath, final String sha) {
+    try {
+      return (Optional.ofNullable(getGpgSignature(projectIdOrPath, sha)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
-
-    /**
-     * Get a Stream of all references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a Stream of all references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public Stream<CommitRef> getCommitRefsStream(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getCommitRefs(projectIdOrPath, sha, RefType.ALL, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a List of all references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
-     * @return a List of all references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public List<CommitRef> getCommitRefs(Object projectIdOrPath, String sha, RefType refType) throws GitLabApiException {
-        return (getCommitRefs(projectIdOrPath, sha, refType, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager of references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public Pager<CommitRef> getCommitRefs(Object projectIdOrPath, String sha, CommitRef.RefType refType, int itemsPerPage) throws GitLabApiException {
-        Form form = new GitLabApiForm().withParam("type", refType);
-        return (new Pager<CommitRef>(this, CommitRef.class, itemsPerPage, form.asMap(),  "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha), "refs"));
-    }
-
-    /**
-     * Get a Stream of all references (from branches or tags) a commit is pushed to.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/refs?type=:refType</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param refType the scope of commits. Possible values branch, tag, all. Default is all.
-     * @return a Stream of all references (from branches or tags) a commit is pushed to
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     * @since Gitlab 10.6
-     */
-    public Stream<CommitRef> getCommitRefsStream(Object projectIdOrPath, String sha, RefType refType) throws GitLabApiException {
-        return (getCommitRefs(projectIdOrPath, sha, refType, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of repository commit statuses that meet the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA
-     * @param filter the commit statuses file, contains ref, stage, name, all
-     * @return a List containing the commit statuses for the specified project and sha that meet the provided filter
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<CommitStatus> getCommitStatuses(Object projectIdOrPath, String sha, CommitStatusFilter filter) throws GitLabApiException {
-        return (getCommitStatuses(projectIdOrPath, sha, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of repository commit statuses that meet the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA
-     * @param filter the commit statuses file, contains ref, stage, name, all
-     * @param page the page to get
-     * @param perPage the number of commits statuses per page
-     * @return a List containing the commit statuses for the specified project and sha that meet the provided filter
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<CommitStatus> getCommitStatuses(Object projectIdOrPath, String sha,
-            CommitStatusFilter filter, int page, int perPage) throws GitLabApiException {
-
-        if (projectIdOrPath == null) {
-            throw new RuntimeException("projectIdOrPath cannot be null");
-        }
-
-        if (sha == null || sha.trim().isEmpty()) {
-            throw new RuntimeException("sha cannot be null");
-        }
-
-        MultivaluedMap<String, String> queryParams = (filter != null ?
-                filter.getQueryParams(page, perPage).asMap() : getPageQueryParams(page, perPage));
-        Response response = get(Response.Status.OK, queryParams,
-                "projects", this.getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "statuses");
-        return (response.readEntity(new GenericType<List<CommitStatus>>() {}));
-    }
-
-    /**
-     * Get a Pager of repository commit statuses that meet the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA
-     * @param filter the commit statuses file, contains ref, stage, name, all
-     * @param itemsPerPage the number of CommitStatus instances that will be fetched per page
-     * @return a Pager containing the commit statuses for the specified project and sha that meet the provided filter
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<CommitStatus> getCommitStatuses(Object projectIdOrPath, String sha,
-            CommitStatusFilter filter, int itemsPerPage) throws GitLabApiException {
-
-        if (projectIdOrPath == null) {
-            throw new RuntimeException("projectIdOrPath cannot be null");
-        }
-
-        if (sha == null || sha.trim().isEmpty()) {
-            throw new RuntimeException("sha cannot be null");
-        }
-
-        MultivaluedMap<String, String> queryParams = (filter != null ? filter.getQueryParams().asMap() : null);
-        return (new Pager<CommitStatus>(this, CommitStatus.class, itemsPerPage, queryParams,
-                "projects", this.getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "statuses"));
-    }
-
-    /**
-     * Get a Stream of repository commit statuses that meet the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/statuses</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA
-     * @param filter the commit statuses file, contains ref, stage, name, all
-     * @return a Stream containing the commit statuses for the specified project and sha that meet the provided filter
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<CommitStatus> getCommitStatusesStream(Object projectIdOrPath, String sha, CommitStatusFilter filter) throws GitLabApiException {
-        return (getCommitStatuses(projectIdOrPath, sha, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * <p>Add or update the build status of a commit.  The following fluent methods are available on the
-     * CommitStatus instance for setting up the status:</p>
-     * <pre><code>
-     * withCoverage(Float)
-     * withDescription(String)
-     * withName(String)
-     * withRef(String)
-     * withTargetUrl(String)
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/statuses/:sha</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance (required)
-     * @param sha a commit SHA (required)
-     * @param state the state of the status. Can be one of the following: PENDING, RUNNING, SUCCESS, FAILED, CANCELED (required)
-     * @param status the CommitSatus instance hoilding the optional parms: ref, name, target_url, description, and coverage
-     * @return a CommitStatus instance with the updated info
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public CommitStatus addCommitStatus(Object projectIdOrPath, String sha, CommitBuildState state, CommitStatus status) throws GitLabApiException {
-        return addCommitStatus(projectIdOrPath, sha, state, null, status);
-    }
-
-    /**
-     * <p>Add or update the build status of a commit.  The following fluent methods are available on the
-     * CommitStatus instance for setting up the status:</p>
-     * <pre><code>
-     * withCoverage(Float)
-     * withDescription(String)
-     * withName(String)
-     * withRef(String)
-     * withTargetUrl(String)
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/statuses/:sha</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance (required)
-     * @param sha a commit SHA (required)
-     * @param state the state of the status. Can be one of the following: PENDING, RUNNING, SUCCESS, FAILED, CANCELED (required)
-     * @param pipelineId 	The ID of the pipeline to set status. Use in case of several pipeline on same SHA (optional)
-     * @param status the CommitSatus instance hoilding the optional parms: ref, name, target_url, description, and coverage
-     * @return a CommitStatus instance with the updated info
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public CommitStatus addCommitStatus(Object projectIdOrPath, String sha, CommitBuildState state, Long pipelineId, CommitStatus status) throws GitLabApiException {
-
-        if (projectIdOrPath == null) {
-            throw new RuntimeException("projectIdOrPath cannot be null");
-        }
-
-        if (sha == null || sha.trim().isEmpty()) {
-            throw new RuntimeException("sha cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("state", state, true);
-        if (status != null) {
-            formData.withParam("ref", status.getRef())
-                .withParam("name", status.getName())
-                .withParam("target_url", status.getTargetUrl())
-                .withParam("description", status.getDescription())
-                .withParam("coverage", status.getCoverage());
-        }
-
-        if (pipelineId != null) {
-            formData.withParam("pipeline_id", pipelineId);
-        }
-
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "statuses", sha);
-        return (response.readEntity(CommitStatus.class));
-    }
-
-    /**
-     * Get the list of diffs of a commit in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a List of Diff instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Diff> getDiff(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getDiff(projectIdOrPath, sha, getDefaultPerPage()).all());
-    }
-
-    /**
-      * Get the Pager of diffs of a commit in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param itemsPerPage the number of Diff instances that will be fetched per page
-     * @return a Pager of Diff instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Diff> getDiff(Object projectIdOrPath, String sha, int itemsPerPage) throws GitLabApiException {
-
-        if (projectIdOrPath == null) {
-            throw new RuntimeException("projectIdOrPath cannot be null");
-        }
-
-        if (sha == null || sha.trim().isEmpty()) {
-            throw new RuntimeException("sha cannot be null");
-        }
-
-        return (new Pager<Diff>(this, Diff.class, itemsPerPage, null,
-            "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "diff"));
-    }
-
-    /**
-      * Get the Diff of diffs of a commit in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/diff</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a Stream of Diff instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Diff> getDiffStream(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getDiff(projectIdOrPath, sha, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the comments of a commit in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a List of Comment instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Comment> getComments(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getComments(projectIdOrPath, sha, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the comments of a commit in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param itemsPerPage the number of Comment instances that will be fetched per page
-     * @return a List of Comment instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Comment> getComments(Object projectIdOrPath, String sha, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Comment>(this, Comment.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "comments");
-    }
-
-    /**
-     * Get the comments of a commit in a project as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/comments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return a Stream of Comment instances for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Comment> getCommentsStream(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getComments(projectIdOrPath, sha, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Add a comment to a commit.  In order to post a comment in a particular line of a particular file,
-     * you must specify the full commit SHA, the path, the line and lineType should be NEW.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/comments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param note the text of the comment, required
-     * @param path the file path relative to the repository, optional
-     * @param line the line number where the comment should be placed, optional
-     * @param lineType the line type, optional
-     * @return a Comment instance for the posted comment
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Comment addComment(Object projectIdOrPath, String sha, String note, String path, Integer line, LineType lineType) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("note", note, true)
-                .withParam("path", path)
-                .withParam("line", line)
-                .withParam("line_type", lineType);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "comments");
-        return (response.readEntity(Comment.class));
-    }
-
-    /**
-     * Add a comment to a commit.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/comments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @param note the text of the comment, required
-     * @return a Comment instance for the posted comment
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Comment addComment(Object projectIdOrPath, String sha, String note) throws GitLabApiException {
-        return (addComment(projectIdOrPath, sha, note, null, null, null));
-    }
-
-    /**
-     * Create a commit with single file and action.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branch tame of the branch to commit into. To create a new branch, also provide startBranch
-     * @param commitMessage the commit message
-     * @param startBranch the name of the branch to start the new commit from
-     * @param authorEmail the commit author's email address
-     * @param authorName the commit author's name
-     * @param action the CommitAction to commit
-     * @return the created Commit instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Commit createCommit(Object projectIdOrPath, String branch, String commitMessage, String startBranch,
-            String authorEmail, String authorName, CommitAction action) throws GitLabApiException {
-
-        // Validate the action
-        if (action == null) {
-            throw new GitLabApiException("action cannot be null or empty.");
-        }
-
-        return (createCommit(projectIdOrPath, branch, commitMessage, startBranch,
-                authorEmail, authorName, Arrays.asList(action)));
-    }
-
-    /**
-     * Create a commit with multiple files and actions.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branch tame of the branch to commit into. To create a new branch, also provide startBranch
-     * @param commitMessage the commit message
-     * @param startBranch the name of the branch to start the new commit from
-     * @param authorEmail the commit author's email address
-     * @param authorName the commit author's name
-     * @param actions the array of CommitAction to commit as a batch
-     * @return the created Commit instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Commit createCommit(Object projectIdOrPath, String branch, String commitMessage, String startBranch,
-            String authorEmail, String authorName, List<CommitAction> actions) throws GitLabApiException {
-
-        CommitPayload payload = new CommitPayload()
-                .withBranch(branch)
-                .withStartBranch(startBranch)
-                .withCommitMessage(commitMessage)
-                .withAuthorEmail(authorEmail)
-                .withAuthorName(authorName)
-                .withActions(actions);
-        return (createCommit(projectIdOrPath, payload));
-    }
-
-    /**
-     * Create a commit with multiple files and actions.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param payload a CommitPayload instance holding the parameters for the commit
-     * @return the created Commit instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Commit createCommit(Object projectIdOrPath, CommitPayload payload) throws GitLabApiException {
-
-        // Validate the actions
-	List<CommitAction> actions = payload.getActions();
-        if (actions == null || actions.isEmpty()) {
-            throw new GitLabApiException("actions cannot be null or empty.");
-        }
-
-        for (CommitAction action : actions) {
-
-            // File content is required for create and update
-            Action actionType = action.getAction();
-            if (actionType == Action.CREATE || actionType == Action.UPDATE) {
-                String content = action.getContent();
-                if (content == null) {
-                    throw new GitLabApiException("Content cannot be null for create or update actions.");
-                }
-            }
-        }
-
-        if (payload.getStartProject() != null) {
-            payload.setStartProject(getProjectIdOrPath(payload.getStartProject()));
-        }
-
-        Response response = post(Response.Status.CREATED, payload,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits");
-        return (response.readEntity(Commit.class));
-    }
-
-    /**
-     * Reverts a commit in a given branch.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/revert</code></pre>
-     *
-     * @since GitLab 11.5
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA to revert
-     * @param branch the target branch to revert the commit on
-     * @return a Commit instance holding the reverted commit
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Commit revertCommit(Object projectIdOrPath, String sha, String branch) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "revert");
-        return (response.readEntity(Commit.class));
-    }
-
-    /**
-     * Cherry picks a commit in a given branch.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:sha/cherry_pick</code></pre>
-     *
-     * @since GitLab 8.15
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA to cherry pick
-     * @param branch the target branch to cherry pick the commit on
-     * @return a Commit instance holding the cherry picked commit
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Commit cherryPickCommit(Object projectIdOrPath, String sha, String branch) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", sha, "cherry_pick");
-        return (response.readEntity(Commit.class));
-    }
-
-    /**
-     * Get a list of Merge Requests related to the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA to get merge requests for
-     * @return a list containing the MergeRequest instances for the specified project/SHA
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, sha, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of Merge Requests related to the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA to get merge requests for
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the MergeRequest instances for the specified project/SHA
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<MergeRequest> getMergeRequests(Object projectIdOrPath, String sha, int itemsPerPage) throws GitLabApiException {
-	return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha), "merge_requests"));
-    }
-
-    /**
-     * Get a Stream of Merge Requests related to the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the commit SHA to get merge requests for
-     * @return a Stream containing the MergeRequest instances for the specified project/SHA
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<MergeRequest> getMergeRequestsStream(Object projectIdOrPath, String sha) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, sha, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the GPG signature from a commit, if it is signed. For unsigned commits, it results in a 404 response.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/signature</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return the GpgSignature instance for the specified project ID/sha pair
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public GpgSignature getGpgSignature(Object projectIdOrPath, String sha) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-        	"projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", urlEncode(sha), "signature");
-        return (response.readEntity(GpgSignature.class));
-    }
-
-    /**
-     * Get the GPG signature from a commit as an Optional instance
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:sha/signature</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha a commit hash or name of a branch or tag
-     * @return the GpgSignature for the specified project ID/sha pair as an Optional instance
-     */
-    public Optional<GpgSignature> getOptionalGpgSignature(Object projectIdOrPath, String sha) {
-        try {
-            return (Optional.ofNullable(getGpgSignature(projectIdOrPath, sha)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ContainerRegistryApi.java
+++ b/src/main/java/org/gitlab4j/api/ContainerRegistryApi.java
@@ -26,236 +26,334 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.RegistryRepository;
 import org.gitlab4j.api.models.RegistryRepositoryTag;
 
 /**
- * <p>This class implements the client side API for the GitLab Container Registry API.
- * See <a href="https://docs.gitlab.com/ee/api/container_registry.html">Container Registry API at GitLab</a>
- * for more information.</p>
+ * This class implements the client side API for the GitLab Container Registry API. See <a
+ * href="https://docs.gitlab.com/ee/api/container_registry.html">Container Registry API at
+ * GitLab</a> for more information.
  */
 public class ContainerRegistryApi extends AbstractApi {
 
-    public ContainerRegistryApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ContainerRegistryApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of registry repositories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of pages in the project's registry repositories
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<RegistryRepository> getRepositories(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getRepositories(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of registry repositories in a project that fall within the specified page
+   * parameters.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of Package instances per page
+   * @return a list of registry repositories for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<RegistryRepository> getRepositories(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "registry",
+            "repositories");
+    return response.readEntity(new GenericType<List<RegistryRepository>>() {});
+  }
+
+  /**
+   * Get a Pager of registry repositories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of RegistryRepository instances per page
+   * @return a Pager of registry repositories for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<RegistryRepository> getRepositories(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<>(
+        this,
+        RegistryRepository.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "registry",
+        "repositories"));
+  }
+
+  /**
+   * Get a Stream of registry repositories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of pages in the project's registry repositories
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<RegistryRepository> getRepositoriesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getRepositories(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Delete a repository in registry.
+   *
+   * <p>This operation is executed asynchronously and might take some time to get executed.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteRepository(final Object projectIdOrPath, final Long repositoryId)
+      throws GitLabApiException {
+
+    if (repositoryId == null) {
+      throw new RuntimeException("repositoryId cannot be null");
     }
 
-    /**
-     * Get a list of registry repositories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of pages in the project's registry repositories
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<RegistryRepository> getRepositories(Object projectIdOrPath) throws GitLabApiException {
-        return (getRepositories(projectIdOrPath, getDefaultPerPage()).all());
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "registry",
+        "repositories",
+        repositoryId);
+  }
+
+  /**
+   * Get a list of tags for given registry repository.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @return a list of Repository Tags for the specified repository ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<RegistryRepositoryTag> getRepositoryTags(
+      final Object projectIdOrPath, final Long repositoryId) throws GitLabApiException {
+    return getRepositoryTags(projectIdOrPath, repositoryId, getDefaultPerPage()).all();
+  }
+
+  /**
+   * Get a Pager of tags for given registry repository.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @param itemsPerPage the number of RegistryRepositoryTag instances per page
+   * @return a Pager of Repository Tags for the specified repository ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<RegistryRepositoryTag> getRepositoryTags(
+      final Object projectIdOrPath, final Long repositoryId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<>(
+        this,
+        RegistryRepositoryTag.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "registry",
+        "repositories",
+        repositoryId,
+        "tags"));
+  }
+
+  /**
+   * Get a Stream of tags for given registry repository.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @return a list of Repository Tags for the specified repository ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<RegistryRepositoryTag> getRepositoryTagsStream(
+      final Object projectIdOrPath, final Long repositoryId) throws GitLabApiException {
+    return getRepositoryTags(projectIdOrPath, repositoryId, getDefaultPerPage()).stream();
+  }
+
+  /**
+   * Get details of a registry repository tag.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @param tagName the name of tag
+   * @return the Repository Tag for the specified repository ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RegistryRepositoryTag getRepositoryTag(
+      final Object projectIdOrPath, final Long repositoryId, final String tagName)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "registry",
+            "repositories",
+            repositoryId,
+            "tags",
+            tagName);
+    return response.readEntity(new GenericType<RegistryRepositoryTag>() {});
+  }
+
+  /**
+   * Get details of a registry repository tag as the value of an Optional.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @param tagName the name of tag
+   * @return the Repository Tag for the specified repository ID as the value of the Optional
+   */
+  public Optional<RegistryRepositoryTag> getOptionalRepositoryTag(
+      final Object projectIdOrPath, final Long repositoryId, final String tagName) {
+    try {
+      return (Optional.ofNullable(getRepositoryTag(projectIdOrPath, repositoryId, tagName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Delete a registry repository tag.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @param tagName the name of the tag to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteRepositoryTag(
+      final Object projectIdOrPath, final Long repositoryId, final String tagName)
+      throws GitLabApiException {
+
+    if (repositoryId == null) {
+      throw new RuntimeException("repositoryId cannot be null");
     }
 
-    /**
-     * Get a list of registry repositories in a project that fall within the specified page parameters.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page            the page to get
-     * @param perPage         the number of Package instances per page
-     * @return a list of registry repositories for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<RegistryRepository> getRepositories(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories");
-        return response.readEntity(new GenericType<List<RegistryRepository>>() {
-        });
-    }
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "registry",
+        "repositories",
+        repositoryId,
+        "tags",
+        tagName);
+  }
 
-    /**
-     * Get a Pager of registry repositories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage    the number of RegistryRepository instances per page
-     * @return a Pager of registry repositories for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<RegistryRepository> getRepositories(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<>(this, RegistryRepository.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories"));
-    }
+  /**
+   * Delete repository tags in bulk based on given criteria.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id/tags</code>
+   * </pre>
+   *
+   * <p>This API call performs the following operations:
+   *
+   * <ol>
+   *   <li>It orders all tags by creation date. The creation date is the time of the manifest
+   *       creation, not the time of tag push.
+   *   <li>It removes only the tags matching the given name_regex.
+   *   <li>It never removes the tag named latest.
+   *   <li>It keeps N latest matching tags (if keep_n is specified).
+   *   <li>It only removes tags that are older than X amount of time (if older_than is specified).
+   *   <li>It schedules the asynchronous job to be executed in the background.
+   * </ol>
+   *
+   * <p>These operations are executed asynchronously and it might take time to get executed. You can
+   * run this at most once an hour for a given container repository.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param repositoryId the ID of registry repository
+   * @param nameRegex the regex of the name to delete. To delete all tags specify <code>.*</code>.
+   * @param keepN the amount of latest tags of given name to keep.
+   * @param olderThan tags to delete that are older than the given time, written in human readable
+   *     form <code>1h</code>, <code>1d</code>, <code>1month</code>.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteRepositoryTags(
+      final Object projectIdOrPath,
+      final Long repositoryId,
+      final String nameRegex,
+      final Integer keepN,
+      final String olderThan)
+      throws GitLabApiException {
 
-    /**
-     * Get a Stream of registry repositories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of pages in the project's registry repositories
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<RegistryRepository> getRepositoriesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getRepositories(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name_regex", nameRegex, true)
+            .withParam("keep_n", keepN)
+            .withParam("older_than", olderThan);
 
-    /**
-     * Delete a repository in registry.
-     * <p>
-     * This operation is executed asynchronously and might take some time to get executed.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId    the ID of registry repository
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteRepository(Object projectIdOrPath, Long repositoryId) throws GitLabApiException {
-
-        if (repositoryId == null) {
-            throw new RuntimeException("repositoryId cannot be null");
-        }
-
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories", repositoryId);
-    }
-
-    /**
-     * Get a list of tags for given registry repository.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @return a list of Repository Tags for the specified repository ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<RegistryRepositoryTag> getRepositoryTags(Object projectIdOrPath, Long repositoryId) throws GitLabApiException {
-        return getRepositoryTags(projectIdOrPath, repositoryId, getDefaultPerPage()).all();
-    }
-
-    /**
-     * Get a Pager of tags for given registry repository.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @param itemsPerPage the number of RegistryRepositoryTag instances per page
-     * @return a Pager of Repository Tags for the specified repository ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<RegistryRepositoryTag> getRepositoryTags(Object projectIdOrPath, Long repositoryId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<>(this, RegistryRepositoryTag.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories", repositoryId, "tags"));
-    }
-
-    /**
-     * Get a Stream of tags for given registry repository.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @return a list of Repository Tags for the specified repository ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<RegistryRepositoryTag> getRepositoryTagsStream(Object projectIdOrPath, Long repositoryId) throws GitLabApiException {
-        return getRepositoryTags(projectIdOrPath, repositoryId, getDefaultPerPage()).stream();
-    }
-
-    /**
-     * Get details of a registry repository tag.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId    the ID of registry repository
-     * @param tagName         the name of tag
-     * @return the Repository Tag for the specified repository ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RegistryRepositoryTag getRepositoryTag(Object projectIdOrPath, Long repositoryId, String tagName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories", repositoryId, "tags", tagName);
-        return response.readEntity(new GenericType<RegistryRepositoryTag>() {
-        });
-    }
-
-    /**
-     * Get details of a registry repository tag as the value of an Optional.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @param tagName the name of tag
-     * @return the Repository Tag for the specified repository ID as the value of the Optional
-     */
-    public Optional<RegistryRepositoryTag> getOptionalRepositoryTag(Object projectIdOrPath, Long repositoryId, String tagName) {
-        try {
-            return (Optional.ofNullable(getRepositoryTag(projectIdOrPath, repositoryId, tagName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Delete a registry repository tag.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id/tags/:tag_name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @param tagName the name of the tag to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteRepositoryTag(Object projectIdOrPath, Long repositoryId, String tagName) throws GitLabApiException {
-
-        if (repositoryId == null) {
-            throw new RuntimeException("repositoryId cannot be null");
-        }
-
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories", repositoryId, "tags", tagName);
-    }
-
-    /**
-     * Delete repository tags in bulk based on given criteria.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/registry/repositories/:repository_id/tags</code></pre>
-     * <p>
-     * This API call performs the following operations:
-     * <ol>
-     * <li>It orders all tags by creation date. The creation date is the time of the manifest creation,
-     * not the time of tag push.</li>
-     * <li>It removes only the tags matching the given name_regex.</li>
-     * <li>It never removes the tag named latest.</li>
-     * <li>It keeps N latest matching tags (if keep_n is specified).</li>
-     * <li>It only removes tags that are older than X amount of time (if older_than is specified).</li>
-     * <li>It schedules the asynchronous job to be executed in the background.</li>
-     * </ol>
-     * <p>
-     * These operations are executed asynchronously and it might take time to get executed. You can run this at most
-     * once an hour for a given container repository.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param repositoryId the ID of registry repository
-     * @param nameRegex the regex of the name to delete. To delete all tags specify <code>.*</code>.
-     * @param keepN the amount of latest tags of given name to keep.
-     * @param olderThan tags to delete that are older than the given time, written in human readable form
-     *                        <code>1h</code>, <code>1d</code>, <code>1month</code>.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteRepositoryTags(Object projectIdOrPath, Long repositoryId, String nameRegex, Integer keepN, String olderThan) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name_regex", nameRegex, true)
-                .withParam("keep_n", keepN)
-                .withParam("older_than", olderThan);
-
-        delete(Response.Status.NO_CONTENT, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "registry", "repositories", repositoryId, "tags");
-    }
+    delete(
+        Response.Status.NO_CONTENT,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "registry",
+        "repositories",
+        repositoryId,
+        "tags");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/DeployKeysApi.java
+++ b/src/main/java/org/gitlab4j/api/DeployKeysApi.java
@@ -3,11 +3,9 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.DeployKey;
 
 /**
@@ -15,7 +13,7 @@ import org.gitlab4j.api.models.DeployKey;
  */
 public class DeployKeysApi extends AbstractApi {
 
-    public DeployKeysApi(GitLabApi gitLabApi) {
+    public DeployKeysApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -32,7 +30,7 @@ public class DeployKeysApi extends AbstractApi {
     }
 
     /**
-     * Get a list of all deploy keys across all projects of the GitLab instance using the specified page and per page settings. 
+     * Get a list of all deploy keys across all projects of the GitLab instance using the specified page and per page settings.
      * This method requires admin access.
      *
      * <pre><code>GitLab Endpoint: GET /deploy_keys</code></pre>
@@ -42,8 +40,8 @@ public class DeployKeysApi extends AbstractApi {
      * @return the list of DeployKey in the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public List<DeployKey> getDeployKeys(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "deploy_keys");
+    public List<DeployKey> getDeployKeys(final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "deploy_keys");
         return (response.readEntity(new GenericType<List<DeployKey>>() {}));
     }
 
@@ -56,7 +54,7 @@ public class DeployKeysApi extends AbstractApi {
      * @return a Pager of DeployKey
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<DeployKey> getDeployKeys(int itemsPerPage) throws GitLabApiException {
+    public Pager<DeployKey> getDeployKeys(final int itemsPerPage) throws GitLabApiException {
         return (new Pager<DeployKey>(this, DeployKey.class, itemsPerPage, null, "deploy_keys"));
     }
 
@@ -81,12 +79,12 @@ public class DeployKeysApi extends AbstractApi {
      * @return a list of DeployKey
      * @throws GitLabApiException if any exception occurs
      */
-    public List<DeployKey> getProjectDeployKeys(Object projectIdOrPath) throws GitLabApiException {
+    public List<DeployKey> getProjectDeployKeys(final Object projectIdOrPath) throws GitLabApiException {
         return (getProjectDeployKeys(projectIdOrPath, getDefaultPerPage()).all());
     }
 
     /**
-     * Get a list of the deploy keys for the specified project using the specified page and per page settings. 
+     * Get a list of the deploy keys for the specified project using the specified page and per page settings.
      * This method requires admin access.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_keys</code></pre>
@@ -97,8 +95,8 @@ public class DeployKeysApi extends AbstractApi {
      * @return the list of DeployKey in the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public List<DeployKey> getProjectDeployKeys(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
+    public List<DeployKey> getProjectDeployKeys(final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
                 "projects", getProjectIdOrPath(projectIdOrPath), "deploy_keys");
         return (response.readEntity(new GenericType<List<DeployKey>>() {}));
     }
@@ -113,7 +111,7 @@ public class DeployKeysApi extends AbstractApi {
      * @return a Pager of DeployKey
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<DeployKey> getProjectDeployKeys(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
+    public Pager<DeployKey> getProjectDeployKeys(final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
         return (new Pager<DeployKey>(this, DeployKey.class, itemsPerPage, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "deploy_keys"));
     }
@@ -127,7 +125,7 @@ public class DeployKeysApi extends AbstractApi {
      * @return a list of DeployKey
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<DeployKey> getProjectDeployKeysStream(Object projectIdOrPath) throws GitLabApiException {
+    public Stream<DeployKey> getProjectDeployKeysStream(final Object projectIdOrPath) throws GitLabApiException {
         return (getProjectDeployKeys(projectIdOrPath, getDefaultPerPage()).stream());
     }
 
@@ -141,13 +139,13 @@ public class DeployKeysApi extends AbstractApi {
      * @return the DeployKey instance for the specified project ID and key ID
      * @throws GitLabApiException if any exception occurs
      */
-    public DeployKey getDeployKey(Object projectIdOrPath, Long keyId) throws GitLabApiException {
+    public DeployKey getDeployKey(final Object projectIdOrPath, final Long keyId) throws GitLabApiException {
 
         if (keyId == null) {
             throw new RuntimeException("keyId cannot be null");
         }
 
-        Response response = get(Response.Status.OK, null,
+        final Response response = get(Response.Status.OK, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "deploy_keys", keyId);
         return (response.readEntity(DeployKey.class));
     }
@@ -161,10 +159,10 @@ public class DeployKeysApi extends AbstractApi {
      * @param keyId the ID of the deploy key to delete
      * @return the DeployKey for the specified project ID and key ID as an Optional instance
      */
-    public Optional<DeployKey> getOptionalDeployKey(Object projectIdOrPath, Long keyId) {
+    public Optional<DeployKey> getOptionalDeployKey(final Object projectIdOrPath, final Long keyId) {
         try {
             return (Optional.ofNullable(getDeployKey(projectIdOrPath, keyId)));
-        } catch (GitLabApiException glae) {
+        } catch (final GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
     }
@@ -181,13 +179,13 @@ public class DeployKeysApi extends AbstractApi {
      * @return an DeployKey instance with info on the added deploy key
      * @throws GitLabApiException if any exception occurs
      */
-    public DeployKey addDeployKey(Object projectIdOrPath, String title, String key, Boolean canPush) throws GitLabApiException {
+    public DeployKey addDeployKey(final Object projectIdOrPath, final String title, final String key, final Boolean canPush) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("title", title, true)
                 .withParam("key", key, true)
                 .withParam("can_push",  canPush);
-        Response response = post(Response.Status.CREATED, formData,
+        final Response response = post(Response.Status.CREATED, formData,
                 "projects", getProjectIdOrPath(projectIdOrPath), "deploy_keys");
         return (response.readEntity(DeployKey.class));
     }
@@ -204,7 +202,7 @@ public class DeployKeysApi extends AbstractApi {
      * @return an updated DeployKey instance
      * @throws GitLabApiException if any exception occurs
      */
-    public DeployKey updateDeployKey(Object projectIdOrPath, Long deployKeyId, String title, Boolean canPush) throws GitLabApiException {
+    public DeployKey updateDeployKey(final Object projectIdOrPath, final Long deployKeyId, final String title, final Boolean canPush) throws GitLabApiException {
 
         if (deployKeyId == null) {
             throw new RuntimeException("deployKeyId cannot be null");
@@ -228,7 +226,7 @@ public class DeployKeysApi extends AbstractApi {
      * @param keyId the ID of the deploy key to delete
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteDeployKey(Object projectIdOrPath, Long keyId) throws GitLabApiException {
+    public void deleteDeployKey(final Object projectIdOrPath, final Long keyId) throws GitLabApiException {
 
         if (keyId == null) {
             throw new RuntimeException("keyId cannot be null");
@@ -247,13 +245,13 @@ public class DeployKeysApi extends AbstractApi {
      * @return an DeployKey instance with info on the enabled deploy key
      * @throws GitLabApiException if any exception occurs
      */
-    public DeployKey enableDeployKey(Object projectIdOrPath, Long keyId) throws GitLabApiException {
+    public DeployKey enableDeployKey(final Object projectIdOrPath, final Long keyId) throws GitLabApiException {
 
         if (keyId == null) {
             throw new RuntimeException("keyId cannot be null");
         }
 
-        Response response = post(Response.Status.CREATED, (Form)null,
+        final Response response = post(Response.Status.CREATED, (Form)null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "deploy_keys", keyId, "enable");
         return (response.readEntity(DeployKey.class));
     }

--- a/src/main/java/org/gitlab4j/api/DeployTokensApi.java
+++ b/src/main/java/org/gitlab4j/api/DeployTokensApi.java
@@ -1,238 +1,318 @@
 package org.gitlab4j.api;
 
-import org.gitlab4j.api.models.DeployToken;
-
-import javax.ws.rs.core.Response;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
+import jakarta.ws.rs.core.Response;
+import org.gitlab4j.api.models.DeployToken;
 
 /**
- * This class implements the client side API for the GitLab Deploy Tokens API calls.
- * See https://docs.gitlab.com/ee/api/deploy_tokens.html
+ * This class implements the client side API for the GitLab Deploy Tokens API calls. See
+ * https://docs.gitlab.com/ee/api/deploy_tokens.html
  *
- * Since GitLab 12.9
- *
+ * <p>Since GitLab 12.9
  */
 public class DeployTokensApi extends AbstractApi {
 
-    public DeployTokensApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public DeployTokensApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /* ************************************************************************************************
+   * Global Deploy Token API
+   */
+
+  /**
+   * Get a list of all deploy tokens across the GitLab instance. This endpoint requires admin
+   * access.
+   *
+   * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
+   *
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<DeployToken> getDeployTokens() throws GitLabApiException {
+    return (getDeployTokens(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of all deploy tokens across all projects of the GitLab instance. This method
+   * requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
+   *
+   * @param itemsPerPage the number of DeployToken instances that will be fetched per page
+   * @return a Pager of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<DeployToken> getDeployTokens(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<>(this, DeployToken.class, itemsPerPage, null, "deploy_tokens"));
+  }
+
+  /**
+   * Get a Stream of all deploy tokens across all projects of the GitLab instance. This method
+   * requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
+   *
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<DeployToken> getDeployTokensStream() throws GitLabApiException {
+    return (getDeployTokens(getDefaultPerPage()).stream());
+  }
+
+  /* ************************************************************************************************
+   * Projects Deploy Token API
+   */
+
+  /**
+   * Get a list of the deploy tokens for the specified project. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<DeployToken> getProjectDeployTokens(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectDeployTokens(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of the deploy tokens for the specified project. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance@param projectId the ID of the project
+   * @param itemsPerPage the number of DeployToken instances that will be fetched per page
+   * @return a Pager of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<DeployToken> getProjectDeployTokens(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<>(
+        this,
+        DeployToken.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "deploy_tokens"));
+  }
+
+  /**
+   * Get a list of the deploy tokens for the specified project. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<DeployToken> getProjectDeployTokensStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectDeployTokens(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Creates a new deploy token for a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/deploy_tokens</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the new deploy token’s name, required
+   * @param expiresAt expiration date for the deploy token. Currently documented as not required but
+   *     api fails if not provided. Does not expire if no value is provided.
+   * @param username the username for deploy token. Currently documented as not required but api
+   *     fails if not provided. Default is gitlab+deploy-token-{n}
+   * @param scopes indicates the deploy token scopes. Must be at least one of {@link
+   *     org.gitlab4j.api.Constants.DeployTokenScope}.
+   * @return an DeployToken instance with info on the added deploy token
+   * @throws GitLabApiException if any exception occurs
+   */
+  public DeployToken addProjectDeployToken(
+      final Object projectIdOrPath,
+      final String name,
+      final Date expiresAt,
+      final String username,
+      final List<DeployTokenScope> scopes)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam(
+                "expires_at",
+                expiresAt,
+                true) // Currently documented as not required but api fails if not provided
+            .withParam(
+                "username",
+                username,
+                true) // Currently documented as not required but api fails if not provided
+            .withParam("scopes", scopes, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "deploy_tokens");
+    return (response.readEntity(DeployToken.class));
+  }
+
+  /**
+   * Removes a deploy token from the group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/deploy_tokens/:token_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param tokenId the ID of the deploy token to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteProjectDeployToken(final Object projectIdOrPath, final Long tokenId)
+      throws GitLabApiException {
+
+    if (tokenId == null) {
+      throw new RuntimeException("tokenId cannot be null");
     }
 
-    /* ************************************************************************************************
-     * Global Deploy Token API
-     */
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "deploy_tokens",
+        tokenId);
+  }
 
-    /**
-     * Get a list of all deploy tokens across the GitLab instance. This endpoint requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
-     *
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<DeployToken> getDeployTokens() throws GitLabApiException {
-        return (getDeployTokens(getDefaultPerPage()).all());
+  /* ************************************************************************************************
+   * Groups Deploy Token API
+   */
+
+  /**
+   * Get a list of the deploy tokens for the specified group. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<DeployToken> getGroupDeployTokens(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getGroupDeployTokens(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of the deploy tokens for the specified group. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group
+   *     instance@param groupId the ID of the group
+   * @param itemsPerPage the number of DeployToken instances that will be fetched per page
+   * @return a Pager of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<DeployToken> getGroupDeployTokens(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<>(
+        this,
+        DeployToken.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "deploy_tokens"));
+  }
+
+  /**
+   * Get a list of the deploy tokens for the specified group. This method requires admin access.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a list of DeployToken
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<DeployToken> getGroupDeployTokensStream(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getGroupDeployTokens(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Creates a new deploy token for a group.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/deploy_tokens</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param name the new deploy token’s name, required
+   * @param expiresAt expiration date for the deploy token. Currently documented as not required but
+   *     api fails if not provided. Does not expire if no value is provided.
+   * @param username the username for deploy token. Currently documented as not required but api
+   *     fails if not provided. Default is gitlab+deploy-token-{n}
+   * @param scopes indicates the deploy token scopes. Must be at least one of {@link
+   *     org.gitlab4j.api.Constants.DeployTokenScope}.
+   * @return an DeployToken instance with info on the added deploy token
+   * @throws GitLabApiException if any exception occurs
+   */
+  public DeployToken addGroupDeployToken(
+      final Object groupIdOrPath,
+      final String name,
+      final Date expiresAt,
+      final String username,
+      final List<DeployTokenScope> scopes)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam(
+                "expires_at",
+                expiresAt,
+                true) // Currently documented as not required but api fails if not provided
+            .withParam(
+                "username",
+                username,
+                true) // Currently documented as not required but api fails if not provided
+            .withParam("scopes", scopes, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "deploy_tokens");
+    return (response.readEntity(DeployToken.class));
+  }
+
+  /**
+   * Removes a deploy token from the group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/deploy_tokens/:token_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param tokenId the ID of the deploy token to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteGroupDeployToken(final Object groupIdOrPath, final Long tokenId)
+      throws GitLabApiException {
+
+    if (tokenId == null) {
+      throw new RuntimeException("tokenId cannot be null");
     }
 
-    /**
-     * Get a Pager of all deploy tokens across all projects of the GitLab instance. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
-     *
-     * @param itemsPerPage the number of DeployToken instances that will be fetched per page
-     * @return a Pager of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<DeployToken> getDeployTokens(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<>(this, DeployToken.class, itemsPerPage, null, "deploy_tokens"));
-    }
-
-    /**
-     * Get a Stream of all deploy tokens across all projects of the GitLab instance. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /deploy_tokens</code></pre>
-     *
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<DeployToken> getDeployTokensStream() throws GitLabApiException {
-        return (getDeployTokens(getDefaultPerPage()).stream());
-    }
-
-    /* ************************************************************************************************
-     * Projects Deploy Token API
-     */
-
-    /**
-     * Get a list of the deploy tokens for the specified project. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<DeployToken> getProjectDeployTokens(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectDeployTokens(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the deploy tokens for the specified project. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance@param projectId the ID of the project
-     * @param itemsPerPage the number of DeployToken instances that will be fetched per page
-     * @return a Pager of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<DeployToken> getProjectDeployTokens(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<>(this, DeployToken.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "deploy_tokens"));
-    }
-
-    /**
-     * Get a list of the deploy tokens for the specified project. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deploy_tokens</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<DeployToken> getProjectDeployTokensStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectDeployTokens(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Creates a new deploy token for a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/deploy_tokens</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the new deploy token’s name, required
-     * @param expiresAt expiration date for the deploy token. Currently documented as not required but api fails if not provided. Does not expire if no value is provided.
-     * @param username the username for deploy token. Currently documented as not required but api fails if not provided. Default is gitlab+deploy-token-{n}
-     * @param scopes indicates the deploy token scopes. Must be at least one of {@link org.gitlab4j.api.Constants.DeployTokenScope}.
-     * @return an DeployToken instance with info on the added deploy token
-     * @throws GitLabApiException if any exception occurs
-     */
-    public DeployToken addProjectDeployToken(Object projectIdOrPath, String name, Date expiresAt, String username, List<DeployTokenScope> scopes) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("expires_at", expiresAt, true) // Currently documented as not required but api fails if not provided
-                .withParam("username",  username, true)// Currently documented as not required but api fails if not provided
-                .withParam("scopes", scopes, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "deploy_tokens");
-        return (response.readEntity(DeployToken.class));
-    }
-
-    /**
-     * Removes a deploy token from the group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/deploy_tokens/:token_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param tokenId the ID of the deploy token to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteProjectDeployToken(Object projectIdOrPath, Long tokenId) throws GitLabApiException {
-
-        if (tokenId == null) {
-            throw new RuntimeException("tokenId cannot be null");
-        }
-
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "deploy_tokens", tokenId);
-    }
-
-    /* ************************************************************************************************
-     * Groups Deploy Token API
-     */
-
-    /**
-     * Get a list of the deploy tokens for the specified group. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<DeployToken> getGroupDeployTokens(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupDeployTokens(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the deploy tokens for the specified group. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance@param groupId the ID of the group
-     * @param itemsPerPage the number of DeployToken instances that will be fetched per page
-     * @return a Pager of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<DeployToken> getGroupDeployTokens(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<>(this, DeployToken.class, itemsPerPage, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "deploy_tokens"));
-    }
-
-    /**
-     * Get a list of the deploy tokens for the specified group. This method requires admin access.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/deploy_tokens</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a list of DeployToken
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<DeployToken> getGroupDeployTokensStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupDeployTokens(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Creates a new deploy token for a group.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/deploy_tokens</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param name the new deploy token’s name, required
-     * @param expiresAt expiration date for the deploy token. Currently documented as not required but api fails if not provided. Does not expire if no value is provided.
-     * @param username the username for deploy token. Currently documented as not required but api fails if not provided. Default is gitlab+deploy-token-{n}
-     * @param scopes indicates the deploy token scopes. Must be at least one of {@link org.gitlab4j.api.Constants.DeployTokenScope}.
-     * @return an DeployToken instance with info on the added deploy token
-     * @throws GitLabApiException if any exception occurs
-     */
-    public DeployToken addGroupDeployToken(Object groupIdOrPath, String name, Date expiresAt, String username, List<DeployTokenScope> scopes) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("expires_at", expiresAt, true) // Currently documented as not required but api fails if not provided
-                .withParam("username",  username, true)// Currently documented as not required but api fails if not provided
-                .withParam("scopes", scopes, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "groups", getGroupIdOrPath(groupIdOrPath), "deploy_tokens");
-        return (response.readEntity(DeployToken.class));
-    }
-
-    /**
-     * Removes a deploy token from the group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/deploy_tokens/:token_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param tokenId the ID of the deploy token to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteGroupDeployToken(Object groupIdOrPath, Long tokenId) throws GitLabApiException {
-
-        if (tokenId == null) {
-            throw new RuntimeException("tokenId cannot be null");
-        }
-
-        delete(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "deploy_tokens", tokenId);
-    }
-
+    delete(
+        Response.Status.OK,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "deploy_tokens",
+        tokenId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/DeploymentsApi.java
+++ b/src/main/java/org/gitlab4j/api/DeploymentsApi.java
@@ -3,238 +3,304 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Deployment;
 import org.gitlab4j.api.models.DeploymentFilter;
 import org.gitlab4j.api.models.MergeRequest;
 
 /**
- * This class implements the client side API for the GitLab Deployments API calls.
- * See https://docs.gitlab.com/ee/api/deployments.html
- *
+ * This class implements the client side API for the GitLab Deployments API calls. See
+ * https://docs.gitlab.com/ee/api/deployments.html
  */
 public class DeploymentsApi extends AbstractApi {
 
-    public DeploymentsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public DeploymentsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of Deployments
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Deployment> getProjectDeployments(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectDeployments(projectIdOrPath, null, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of all deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Deployments instances that will be fetched per page
+   * @return a Pager of Deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Deployment> getProjectDeployments(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (getProjectDeployments(projectIdOrPath, null, itemsPerPage));
+  }
+
+  /**
+   * Get a Pager of all deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
+   * @return a Pager of Deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Deployment> getProjectDeployments(
+      final Object projectIdOrPath, final DeploymentFilter filter) throws GitLabApiException {
+    return (getProjectDeployments(projectIdOrPath, filter, getDefaultPerPage()));
+  }
+
+  /**
+   * Get a Pager of all deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
+   * @param itemsPerPage the number of Deployments instances that will be fetched per page
+   * @return a Pager of Deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Deployment> getProjectDeployments(
+      final Object projectIdOrPath, final DeploymentFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
+    return (new Pager<Deployment>(
+        this,
+        Deployment.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "deployments"));
+  }
+
+  /**
+   * Get a Stream of all deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of Deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Deployment> getProjectDeploymentsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectDeployments(projectIdOrPath, null, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a Stream of all deployments for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
+   * @return a list of Deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Deployment> getProjectDeploymentsStream(
+      final Object projectIdOrPath, final DeploymentFilter filter) throws GitLabApiException {
+    return (getProjectDeployments(projectIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific deployment.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId the ID of a project's deployment
+   * @return the specified Deployment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Deployment getDeployment(final Object projectIdOrPath, final Long deploymentId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "deployments",
+            deploymentId);
+    return (response.readEntity(Deployment.class));
+  }
+
+  /**
+   * Get a specific deployment as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId the ID of a project's deployment
+   * @return the specified Deployment as an Optional instance
+   */
+  public Optional<Deployment> getOptionalDeployment(
+      final Object projectIdOrPath, final Long deploymentId) {
+    try {
+      return (Optional.ofNullable(getDeployment(projectIdOrPath, deploymentId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a new deployment for a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/deployments</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param environment The name of the environment to create the deployment for, required
+   * @param sha The SHA of the commit that is deployed, required
+   * @param ref The name of the branch or tag that is deployed, required
+   * @param tag A boolean that indicates if the deployed ref is a tag (true) or not (false),
+   *     required
+   * @param status The status to filter deployments by, required
+   * @return a Deployment instance with info on the added deployment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Deployment addDeployment(
+      final Object projectIdOrPath,
+      final String environment,
+      final String sha,
+      final String ref,
+      final Boolean tag,
+      final DeploymentStatus status)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("environment", environment, true)
+            .withParam("sha", sha, true)
+            .withParam("ref", ref, true)
+            .withParam("tag", tag, true)
+            .withParam("status", status, true);
+
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "deployments");
+    return (response.readEntity(Deployment.class));
+  }
+
+  /**
+   * Updates an existing project deploy key.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/deployments/:key_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId The ID of the deployment to update, required
+   * @param status The new status of the deployment, required
+   * @return an updated Deployment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Deployment updateDeployment(
+      final Object projectIdOrPath, final Long deploymentId, final DeploymentStatus status)
+      throws GitLabApiException {
+
+    if (deploymentId == null) {
+      throw new RuntimeException("deploymentId cannot be null");
     }
 
-    /**
-     * Get a list of deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of Deployments
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Deployment> getProjectDeployments(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectDeployments(projectIdOrPath, null, getDefaultPerPage()).all());
-    }
+    final Deployment deployment = new Deployment();
+    deployment.setStatus(status);
+    final Response response =
+        put(
+            Response.Status.OK,
+            deployment,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "deployments",
+            deploymentId);
 
-    /**
-     * Get a Pager of all deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Deployments instances that will be fetched per page
-     * @return a Pager of Deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Deployment> getProjectDeployments(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getProjectDeployments(projectIdOrPath, null, itemsPerPage));
-    }
+    return (response.readEntity(Deployment.class));
+  }
 
-    /**
-     * Get a Pager of all deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter  {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
-     * @return a Pager of Deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Deployment> getProjectDeployments(Object projectIdOrPath, DeploymentFilter filter) throws GitLabApiException {
-        return (getProjectDeployments(projectIdOrPath, filter, getDefaultPerPage()));
-    }
+  /**
+   * Get a list of Merge Requests shipped with a given deployment.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId The ID of the deployment to update, required
+   * @return a list containing the MergeRequest instances shipped with a given deployment
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<MergeRequest> getMergeRequests(final Object projectIdOrPath, final Long deploymentId)
+      throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, deploymentId, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Pager of all deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter  {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
-     * @param itemsPerPage the number of Deployments instances that will be fetched per page
-     * @return a Pager of Deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Deployment> getProjectDeployments(Object projectIdOrPath, DeploymentFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
-        return (new Pager<Deployment>(this, Deployment.class, itemsPerPage, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "deployments"));
-    }
+  /**
+   * Get a Pager of Merge Requests shipped with a given deployment.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId The ID of the deployment to update, required
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the MergeRequest instances shipped with a given deployment
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath, final Long deploymentId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<MergeRequest>(
+        this,
+        MergeRequest.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "deployments",
+        deploymentId,
+        "merge_requests"));
+  }
 
-    /**
-     * Get a Stream of all deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of Deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Deployment> getProjectDeploymentsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectDeployments(projectIdOrPath, null, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a Stream of all deployments for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter  {@link DeploymentFilter} a DeploymentFilter instance with the filter settings
-     * @return a list of Deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Deployment> getProjectDeploymentsStream(Object projectIdOrPath, DeploymentFilter filter) throws GitLabApiException {
-        return (getProjectDeployments(projectIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific deployment.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId the ID of a project's deployment
-     * @return the specified Deployment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Deployment getDeployment(Object projectIdOrPath, Long deploymentId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "deployments", deploymentId);
-        return (response.readEntity(Deployment.class));
-    }
-
-    /**
-     * Get a specific deployment as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId the ID of a project's deployment
-     * @return the specified Deployment as an Optional instance
-     */
-    public Optional<Deployment> getOptionalDeployment(Object projectIdOrPath, Long deploymentId) {
-        try {
-            return (Optional.ofNullable(getDeployment(projectIdOrPath, deploymentId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new deployment for a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/deployments</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param environment The name of the environment to create the deployment for, required
-     * @param sha The SHA of the commit that is deployed, required
-     * @param ref The name of the branch or tag that is deployed, required
-     * @param tag A boolean that indicates if the deployed ref is a tag (true) or not (false), required
-     * @param status The status to filter deployments by, required
-     * @return a Deployment instance with info on the added deployment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Deployment addDeployment(Object projectIdOrPath, String environment, String sha, String ref, Boolean tag, DeploymentStatus status) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("environment", environment, true)
-                .withParam("sha", sha, true)
-                .withParam("ref", ref, true)
-                .withParam("tag", tag, true)
-                .withParam("status", status, true);
-
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "deployments");
-        return (response.readEntity(Deployment.class));
-    }
-
-    /**
-     * Updates an existing project deploy key.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/deployments/:key_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId The ID of the deployment to update, required
-     * @param status The new status of the deployment, required
-     * @return an updated Deployment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Deployment updateDeployment(Object projectIdOrPath, Long deploymentId, DeploymentStatus status) throws GitLabApiException {
-
-        if (deploymentId == null) {
-            throw new RuntimeException("deploymentId cannot be null");
-        }
-
-        final Deployment deployment = new Deployment();
-        deployment.setStatus(status);
-        final Response response = put(Response.Status.OK, deployment,
-                "projects", getProjectIdOrPath(projectIdOrPath), "deployments", deploymentId);
-
-        return (response.readEntity(Deployment.class));
-    }
-
-    /**
-     * Get a list of Merge Requests shipped with a given deployment.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId The ID of the deployment to update, required
-     * @return a list containing the MergeRequest instances shipped with a given deployment
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath, Long deploymentId) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, deploymentId, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of Merge Requests shipped with a given deployment.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId The ID of the deployment to update, required
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the MergeRequest instances shipped with a given deployment
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<MergeRequest> getMergeRequests(Object projectIdOrPath, Long deploymentId, int itemsPerPage) throws GitLabApiException {
-    return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "deployments", deploymentId, "merge_requests"));
-    }
-
-    /**
-     * Get a Stream of Merge Requests shipped with a given deployment.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param deploymentId The ID of the deployment to update, required
-     * @return a Stream containing the MergeRequest instances shipped with a given deployment
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<MergeRequest> getMergeRequestsStream(Object projectIdOrPath, Long deploymentId) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, deploymentId, getDefaultPerPage()).stream());
-    }
-
-
+  /**
+   * Get a Stream of Merge Requests shipped with a given deployment.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/deployments/:deployment_id/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param deploymentId The ID of the deployment to update, required
+   * @return a Stream containing the MergeRequest instances shipped with a given deployment
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<MergeRequest> getMergeRequestsStream(
+      final Object projectIdOrPath, final Long deploymentId) throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, deploymentId, getDefaultPerPage()).stream());
+  }
 }

--- a/src/main/java/org/gitlab4j/api/DiscussionsApi.java
+++ b/src/main/java/org/gitlab4j/api/DiscussionsApi.java
@@ -4,754 +4,1169 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Discussion;
 import org.gitlab4j.api.models.Note;
 import org.gitlab4j.api.models.Position;
 
 /**
- * This class implements the client side API for the GitLab Discussions API.
- * See <a href="https://docs.gitlab.com/ee/api/discussions.html">Discussions API at GitLab</a> for more information.
+ * This class implements the client side API for the GitLab Discussions API. See <a
+ * href="https://docs.gitlab.com/ee/api/discussions.html">Discussions API at GitLab</a> for more
+ * information.
  */
 public class DiscussionsApi extends AbstractApi {
 
-    public DiscussionsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public DiscussionsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of all discussions for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid the internal ID of the issue
+   * @return a list containing all the discussions for the specified issue
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getIssueDiscussions(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getIssueDiscussionsPager(projectIdOrPath, issueIid, getDefaultPerPage());
+    return (pager.all());
+  }
+
+  /**
+   * Get a list of discussions for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid the internal ID of the issue
+   * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all
+   *     Discussion instances for the issue
+   * @return a list containing the discussions for the specified issue
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getIssueDiscussions(
+      final Object projectIdOrPath, final Long issueIid, final int maxItems)
+      throws GitLabApiException {
+    if (maxItems < 1) {
+      return (getIssueDiscussions(projectIdOrPath, issueIid));
+    } else {
+      final Response response =
+          get(
+              Response.Status.OK,
+              getPerPageQueryParam(maxItems),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "issues",
+              issueIid,
+              "discussions");
+      return (response.readEntity(new GenericType<List<Discussion>>() {}));
+    }
+  }
+
+  /**
+   * Get a Pager of Discussion instances for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid the internal ID of the issue
+   * @param itemsPerPage the number of Discussion instances that will be fetched per page
+   * @return a Pager containing the Discussion instances for the specified issue
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Discussion> getIssueDiscussionsPager(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Discussion>(
+        this,
+        Discussion.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "discussions"));
+  }
+
+  /**
+   * Get a Stream of Discussion instances for the specified issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid the internal ID of the issue
+   * @return a Stream instance containing the Discussion instances for the specified issue
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Discussion> getIssueDiscussionsStream(
+      final Object projectIdOrPath, final Long issueIid) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getIssueDiscussionsPager(projectIdOrPath, issueIid, getDefaultPerPage());
+    return (pager.stream());
+  }
+
+  /**
+   * Get a list of all discussions for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param snippetId the ID of the snippet
+   * @return a list containing all the discussions for the specified snippet
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getSnippetDiscussions(final Object projectIdOrPath, final Long snippetId)
+      throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getSnippetDiscussionsPager(projectIdOrPath, snippetId, getDefaultPerPage());
+    return (pager.all());
+  }
+
+  /**
+   * Get a list of discussions for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param snippetId the ID of the snippet
+   * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all
+   *     Discussion instances for the snippet
+   * @return a list containing the discussions for the specified snippet
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getSnippetDiscussions(
+      final Object projectIdOrPath, final Long snippetId, final int maxItems)
+      throws GitLabApiException {
+    if (maxItems < 1) {
+      return (getSnippetDiscussions(projectIdOrPath, snippetId));
+    } else {
+      final Response response =
+          get(
+              Response.Status.OK,
+              getPerPageQueryParam(maxItems),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "snippets",
+              snippetId,
+              "discussions");
+      return (response.readEntity(new GenericType<List<Discussion>>() {}));
+    }
+  }
+
+  /**
+   * Get a Pager of Discussion instances for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param snippetId the ID of the snippet
+   * @param itemsPerPage the number of Discussion instances that will be fetched per page
+   * @return a Pager containing the Discussion instances for the specified snippet
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Discussion> getSnippetDiscussionsPager(
+      final Object projectIdOrPath, final Long snippetId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Discussion>(
+        this,
+        Discussion.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "snippets",
+        snippetId,
+        "discussions"));
+  }
+
+  /**
+   * Get a Stream of Discussion instances for the specified snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param snippetId the ID of the snippet
+   * @return a Stream instance containing the Discussion instances for the specified snippet
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Discussion> getSnippetDiscussionsStream(
+      final Object projectIdOrPath, final Long snippetId) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getSnippetDiscussionsPager(projectIdOrPath, snippetId, getDefaultPerPage());
+    return (pager.stream());
+  }
+
+  /**
+   * Get a list of all discussions for the specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param epicId the internal ID of the epic
+   * @return a list containing all the discussions for the specified epic
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getEpicDiscussions(final Object projectIdOrPath, final Long epicId)
+      throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getEpicDiscussionsPager(projectIdOrPath, epicId, getDefaultPerPage());
+    return (pager.all());
+  }
+
+  /**
+   * Get a list of discussions for the specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param epicId the internal ID of the epic
+   * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all
+   *     Discussion instances for the epic
+   * @return a list containing the discussions for the specified epic
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getEpicDiscussions(
+      final Object projectIdOrPath, final Long epicId, final int maxItems)
+      throws GitLabApiException {
+    if (maxItems < 1) {
+      return (getEpicDiscussions(projectIdOrPath, epicId));
+    } else {
+      final Response response =
+          get(
+              Response.Status.OK,
+              getPerPageQueryParam(maxItems),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "epics",
+              epicId,
+              "discussions");
+      return (response.readEntity(new GenericType<List<Discussion>>() {}));
+    }
+  }
+
+  /**
+   * Get a Pager of Discussion instances for the specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param epicId the internal ID of the epic
+   * @param itemsPerPage the number of Discussion instances that will be fetched per page
+   * @return a Pager containing the Discussion instances for the specified epic
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Discussion> getEpicDiscussionsPager(
+      final Object projectIdOrPath, final Long epicId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Discussion>(
+        this,
+        Discussion.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "epics",
+        epicId,
+        "discussions"));
+  }
+
+  /**
+   * Get a Stream of Discussion instances for the specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param epicId the internal ID of the epic
+   * @return a Stream instance containing the Discussion instances for the specified epic
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Discussion> getEpicDiscussionsStream(
+      final Object projectIdOrPath, final Long epicId) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getEpicDiscussionsPager(projectIdOrPath, epicId, getDefaultPerPage());
+    return (pager.stream());
+  }
+
+  /**
+   * Get a list of all discussions for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a list containing all the discussions for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getMergeRequestDiscussions(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getMergeRequestDiscussionsPager(projectIdOrPath, mergeRequestIid, getDefaultPerPage());
+    return (pager.all());
+  }
+
+  /**
+   * Get a list of discussions for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all
+   *     Discussion instances for the merge request
+   * @return a list containing the discussions for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getMergeRequestDiscussions(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int maxItems)
+      throws GitLabApiException {
+    if (maxItems < 1) {
+      return (getMergeRequestDiscussions(projectIdOrPath, mergeRequestIid));
+    } else {
+      final Response response =
+          get(
+              Response.Status.OK,
+              getPerPageQueryParam(maxItems),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "merge_requests",
+              mergeRequestIid,
+              "discussions");
+      return (response.readEntity(new GenericType<List<Discussion>>() {}));
+    }
+  }
+
+  /**
+   * Get a Pager of Discussion instances for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param itemsPerPage the number of Discussion instances that will be fetched per page
+   * @return a Pager containing the Discussion instances for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Discussion> getMergeRequestDiscussionsPager(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Discussion>(
+        this,
+        Discussion.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "discussions"));
+  }
+
+  /**
+   * Get a Stream of Discussion instances for the specified merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Stream instance containing the Discussion instances for the specified issue
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Discussion> getMergeRequestDiscussionsStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getMergeRequestDiscussionsPager(projectIdOrPath, mergeRequestIid, getDefaultPerPage());
+    return (pager.stream());
+  }
+
+  /**
+   * Creates a new discussion to a single project merge request. This is similar to creating a note
+   * but other comments (replies) can be added to it later.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param body the content of a discussion
+   * @param createdAt date the discussion was created (requires admin or project/group owner rights)
+   * @param positionHash position when creating a diff note
+   * @param position a Position instance holding the position attributes
+   * @return a Discussion instance containing the newly created discussion
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Discussion createMergeRequestDiscussion(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String body,
+      final Date createdAt,
+      final String positionHash,
+      final Position position)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("body", body, true)
+            .withParam("created_at", createdAt)
+            .withParam("position", positionHash);
+
+    if (position != null) {
+      formData
+          .withParam("position[base_sha]", position.getBaseSha(), true)
+          .withParam("position[start_sha]", position.getStartSha(), true)
+          .withParam("position[head_sha]", position.getHeadSha(), true)
+          .withParam("position[position_type]", position.getPositionType(), true)
+          .withParam("position[new_path]", position.getNewPath())
+          .withParam("position[new_line]", position.getNewLine())
+          .withParam("position[old_path]", position.getOldPath())
+          .withParam("position[old_line]", position.getOldLine())
+          .withParam("position[width]", position.getWidth())
+          .withParam("position[height]", position.getHeight())
+          .withParam("position[x]", position.getX())
+          .withParam("position[y]", position.getY());
     }
 
-    /**
-     * Get a list of all discussions for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of the issue
-     * @return a list containing all the discussions for the specified issue
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getIssueDiscussions(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        Pager<Discussion> pager = getIssueDiscussionsPager(projectIdOrPath, issueIid, getDefaultPerPage());
-        return (pager.all());
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "discussions");
+    return (response.readEntity(Discussion.class));
+  }
+
+  /**
+   * Resolve or unresolve whole discussion of a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param discussionId the ID of a discussion
+   * @param resolved resolve/unresolve the discussion
+   * @return the updated DIscussion instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Discussion resolveMergeRequestDiscussion(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String discussionId,
+      final Boolean resolved)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("resolved", resolved, true);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "discussions",
+            discussionId);
+    return (response.readEntity(Discussion.class));
+  }
+
+  /**
+   * Deletes an existing discussion note of a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to delete
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deleteMergeRequestDiscussionNote(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String discussionId,
+      final Long noteId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "discussions",
+        discussionId,
+        "notes",
+        noteId);
+  }
+
+  /**
+   * Get a list of all discussions for the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @return a list containing all the discussions for the specified commit
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getCommitDiscussions(final Object projectIdOrPath, final String commitSha)
+      throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getCommitDiscussionsPager(projectIdOrPath, commitSha, getDefaultPerPage());
+    return (pager.all());
+  }
+
+  /**
+   * Get a list of discussions for the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all
+   *     Discussion instances for the commit
+   * @return a list containing the discussions for the specified commit
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Discussion> getCommitDiscussions(
+      final Object projectIdOrPath, final String commitSha, final int maxItems)
+      throws GitLabApiException {
+    if (maxItems < 1) {
+      return (getCommitDiscussions(projectIdOrPath, commitSha));
+    } else {
+      final Response response =
+          get(
+              Response.Status.OK,
+              getPerPageQueryParam(maxItems),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "commits",
+              commitSha,
+              "discussions");
+      return (response.readEntity(new GenericType<List<Discussion>>() {}));
+    }
+  }
+
+  /**
+   * Get a Pager of Discussion instances for the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @param itemsPerPage the number of Discussion instances that will be fetched per page
+   * @return a Pager containing the Discussion instances for the specified commit
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Discussion> getCommitDiscussionsPager(
+      final Object projectIdOrPath, final String commitSha, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Discussion>(
+        this,
+        Discussion.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        commitSha,
+        "discussions"));
+  }
+
+  /**
+   * Get a Stream of Discussion instances for the specified commit.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @return a Stream instance containing the Discussion instances for the specified commit
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Discussion> getCommitDiscussionsStream(
+      final Object projectIdOrPath, final String commitSha) throws GitLabApiException {
+    final Pager<Discussion> pager =
+        getCommitDiscussionsPager(projectIdOrPath, commitSha, getDefaultPerPage());
+    return (pager.stream());
+  }
+
+  /**
+   * Get a single discussion for the specified commit.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @param discussionId the ID of the discussion
+   * @return the Discussion instance specified by discussionId for the specified commit
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Discussion getCommitDiscussion(
+      final Object projectIdOrPath, final String commitSha, final String discussionId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            commitSha,
+            "discussions",
+            discussionId);
+    return (response.readEntity(Discussion.class));
+  }
+
+  /**
+   * Get an Optional instance of a single discussion for the specified commit.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the SHA of the commit to get discussions for
+   * @param discussionId the ID of the discussion
+   * @return an Optional instance with the specified Discussion instance as a value
+   */
+  public Optional<Discussion> getOptionalCommitDiscussion(
+      final Object projectIdOrPath, final String commitSha, final String discussionId) {
+    try {
+      return (Optional.ofNullable(getCommitDiscussion(projectIdOrPath, commitSha, discussionId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a new discussion to a single project commit. This is similar to creating a note but
+   * other comments (replies) can be added to it later.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/repository/commits/:commit_sha/discussions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the commit SHA to create the discussion for
+   * @param body the content of a discussion
+   * @param createdAt date the discussion was created (requires admin or project/group owner rights)
+   * @param positionHash position when creating a diff note
+   * @param position a Position instance holding the position attributes
+   * @return a Discussion instance containing the newly created discussion
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Discussion createCommitDiscussion(
+      final Object projectIdOrPath,
+      final String commitSha,
+      final String body,
+      final Date createdAt,
+      final String positionHash,
+      final Position position)
+      throws GitLabApiException {
+
+    if (position == null) {
+      throw new GitLabApiException("position instance can not be null");
     }
 
-    /**
-     * Get a list of discussions for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of the issue
-     * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all Discussion instances for the issue
-     * @return a list containing the discussions for the specified issue
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getIssueDiscussions(Object projectIdOrPath, Long issueIid, int maxItems) throws GitLabApiException {
-        if (maxItems < 1) {
-            return (getIssueDiscussions(projectIdOrPath, issueIid));
-        } else {
-            Response response = get(Response.Status.OK, getPerPageQueryParam(maxItems),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions");
-            return (response.readEntity(new GenericType<List<Discussion>>() {}));
-        }
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("body", body, true)
+            .withParam("created_at", createdAt)
+            .withParam("position", positionHash)
+            .withParam("position[base_sha]", position.getBaseSha(), true)
+            .withParam("position[start_sha]", position.getStartSha(), true)
+            .withParam("position[head_sha]", position.getHeadSha(), true)
+            .withParam("position[position_type]", position.getPositionType(), true)
+            .withParam("position[new_path]", position.getNewPath())
+            .withParam("position[new_line]", position.getNewLine())
+            .withParam("position[old_path]", position.getOldPath())
+            .withParam("position[old_line]", position.getOldLine())
+            .withParam("position[width]", position.getWidth())
+            .withParam("position[height]", position.getHeight())
+            .withParam("position[x]", position.getX())
+            .withParam("position[y]", position.getY());
 
-    /**
-     * Get a Pager of Discussion instances for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of the issue
-     * @param itemsPerPage the number of Discussion instances that will be fetched per page
-     * @return a Pager containing the Discussion instances for the specified issue
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Discussion> getIssueDiscussionsPager(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Discussion>(this, Discussion.class, itemsPerPage, null,
-              "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions"));
-    }
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            commitSha,
+            "discussions");
+    return (response.readEntity(Discussion.class));
+  }
 
-    /**
-     * Get a Stream of Discussion instances for the specified issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of the issue
-     * @return a Stream instance containing the Discussion instances for the specified issue
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Discussion> getIssueDiscussionsStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        Pager<Discussion> pager = getIssueDiscussionsPager(projectIdOrPath, issueIid, getDefaultPerPage());
-        return (pager.stream());
-    }
+  /**
+   * Adds a note to an existing commit discussion.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the commit SHA to create the discussion for
+   * @param discussionId the ID of a discussion
+   * @param body the content of a discussion
+   * @param createdAt date the discussion was created (requires admin or project/group owner rights)
+   * @return a Note instance containing the newly created discussion note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note addCommitDiscussionNote(
+      final Object projectIdOrPath,
+      final String commitSha,
+      final String discussionId,
+      final String body,
+      final Date createdAt)
+      throws GitLabApiException {
 
-    /**
-     * Get a list of all discussions for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param snippetId the ID of the snippet
-     * @return a list containing all the discussions for the specified snippet
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getSnippetDiscussions(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        Pager<Discussion> pager = getSnippetDiscussionsPager(projectIdOrPath, snippetId, getDefaultPerPage());
-        return (pager.all());
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body, true).withParam("created_at", createdAt);
 
-    /**
-     * Get a list of discussions for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param snippetId the ID of the snippet
-     * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all Discussion instances for the snippet
-     * @return a list containing the discussions for the specified snippet
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getSnippetDiscussions(Object projectIdOrPath, Long snippetId, int maxItems) throws GitLabApiException {
-        if (maxItems < 1) {
-            return (getSnippetDiscussions(projectIdOrPath, snippetId));
-        } else {
-            Response response = get(Response.Status.OK, getPerPageQueryParam(maxItems),
-                "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "discussions");
-            return (response.readEntity(new GenericType<List<Discussion>>() {}));
-        }
-    }
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            commitSha,
+            "discussions",
+            discussionId,
+            "notes");
+    return (response.readEntity(Note.class));
+  }
 
-    /**
-     * Get a Pager of Discussion instances for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param snippetId the ID of the snippet
-     * @param itemsPerPage the number of Discussion instances that will be fetched per page
-     * @return a Pager containing the Discussion instances for the specified snippet
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Discussion> getSnippetDiscussionsPager(Object projectIdOrPath, Long snippetId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Discussion>(this, Discussion.class, itemsPerPage, null,
-              "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "discussions"));
-    }
+  /**
+   * Modify an existing discussion note of a commit.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the commit SHA to delete the discussion from
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to modify
+   * @param body the content of a discussion
+   * @return a Note instance containing the updated discussion note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note modifyCommitDiscussionNote(
+      final Object projectIdOrPath,
+      final String commitSha,
+      final String discussionId,
+      final Long noteId,
+      final String body)
+      throws GitLabApiException {
 
-    /**
-     * Get a Stream of Discussion instances for the specified snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param snippetId the ID of the snippet
-     * @return a Stream instance containing the Discussion instances for the specified snippet
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Discussion> getSnippetDiscussionsStream(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        Pager<Discussion> pager = getSnippetDiscussionsPager(projectIdOrPath, snippetId, getDefaultPerPage());
-        return (pager.stream());
-    }
+    final GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+    final Response response =
+        this.putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            commitSha,
+            "discussions",
+            discussionId,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
 
+  /**
+   * Resolve or unresolve an existing discussion note of a commit.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the commit SHA to delete the discussion from
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to resolve or unresolve
+   * @param resolved if true will resolve the note, false will unresolve the note
+   * @return a Note instance containing the updated discussion note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note resolveCommitDiscussionNote(
+      final Object projectIdOrPath,
+      final String commitSha,
+      final String discussionId,
+      final Long noteId,
+      final Boolean resolved)
+      throws GitLabApiException {
 
-    /**
-     * Get a list of all discussions for the specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param epicId the internal ID of the epic
-     * @return a list containing all the discussions for the specified epic
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getEpicDiscussions(Object projectIdOrPath, Long epicId) throws GitLabApiException {
-        Pager<Discussion> pager = getEpicDiscussionsPager(projectIdOrPath, epicId, getDefaultPerPage());
-        return (pager.all());
-    }
+    final GitLabApiForm queryParams = new GitLabApiForm().withParam("resolved", resolved);
+    final Response response =
+        this.put(
+            Response.Status.OK,
+            queryParams.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "commits",
+            commitSha,
+            "discussions",
+            discussionId,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
 
-    /**
-     * Get a list of discussions for the specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param epicId the internal ID of the epic
-     * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all Discussion instances for the epic
-     * @return a list containing the discussions for the specified epic
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getEpicDiscussions(Object projectIdOrPath, Long epicId, int maxItems) throws GitLabApiException {
-        if (maxItems < 1) {
-            return (getEpicDiscussions(projectIdOrPath, epicId));
-        } else {
-            Response response = get(Response.Status.OK, getPerPageQueryParam(maxItems),
-                "projects", getProjectIdOrPath(projectIdOrPath), "epics", epicId, "discussions");
-            return (response.readEntity(new GenericType<List<Discussion>>() {}));
-        }
-    }
+  /**
+   * Deletes an existing discussion note of a commit.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param commitSha the commit SHA to delete the discussion from
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to delete
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deleteCommitDiscussionNote(
+      final Object projectIdOrPath,
+      final String commitSha,
+      final String discussionId,
+      final Long noteId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "commits",
+        commitSha,
+        "discussions",
+        discussionId,
+        "notes",
+        noteId);
+  }
 
-    /**
-     * Get a Pager of Discussion instances for the specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param epicId the internal ID of the epic
-     * @param itemsPerPage the number of Discussion instances that will be fetched per page
-     * @return a Pager containing the Discussion instances for the specified epic
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Discussion> getEpicDiscussionsPager(Object projectIdOrPath, Long epicId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Discussion>(this, Discussion.class, itemsPerPage, null,
-              "projects", getProjectIdOrPath(projectIdOrPath), "epics", epicId, "discussions"));
-    }
+  /**
+   * Adds a new note to the thread. This can also create a thread from a single comment.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param discussionId the ID of a discussion
+   * @param body the content of a discussion
+   * @param createdAt date the discussion was created (requires admin or project/group owner rights)
+   * @return a Note instance containing the newly created discussion note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note addMergeRequestThreadNote(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String discussionId,
+      final String body,
+      final Date createdAt)
+      throws GitLabApiException {
 
-    /**
-     * Get a Stream of Discussion instances for the specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param epicId the internal ID of the epic
-     * @return a Stream instance containing the Discussion instances for the specified epic
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Discussion> getEpicDiscussionsStream(Object projectIdOrPath, Long epicId) throws GitLabApiException {
-        Pager<Discussion> pager = getEpicDiscussionsPager(projectIdOrPath, epicId, getDefaultPerPage());
-        return (pager.stream());
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body, true).withParam("created_at", createdAt);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "discussions",
+            discussionId,
+            "notes");
+    return (response.readEntity(Note.class));
+  }
 
-    /**
-     * Get a list of all discussions for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a list containing all the discussions for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getMergeRequestDiscussions(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        Pager<Discussion> pager = getMergeRequestDiscussionsPager(projectIdOrPath, mergeRequestIid, getDefaultPerPage());
-        return (pager.all());
-    }
+  /**
+   * Modify or resolve an existing thread note of a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to modify
+   * @param body the content of a discussion
+   * @param resolved if true will resolve the note, false will unresolve the note
+   * @return a Note instance containing the updated discussion note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note modifyMergeRequestThreadNote(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String discussionId,
+      final Long noteId,
+      final String body,
+      final Boolean resolved)
+      throws GitLabApiException {
 
-    /**
-     * Get a list of discussions for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all Discussion instances for the merge request
-     * @return a list containing the discussions for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getMergeRequestDiscussions(Object projectIdOrPath, Long mergeRequestIid, int maxItems) throws GitLabApiException {
-        if (maxItems < 1) {
-            return (getMergeRequestDiscussions(projectIdOrPath, mergeRequestIid));
-        } else {
-            Response response = get(Response.Status.OK, getPerPageQueryParam(maxItems),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "discussions");
-            return (response.readEntity(new GenericType<List<Discussion>>() {}));
-        }
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body).withParam("resolved", resolved);
+    final Response response =
+        this.putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "discussions",
+            discussionId,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
 
-    /**
-     * Get a Pager of Discussion instances for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param itemsPerPage the number of Discussion instances that will be fetched per page
-     * @return a Pager containing the Discussion instances for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Discussion> getMergeRequestDiscussionsPager(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Discussion>(this, Discussion.class, itemsPerPage, null,
-              "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "discussions"));
-    }
+  /**
+   * Deletes an existing thread note of a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
+   * @param discussionId the ID of a discussion
+   * @param noteId the note ID to delete
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deleteMergeRequestThreadNote(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String discussionId,
+      final Long noteId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "discussions",
+        discussionId,
+        "notes",
+        noteId);
+  }
 
-    /**
-     * Get a Stream of Discussion instances for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Stream instance containing the Discussion instances for the specified issue
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Discussion> getMergeRequestDiscussionsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        Pager<Discussion> pager = getMergeRequestDiscussionsPager(projectIdOrPath, mergeRequestIid, getDefaultPerPage());
-        return (pager.stream());
-    }
+  /**
+   * Creates a new thread to a single project issue. This is similar to creating a note but other
+   * comments (replies) can be added to it later.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/discussions</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid The IID of an issue
+   * @param body the content of the discussion
+   * @param createdAt (optional) date the discussion was created (requires admin or project/group
+   *     owner rights)
+   * @return a Discussion instance containing the newly created discussion
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Discussion createIssueDiscussion(
+      final Object projectIdOrPath, final Long issueIid, final String body, final Date createdAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body, true).withParam("created_at", createdAt);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "discussions");
+    return (response.readEntity(Discussion.class));
+  }
 
-    /**
-     * Creates a new discussion to a single project merge request. This is similar to creating
-     * a note but other comments (replies) can be added to it later.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param body the content of a discussion
-     * @param createdAt date the discussion was created (requires admin or project/group owner rights)
-     * @param positionHash position when creating a diff note
-     * @param position a Position instance holding the position attributes
-     * @return a Discussion instance containing the newly created discussion
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Discussion createMergeRequestDiscussion(Object projectIdOrPath, Long mergeRequestIid,
-            String body, Date createdAt, String positionHash, Position position) throws GitLabApiException {
+  /**
+   * Adds a new note to the thread.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid The IID of an issue
+   * @param discussionId the id of discussion
+   * @param body the content of the note
+   * @param createdAt (optional) date the discussion was created (requires admin or project/group
+   *     owner rights)
+   * @return a Note instance containing the newly created note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note addIssueThreadNote(
+      final Object projectIdOrPath,
+      final Long issueIid,
+      final String discussionId,
+      final String body,
+      final Date createdAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body, true).withParam("created_at", createdAt);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "discussions",
+            discussionId,
+            "notes");
+    return (response.readEntity(Note.class));
+  }
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt)
-                .withParam("position", positionHash);
+  /**
+   * Modify existing thread note of an issue.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid The IID of an issue
+   * @param discussionId the id of discussion
+   * @param noteId the id of the note
+   * @param body the content of the note
+   * @return a Note instance containing the modified note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Note modifyIssueThreadNote(
+      final Object projectIdOrPath,
+      final Long issueIid,
+      final String discussionId,
+      final Long noteId,
+      final String body)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "discussions",
+            discussionId,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
 
-        if (position != null) {
-            formData.withParam("position[base_sha]", position.getBaseSha(), true)
-                .withParam("position[start_sha]", position.getStartSha(), true)
-                .withParam("position[head_sha]", position.getHeadSha(), true)
-                .withParam("position[position_type]", position.getPositionType(), true)
-                .withParam("position[new_path]", position.getNewPath())
-                .withParam("position[new_line]", position.getNewLine())
-                .withParam("position[old_path]", position.getOldPath())
-                .withParam("position[old_line]", position.getOldLine())
-                .withParam("position[width]", position.getWidth())
-                .withParam("position[height]", position.getHeight())
-                .withParam("position[x]", position.getX())
-                .withParam("position[y]", position.getY());
-        }
-
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "discussions");
-        return (response.readEntity(Discussion.class));
-    }
-
-    /**
-     * Resolve or unresolve whole discussion of a merge request.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param discussionId the ID of a discussion
-     * @param resolved resolve/unresolve the discussion
-     * @return the updated DIscussion instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Discussion resolveMergeRequestDiscussion(Object projectIdOrPath, Long mergeRequestIid,
-            String discussionId, Boolean resolved)  throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("resolved", resolved, true);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "discussions", discussionId);
-        return (response.readEntity(Discussion.class));
-    }
-
-    /**
-     * Deletes an existing discussion note of a merge request.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to delete
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deleteMergeRequestDiscussionNote(Object projectIdOrPath, Long mergeRequestIid,
-            String discussionId, Long noteId)  throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "discussions", discussionId, "notes", noteId);
-    }
-
-    /**
-     * Get a list of all discussions for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @return a list containing all the discussions for the specified commit
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getCommitDiscussions(Object projectIdOrPath, String commitSha) throws GitLabApiException {
-        Pager<Discussion> pager = getCommitDiscussionsPager(projectIdOrPath, commitSha, getDefaultPerPage());
-        return (pager.all());
-    }
-
-    /**
-     * Get a list of discussions for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @param maxItems the maximum number of Discussion instances to get, if &lt; 1 will fetch all Discussion instances for the commit
-     * @return a list containing the discussions for the specified commit
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Discussion> getCommitDiscussions(Object projectIdOrPath, String commitSha, int maxItems) throws GitLabApiException {
-        if (maxItems < 1) {
-            return (getCommitDiscussions(projectIdOrPath, commitSha));
-        } else {
-            Response response = get(Response.Status.OK, getPerPageQueryParam(maxItems),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", commitSha, "discussions");
-            return (response.readEntity(new GenericType<List<Discussion>>() {}));
-        }
-    }
-
-    /**
-     * Get a Pager of Discussion instances for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @param itemsPerPage the number of Discussion instances that will be fetched per page
-     * @return a Pager containing the Discussion instances for the specified commit
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Discussion> getCommitDiscussionsPager(Object projectIdOrPath, String commitSha, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Discussion>(this, Discussion.class, itemsPerPage, null,
-              "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", commitSha, "discussions"));
-    }
-
-    /**
-     * Get a Stream of Discussion instances for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @return a Stream instance containing the Discussion instances for the specified commit
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Discussion> getCommitDiscussionsStream(Object projectIdOrPath, String commitSha) throws GitLabApiException {
-        Pager<Discussion> pager = getCommitDiscussionsPager(projectIdOrPath, commitSha, getDefaultPerPage());
-        return (pager.stream());
-    }
-
-    /**
-     * Get a single discussion for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @param discussionId the ID of the discussion
-     * @return the Discussion instance specified by discussionId for the specified commit
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Discussion getCommitDiscussion(Object projectIdOrPath, String commitSha, String discussionId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-            "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", commitSha, "discussions", discussionId);
-        return (response.readEntity(Discussion.class));
-    }
-
-    /**
-     * Get an Optional instance of a single discussion for the specified commit.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the SHA of the commit to get discussions for
-     * @param discussionId the ID of the discussion
-     * @return an Optional instance with the specified Discussion instance as a value
-     */
-    public Optional<Discussion> getOptionalCommitDiscussion(Object projectIdOrPath, String commitSha, String discussionId) {
-        try {
-            return (Optional.ofNullable(getCommitDiscussion(projectIdOrPath, commitSha, discussionId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new discussion to a single project commit. This is similar to creating
-     * a note but other comments (replies) can be added to it later.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the commit SHA to create the discussion for
-     * @param body the content of a discussion
-     * @param createdAt date the discussion was created (requires admin or project/group owner rights)
-     * @param positionHash position when creating a diff note
-     * @param position a Position instance holding the position attributes
-     * @return a Discussion instance containing the newly created discussion
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Discussion createCommitDiscussion(Object projectIdOrPath, String commitSha,
-            String body, Date createdAt, String positionHash, Position position) throws GitLabApiException {
-
-        if (position == null) {
-            throw new GitLabApiException("position instance can not be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt)
-                .withParam("position", positionHash)
-                .withParam("position[base_sha]", position.getBaseSha(), true)
-                .withParam("position[start_sha]", position.getStartSha(), true)
-                .withParam("position[head_sha]", position.getHeadSha(), true)
-                .withParam("position[position_type]", position.getPositionType(), true)
-                .withParam("position[new_path]", position.getNewPath())
-                .withParam("position[new_line]", position.getNewLine())
-                .withParam("position[old_path]", position.getOldPath())
-                .withParam("position[old_line]", position.getOldLine())
-                .withParam("position[width]", position.getWidth())
-                .withParam("position[height]", position.getHeight())
-                .withParam("position[x]", position.getX())
-                .withParam("position[y]", position.getY());
-
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "commits", commitSha, "discussions");
-        return (response.readEntity(Discussion.class));
-    }
-
-    /**
-     * Adds a note to an existing commit discussion.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the commit SHA to create the discussion for
-     * @param discussionId the ID of a discussion
-     * @param body the content of a discussion
-     * @param createdAt date the discussion was created (requires admin or project/group owner rights)
-     * @return a Note instance containing the newly created discussion note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note addCommitDiscussionNote(Object projectIdOrPath, String commitSha, String discussionId,
-            String body, Date createdAt) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt);
-
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath),
-                "repository", "commits", commitSha, "discussions", discussionId, "notes");
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Modify an existing discussion note of a commit.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the commit SHA to delete the discussion from
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to modify
-     * @param body the content of a discussion
-     * @return a Note instance containing the updated discussion note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note modifyCommitDiscussionNote(Object projectIdOrPath,
-            String commitSha, String discussionId, Long noteId, String body) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
-        Response response = this.putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath),
-                "repository", "commits", commitSha, "discussions", discussionId, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Resolve or unresolve an existing discussion note of a commit.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the commit SHA to delete the discussion from
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to resolve or unresolve
-     * @param resolved if true will resolve the note, false will unresolve the note
-     * @return a Note instance containing the updated discussion note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note resolveCommitDiscussionNote(Object projectIdOrPath,
-            String commitSha, String discussionId, Long noteId, Boolean resolved) throws GitLabApiException {
-
-        GitLabApiForm queryParams = new GitLabApiForm().withParam("resolved", resolved);
-        Response response = this.put(Response.Status.OK, queryParams.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath),
-                "repository", "commits", commitSha, "discussions", discussionId, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Deletes an existing discussion note of a commit.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/commits/:commit_sha/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitSha the commit SHA to delete the discussion from
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to delete
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deleteCommitDiscussionNote(Object projectIdOrPath, String commitSha,
-            String discussionId, Long noteId)  throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "repository", "commits", commitSha, "discussions", discussionId, "notes", noteId);
-    }
-
-    /**
-     * Adds a new note to the thread. This can also create a thread from a single comment.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param discussionId the ID of a discussion
-     * @param body the content of a discussion
-     * @param createdAt date the discussion was created (requires admin or project/group owner rights)
-     * @return a Note instance containing the newly created discussion note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note addMergeRequestThreadNote(Object projectIdOrPath, Long mergeRequestIid,
-	    String discussionId, String body, Date createdAt) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "discussions", discussionId, "notes");
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Modify or resolve an existing thread note of a merge request.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to modify
-     * @param body the content of a discussion
-     * @param resolved if true will resolve the note, false will unresolve the note
-     * @return a Note instance containing the updated discussion note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note modifyMergeRequestThreadNote(Object projectIdOrPath, Long mergeRequestIid,
-	    String discussionId, Long noteId, String body, Boolean resolved) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body).withParam("resolved", resolved);
-        Response response = this.putWithFormData(Response.Status.OK, formData,
-               "projects", getProjectIdOrPath(projectIdOrPath),
-               "merge_requests", mergeRequestIid, "discussions", discussionId, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Deletes an existing thread note of a merge request.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid mergeRequestIid the internal ID of the merge request
-     * @param discussionId the ID of a discussion
-     * @param noteId the note ID to delete
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deleteMergeRequestThreadNote(Object projectIdOrPath, Long mergeRequestIid,
-	    String discussionId, Long noteId)  throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "discussions", discussionId, "notes", noteId);
-    }
-
-    /**
-     * Creates a new thread to a single project issue. This is similar to creating a note but other comments (replies) can be added to it later.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/discussions</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid The IID of an issue
-     * @param body the content of the discussion
-     * @param createdAt (optional) date the discussion was created (requires admin or project/group owner rights)
-     * @return a Discussion instance containing the newly created discussion
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Discussion createIssueDiscussion(Object projectIdOrPath, Long issueIid, String body, Date createdAt) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions");
-        return (response.readEntity(Discussion.class));
-    }
-
-    /**
-     * Adds a new note to the thread.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid The IID of an issue
-     * @param discussionId the id of discussion
-     * @param body the content of the note
-     * @param createdAt (optional) date the discussion was created (requires admin or project/group owner rights)
-     * @return a Note instance containing the newly created note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note addIssueThreadNote(Object projectIdOrPath, Long issueIid,
-                                   String discussionId, String body, Date createdAt) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions", discussionId, "notes");
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Modify existing thread note of an issue.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid The IID of an issue
-     * @param discussionId the id of discussion
-     * @param noteId the id of the note
-     * @param body the content of the note
-     * @return a Note instance containing the modified note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Note modifyIssueThreadNote(Object projectIdOrPath, Long issueIid,
-                                      String discussionId, Long noteId, String body) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions", discussionId, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Deletes an existing thread note of an issue.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes/:note_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid The IID of an issue
-     * @param discussionId the id of discussion
-     * @param noteId the id of the note
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deleteIssueThreadNote(Object projectIdOrPath, Long issueIid,
-                                      String discussionId, Long noteId) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "discussions", discussionId, "notes", noteId);
-    }
-
+  /**
+   * Deletes an existing thread note of an issue.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/discussions/:discussion_id/notes/:note_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance
+   * @param issueIid The IID of an issue
+   * @param discussionId the id of discussion
+   * @param noteId the id of the note
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deleteIssueThreadNote(
+      final Object projectIdOrPath,
+      final Long issueIid,
+      final String discussionId,
+      final Long noteId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "discussions",
+        discussionId,
+        "notes",
+        noteId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/EnvironmentsApi.java
+++ b/src/main/java/org/gitlab4j/api/EnvironmentsApi.java
@@ -3,176 +3,244 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Environment;
 
 /**
  * This class provides an entry point to all the GitLab API Environments API calls.
+ *
  * @see <a href="https://docs.gitlab.com/ce/api/environments.html">Environments API</a>
  */
 public class EnvironmentsApi extends AbstractApi {
 
-    public EnvironmentsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public EnvironmentsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Get all environments for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a List of Environment instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Environment> getEnvironments(Object projectIdOrPath) throws GitLabApiException {
-        return (getEnvironments(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Get all environments for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a List of Environment instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Environment> getEnvironments(final Object projectIdOrPath) throws GitLabApiException {
+    return (getEnvironments(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Stream of all environments for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Stream of Environment instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Environment> getEnvironmentsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getEnvironments(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of all environments for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Stream of Environment instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Environment> getEnvironmentsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getEnvironments(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get a Pager of all environments for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param itemsPerPage the number of Environment instances that will be fetched per page
-     * @return a Pager of Environment instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Environment> getEnvironments(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Environment>(this, Environment.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments"));
-    }
+  /**
+   * Get a Pager of all environments for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/environments</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param itemsPerPage the number of Environment instances that will be fetched per page
+   * @return a Pager of Environment instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Environment> getEnvironments(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Environment>(
+        this,
+        Environment.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "environments"));
+  }
 
-    /**
-     * Get a specific environment.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/environments/:environment_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to get
-     * @return an Environment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Environment getEnvironment(Object projectIdOrPath, Long environmentId) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments", environmentId);
-	return (response.readEntity(Environment.class));
-    }
+  /**
+   * Get a specific environment.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/environments/:environment_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to get
+   * @return an Environment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Environment getEnvironment(final Object projectIdOrPath, final Long environmentId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "environments",
+            environmentId);
+    return (response.readEntity(Environment.class));
+  }
 
-    /**
-     * Get a specific environment. as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/environments/:environment_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to get
-     * @return the Environment as an Optional instance
-     */
-    public Optional<Environment> getOptionalEnvironment(Object projectIdOrPath, Long environmentId) {
-	try {
-	    return (Optional.ofNullable(getEnvironment(projectIdOrPath, environmentId)));
-	} catch (GitLabApiException glae) {
-	    return (GitLabApi.createOptionalFromException(glae));
-	}
+  /**
+   * Get a specific environment. as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/environments/:environment_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to get
+   * @return the Environment as an Optional instance
+   */
+  public Optional<Environment> getOptionalEnvironment(
+      final Object projectIdOrPath, final Long environmentId) {
+    try {
+      return (Optional.ofNullable(getEnvironment(projectIdOrPath, environmentId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Create a new environment with the given name and external_url.
-     *
-     * <pre><code>GitLab Endpoint:POST /projects/:id/environments</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name the name of the environment
-     * @param externalUrl the place to link to for this environment
-     * @return the created Environment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Environment createEnvironment(Object projectIdOrPath, String name, String externalUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm().withParam("name", name, true).withParam("external_url", externalUrl);
-	Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments");
-	return (response.readEntity(Environment.class));
-    }
+  /**
+   * Create a new environment with the given name and external_url.
+   *
+   * <pre><code>GitLab Endpoint:POST /projects/:id/environments</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name the name of the environment
+   * @param externalUrl the place to link to for this environment
+   * @return the created Environment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Environment createEnvironment(
+      final Object projectIdOrPath, final String name, final String externalUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("name", name, true).withParam("external_url", externalUrl);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "environments");
+    return (response.readEntity(Environment.class));
+  }
 
-    /**
-     * Update an existing environment.
-     *
-     * <pre><code>GitLab Endpoint:POST /projects/:id/environments</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to update
-     * @param name the name of the environment
-     * @param externalUrl the place to link to for this environment
-     * @return the created Environment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Environment updateEnvironment(Object projectIdOrPath, Long environmentId, String name, String externalUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm().withParam("name", name).withParam("external_url", externalUrl);
-	Response response = putWithFormData(Response.Status.OK, formData, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments", environmentId);
-	return (response.readEntity(Environment.class));
-    }
+  /**
+   * Update an existing environment.
+   *
+   * <pre><code>GitLab Endpoint:POST /projects/:id/environments</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to update
+   * @param name the name of the environment
+   * @param externalUrl the place to link to for this environment
+   * @return the created Environment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Environment updateEnvironment(
+      final Object projectIdOrPath,
+      final Long environmentId,
+      final String name,
+      final String externalUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("name", name).withParam("external_url", externalUrl);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "environments",
+            environmentId);
+    return (response.readEntity(Environment.class));
+  }
 
-    /**
-     * Stop an environment.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/environments/:environment_id/stop</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to stop
-     * @return the stopped Environment instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Environment stopEnvironment(Object projectIdOrPath, Long environmentId) throws GitLabApiException {
-	Response response = post(Response.Status.OK, (GitLabApiForm) null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments", environmentId, "stop");
-	return (response.readEntity(Environment.class));
-    }
+  /**
+   * Stop an environment.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/environments/:environment_id/stop</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to stop
+   * @return the stopped Environment instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Environment stopEnvironment(final Object projectIdOrPath, final Long environmentId)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.OK,
+            (GitLabApiForm) null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "environments",
+            environmentId,
+            "stop");
+    return (response.readEntity(Environment.class));
+  }
 
-    /**
-     * Delete an environment.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/environments/:environment_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteEnvironment(Object projectIdOrPath, Long environmentId) throws GitLabApiException {
-	delete(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments", environmentId);
-    }
+  /**
+   * Delete an environment.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/environments/:environment_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteEnvironment(final Object projectIdOrPath, final Long environmentId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "environments",
+        environmentId);
+  }
 
-    /**
-     * Stop an environment.
-     *
-     * <pre><code>GitLab Endpoint:POST /projects/:id/environments/:environment_id/stop</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param environmentId the ID of the environment to stop
-     * @return the Environment instance of the stopped environment
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Environment createEnvironment(Object projectIdOrPath, Long environmentId) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm();
-	Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "environments", environmentId, "stop");
-	return (response.readEntity(Environment.class));
-    }
+  /**
+   * Stop an environment.
+   *
+   * <pre><code>GitLab Endpoint:POST /projects/:id/environments/:environment_id/stop</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param environmentId the ID of the environment to stop
+   * @return the Environment instance of the stopped environment
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Environment createEnvironment(final Object projectIdOrPath, final Long environmentId)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm();
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "environments",
+            environmentId,
+            "stop");
+    return (response.readEntity(Environment.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/EpicsApi.java
+++ b/src/main/java/org/gitlab4j/api/EpicsApi.java
@@ -4,457 +4,646 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Epic;
 import org.gitlab4j.api.models.EpicIssue;
 
 /**
  * This class implements the client side API for the GitLab Epics and Epic Issues API calls.
  *
- * NOTE:
- *  - If a user is not a member of a group and the group is private, a GET request on that group will result to a 404 status code.
- *  - Epics are available only in Ultimate. If epics feature is not available a 403 status code will be returned.
+ * <p>NOTE: - If a user is not a member of a group and the group is private, a GET request on that
+ * group will result to a 404 status code. - Epics are available only in Ultimate. If epics feature
+ * is not available a 403 status code will be returned.
  *
  * @see <a href="https://docs.gitlab.com/ee/api/epics.html">GitLab Epics API Documentaion</a>
- * @see <a href="https://docs.gitlab.com/ee/api/epic_issues.html">GitLab Epic Issues API Documentation</a>
+ * @see <a href="https://docs.gitlab.com/ee/api/epic_issues.html">GitLab Epic Issues API
+ *     Documentation</a>
  */
 public class EpicsApi extends AbstractApi {
 
-    public EpicsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public EpicsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a list of all epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpics(Object groupIdOrPath) throws GitLabApiException {
-        return (getEpics(groupIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a list of all epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpics(final Object groupIdOrPath) throws GitLabApiException {
+    return (getEpics(groupIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups using the specified page and per page setting.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return a list of all epics of the requested group and its subgroups in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpics(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups", getGroupIdOrPath(groupIdOrPath), "epics");
-        return (response.readEntity(new GenericType<List<Epic>>() { }));
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups using the specified page and per page
+   * setting.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return a list of all epics of the requested group and its subgroups in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpics(final Object groupIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics");
+    return (response.readEntity(new GenericType<List<Epic>>() {}));
+  }
 
-    /**
-     * Get a Pager of all epics of the requested group and its subgroups.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of issues per page
-     * @return the Pager of all epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Epic> getEpics(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Epic>(this, Epic.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics"));
-    }
+  /**
+   * Get a Pager of all epics of the requested group and its subgroups.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of issues per page
+   * @return the Pager of all epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Epic> getEpics(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Epic>(
+        this, Epic.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics"));
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of all epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Epic> getEpicsStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getEpics(groupIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups as a Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of all epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Epic> getEpicsStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getEpics(groupIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param authorId returns epics created by the given user id
-     * @param labels return epics matching a comma separated list of labels names.
-     *        Label names from the epic group or a parent group can be used
-     * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
-     * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
-     * @param search search epics against their title and description
-     * @return a list of matching epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpics(Object groupIdOrPath, Long authorId, String labels, EpicOrderBy orderBy,
-            SortOrder sortOrder, String search) throws GitLabApiException {
-        return (getEpics(groupIdOrPath, authorId, labels, orderBy, sortOrder, search, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param authorId returns epics created by the given user id
+   * @param labels return epics matching a comma separated list of labels names. Label names from
+   *     the epic group or a parent group can be used
+   * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
+   * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
+   * @param search search epics against their title and description
+   * @return a list of matching epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpics(
+      final Object groupIdOrPath,
+      final Long authorId,
+      final String labels,
+      final EpicOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search)
+      throws GitLabApiException {
+    return (getEpics(
+            groupIdOrPath, authorId, labels, orderBy, sortOrder, search, getDefaultPerPage())
+        .all());
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups using the specified page and per page setting.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param authorId returns epics created by the given user id
-     * @param labels return epics matching a comma separated list of labels names
-     *        Label names from the epic group or a parent group can be used
-     * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
-     * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
-     * @param search search epics against their title and description
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return a list of matching epics of the requested group and its subgroups in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpics(Object groupIdOrPath, Long authorId, String labels,
-            EpicOrderBy orderBy, SortOrder sortOrder, String search, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm(page, perPage)
-                .withParam("author_id", authorId)
-                .withParam("labels", labels)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sortOrder)
-                .withParam("search", search);
-        Response response = get(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "epics");
-        return (response.readEntity(new GenericType<List<Epic>>() { }));
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups using the specified page and per page
+   * setting.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param authorId returns epics created by the given user id
+   * @param labels return epics matching a comma separated list of labels names Label names from the
+   *     epic group or a parent group can be used
+   * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
+   * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
+   * @param search search epics against their title and description
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return a list of matching epics of the requested group and its subgroups in the specified
+   *     range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpics(
+      final Object groupIdOrPath,
+      final Long authorId,
+      final String labels,
+      final EpicOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm(page, perPage)
+            .withParam("author_id", authorId)
+            .withParam("labels", labels)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sortOrder)
+            .withParam("search", search);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics");
+    return (response.readEntity(new GenericType<List<Epic>>() {}));
+  }
 
-    /**
-     * Get a Pager of all epics of the requested group and its subgroups.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param authorId returns epics created by the given user id
-     * @param labels return epics matching a comma separated list of labels names.
-     *        Label names from the epic group or a parent group can be used
-     * @param itemsPerPage the number of issues per page
-     * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
-     * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
-     * @param search search epics against their title and description
-     * @return the Pager of matching epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Epic> getEpics(Object groupIdOrPath, Long authorId, String labels,
-            EpicOrderBy orderBy, SortOrder sortOrder, String search, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("author_id", authorId)
-                .withParam("labels", labels)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sortOrder)
-                .withParam("search", search);
-        return (new Pager<Epic>(this, Epic.class, itemsPerPage, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "epics"));
-    }
+  /**
+   * Get a Pager of all epics of the requested group and its subgroups.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param authorId returns epics created by the given user id
+   * @param labels return epics matching a comma separated list of labels names. Label names from
+   *     the epic group or a parent group can be used
+   * @param itemsPerPage the number of issues per page
+   * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
+   * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
+   * @param search search epics against their title and description
+   * @return the Pager of matching epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Epic> getEpics(
+      final Object groupIdOrPath,
+      final Long authorId,
+      final String labels,
+      final EpicOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("author_id", authorId)
+            .withParam("labels", labels)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sortOrder)
+            .withParam("search", search);
+    return (new Pager<Epic>(
+        this,
+        Epic.class,
+        itemsPerPage,
+        formData.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "epics"));
+  }
 
-    /**
-     * Gets all epics of the requested group and its subgroups as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param authorId returns epics created by the given user id
-     * @param labels return epics matching a comma separated list of labels names.
-     *        Label names from the epic group or a parent group can be used
-     * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
-     * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
-     * @param search search epics against their title and description
-     * @return a Stream of matching epics of the requested group and its subgroups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Epic> getEpicsStream(Object groupIdOrPath, Long authorId, String labels, EpicOrderBy orderBy,
-            SortOrder sortOrder, String search) throws GitLabApiException {
-        return (getEpics(groupIdOrPath, authorId, labels, orderBy, sortOrder, search, getDefaultPerPage()).stream());
-    }
+  /**
+   * Gets all epics of the requested group and its subgroups as a Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param authorId returns epics created by the given user id
+   * @param labels return epics matching a comma separated list of labels names. Label names from
+   *     the epic group or a parent group can be used
+   * @param orderBy return epics ordered by CREATED_AT or UPDATED_AT. Default is CREATED_AT
+   * @param sortOrder return epics sorted in ASC or DESC order. Default is DESC
+   * @param search search epics against their title and description
+   * @return a Stream of matching epics of the requested group and its subgroups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Epic> getEpicsStream(
+      final Object groupIdOrPath,
+      final Long authorId,
+      final String labels,
+      final EpicOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search)
+      throws GitLabApiException {
+    return (getEpics(
+        groupIdOrPath, authorId, labels, orderBy, sortOrder, search, getDefaultPerPage())
+        .stream());
+  }
 
-    /**
-     * Get a single epic for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get
-     * @return an Epic instance for the specified Epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Epic getEpic(Object groupIdOrPath, Long epicIid) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid);
-        return (response.readEntity(Epic.class));
-    }
+  /**
+   * Get a single epic for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get
+   * @return an Epic instance for the specified Epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Epic getEpic(final Object groupIdOrPath, final Long epicIid) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid);
+    return (response.readEntity(Epic.class));
+  }
 
-    /**
-     * Get an Optional instance with the value for the specific Epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get
-     * @return an Optional instance with the specified Epic as a value
-     */
-    public Optional<Epic> getOptionalEpic(Object groupIdOrPath, Long epicIid) {
-        try {
-            return (Optional.ofNullable(getEpic(groupIdOrPath, epicIid)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+  /**
+   * Get an Optional instance with the value for the specific Epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get
+   * @return an Optional instance with the specified Epic as a value
+   */
+  public Optional<Epic> getOptionalEpic(final Object groupIdOrPath, final Long epicIid) {
+    try {
+      return (Optional.ofNullable(getEpic(groupIdOrPath, epicIid)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Creates a new epic.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param title the title of the epic (required)
-     * @param labels comma separated list of labels (optional)
-     * @param description the description of the epic (optional)
-     * @param startDate the start date of the epic (optional)
-     * @param endDate the end date of the epic (optional)
-     * @return an Epic instance containing info on the newly created epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Epic createEpic(Object groupIdOrPath, String title, String labels, String description,
-            Date startDate, Date endDate) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("labels", labels)
-                .withParam("description", description)
-                .withParam("start_date", startDate)
-                .withParam("end_date", endDate);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics");
-        return (response.readEntity(Epic.class));
-    }
+  /**
+   * Creates a new epic.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param title the title of the epic (required)
+   * @param labels comma separated list of labels (optional)
+   * @param description the description of the epic (optional)
+   * @param startDate the start date of the epic (optional)
+   * @param endDate the end date of the epic (optional)
+   * @return an Epic instance containing info on the newly created epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Epic createEpic(
+      final Object groupIdOrPath,
+      final String title,
+      final String labels,
+      final String description,
+      final Date startDate,
+      final Date endDate)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("labels", labels)
+            .withParam("description", description)
+            .withParam("start_date", startDate)
+            .withParam("end_date", endDate);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics");
+    return (response.readEntity(Epic.class));
+  }
 
-    /**
-     * Creates a new epic using the information contained in the provided Epic instance.  Only the following
-     * fields from the Epic instance are used:
-     * <pre><code>
-     *      title - the title of the epic (required)
-     *      labels - comma separated list of labels (optional)
-     *      description - the description of the epic (optional)
-     *      startDate - the start date of the epic (optional)
-     *      endDate - the end date of the epic (optional)
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/epics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epic the Epic instance with information for the new epic
-     * @return an Epic instance containing info on the newly created epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Epic createEpic(Object groupIdOrPath, Epic epic) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("title", epic.getTitle(), true)
-                .withParam("labels", epic.getLabels())
-                .withParam("description", epic.getDescription())
-                .withParam("start_date", epic.getStartDate())
-                .withParam("end_date", epic.getEndDate());
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics");
-        return (response.readEntity(Epic.class));
-    }
+  /**
+   * Creates a new epic using the information contained in the provided Epic instance. Only the
+   * following fields from the Epic instance are used:
+   *
+   * <pre><code>
+   *      title - the title of the epic (required)
+   *      labels - comma separated list of labels (optional)
+   *      description - the description of the epic (optional)
+   *      startDate - the start date of the epic (optional)
+   *      endDate - the end date of the epic (optional)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/epics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epic the Epic instance with information for the new epic
+   * @return an Epic instance containing info on the newly created epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Epic createEpic(final Object groupIdOrPath, final Epic epic) throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("title", epic.getTitle(), true)
+            .withParam("labels", epic.getLabels())
+            .withParam("description", epic.getDescription())
+            .withParam("start_date", epic.getStartDate())
+            .withParam("end_date", epic.getEndDate());
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics");
+    return (response.readEntity(Epic.class));
+  }
 
-    /**
-     * Updates an existing epic.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to update
-     * @param title the title of the epic (optional)
-     * @param labels comma separated list of labels (optional)
-     * @param description the description of the epic (optional)
-     * @param startDate the start date of the epic (optional)
-     * @param endDate the end date of the epic (optional)
-     * @return an Epic instance containing info on the newly created epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Epic updateEpic(Object groupIdOrPath, Long epicIid, String title, String labels, String description,
-            Date startDate, Date endDate) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("labels", labels)
-                .withParam("description", description)
-                .withParam("start_date", startDate)
-                .withParam("end_date", endDate);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid);
-        return (response.readEntity(Epic.class));
-    }
+  /**
+   * Updates an existing epic.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to update
+   * @param title the title of the epic (optional)
+   * @param labels comma separated list of labels (optional)
+   * @param description the description of the epic (optional)
+   * @param startDate the start date of the epic (optional)
+   * @param endDate the end date of the epic (optional)
+   * @return an Epic instance containing info on the newly created epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Epic updateEpic(
+      final Object groupIdOrPath,
+      final Long epicIid,
+      final String title,
+      final String labels,
+      final String description,
+      final Date startDate,
+      final Date endDate)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("labels", labels)
+            .withParam("description", description)
+            .withParam("start_date", startDate)
+            .withParam("end_date", endDate);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid);
+    return (response.readEntity(Epic.class));
+  }
 
-    /**
-     * Updates an epic using the information contained in the provided Epic instance.  Only the following
-     * fields from the Epic instance are used:
-     * <pre><code>
-     *      title - the title of the epic (optional)
-     *      labels - comma separated list of labels (optional)
-     *      description - the description of the epic (optional)
-     *      startDate - the start date of the epic (optional)
-     *      endDate - the end date of the epic (optional)
-     * </code></pre>
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to update
-     * @param epic the Epic instance with update information
-     * @return an Epic instance containing info on the updated epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Epic updateEpic(Object groupIdOrPath, Long epicIid, Epic epic) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("title", epic.getTitle(), true)
-                .withParam("labels", epic.getLabels())
-                .withParam("description", epic.getDescription())
-                .withParam("start_date", epic.getStartDate())
-                .withParam("end_date", epic.getEndDate());
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid);
-        return (response.readEntity(Epic.class));
-    }
+  /**
+   * Updates an epic using the information contained in the provided Epic instance. Only the
+   * following fields from the Epic instance are used:
+   *
+   * <pre><code>
+   *      title - the title of the epic (optional)
+   *      labels - comma separated list of labels (optional)
+   *      description - the description of the epic (optional)
+   *      startDate - the start date of the epic (optional)
+   *      endDate - the end date of the epic (optional)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to update
+   * @param epic the Epic instance with update information
+   * @return an Epic instance containing info on the updated epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Epic updateEpic(final Object groupIdOrPath, final Long epicIid, final Epic epic)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("title", epic.getTitle(), true)
+            .withParam("labels", epic.getLabels())
+            .withParam("description", epic.getDescription())
+            .withParam("start_date", epic.getStartDate())
+            .withParam("end_date", epic.getEndDate());
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid);
+    return (response.readEntity(Epic.class));
+  }
 
-    /**
-     * Deletes an epic.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/epics/:epic_iid</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteEpic(Object groupIdOrPath, Long epicIid) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid);
-    }
+  /**
+   * Deletes an epic.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/epics/:epic_iid</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteEpic(final Object groupIdOrPath, final Long epicIid) throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "epics",
+        epicIid);
+  }
 
-    /**
-     * Gets all issues that are assigned to an epic and the authenticated user has access to.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get issues for
-     * @return a list of all epic issues belonging to the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpicIssues(Object groupIdOrPath, Long epicIid) throws GitLabApiException {
-        return (getEpicIssues(groupIdOrPath, epicIid, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets all issues that are assigned to an epic and the authenticated user has access to.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get issues for
+   * @return a list of all epic issues belonging to the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpicIssues(final Object groupIdOrPath, final Long epicIid)
+      throws GitLabApiException {
+    return (getEpicIssues(groupIdOrPath, epicIid, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Gets all issues that are assigned to an epic and the authenticated user has access to
-     * using the specified page and per page setting.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get issues for
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return a list of all epic issues belonging to the specified epic in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Epic> getEpicIssues(Object groupIdOrPath, Long epicIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid, "issues");
-        return (response.readEntity(new GenericType<List<Epic>>() { }));
-    }
+  /**
+   * Gets all issues that are assigned to an epic and the authenticated user has access to using the
+   * specified page and per page setting.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get issues for
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return a list of all epic issues belonging to the specified epic in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Epic> getEpicIssues(
+      final Object groupIdOrPath, final Long epicIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid,
+            "issues");
+    return (response.readEntity(new GenericType<List<Epic>>() {}));
+  }
 
-    /**
-     * Get a Pager of all issues that are assigned to an epic and the authenticated user has access to.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get issues for
-     * @param itemsPerPage the number of issues per page
-     * @return the Pager of all epic issues belonging to the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Epic> getEpicIssues(Object groupIdOrPath, Long epicIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Epic>(this, Epic.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid, "issues"));
-    }
+  /**
+   * Get a Pager of all issues that are assigned to an epic and the authenticated user has access
+   * to.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get issues for
+   * @param itemsPerPage the number of issues per page
+   * @return the Pager of all epic issues belonging to the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Epic> getEpicIssues(
+      final Object groupIdOrPath, final Long epicIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Epic>(
+        this,
+        Epic.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "epics",
+        epicIid,
+        "issues"));
+  }
 
-    /**
-     * Gets all issues that are assigned to an epic and the authenticated user has access to as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the IID of the epic to get issues for
-     * @return a Stream of all epic issues belonging to the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Epic> getEpicIssuesStream(Object groupIdOrPath, Long epicIid) throws GitLabApiException {
-        return (getEpicIssues(groupIdOrPath, epicIid, getDefaultPerPage()).stream());
-    }
+  /**
+   * Gets all issues that are assigned to an epic and the authenticated user has access to as a
+   * Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/epics/:epic_iid/issues</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the IID of the epic to get issues for
+   * @return a Stream of all epic issues belonging to the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Epic> getEpicIssuesStream(final Object groupIdOrPath, final Long epicIid)
+      throws GitLabApiException {
+    return (getEpicIssues(groupIdOrPath, epicIid, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Creates an epic - issue association. If the issue in question belongs to another epic
-     * it is unassigned from that epic.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the Epic IID to assign the issue to
-     * @param issueIid the issue IID of the issue to assign to the epic
-     * @return an EpicIssue instance containing info on the newly assigned epic issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public EpicIssue assignIssue(Object groupIdOrPath, Long epicIid, Long issueIid) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (Form)null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid, "issues", issueIid);
-        return (response.readEntity(EpicIssue.class));
-    }
+  /**
+   * Creates an epic - issue association. If the issue in question belongs to another epic it is
+   * unassigned from that epic.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the Epic IID to assign the issue to
+   * @param issueIid the issue IID of the issue to assign to the epic
+   * @return an EpicIssue instance containing info on the newly assigned epic issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public EpicIssue assignIssue(final Object groupIdOrPath, final Long epicIid, final Long issueIid)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (Form) null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid,
+            "issues",
+            issueIid);
+    return (response.readEntity(EpicIssue.class));
+  }
 
-    /**
-     * Remove an epic - issue association.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the Epic IID to remove the issue from
-     * @param issueIid the issue IID of the issue to remove from the epic
-     * @return an EpicIssue instance containing info on the removed issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public EpicIssue removeIssue(Object groupIdOrPath, Long epicIid, Long issueIid) throws GitLabApiException {
-        Response response = delete(Response.Status.OK, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid, "issues", issueIid);
-        return (response.readEntity(EpicIssue.class));
-    }
+  /**
+   * Remove an epic - issue association.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the Epic IID to remove the issue from
+   * @param issueIid the issue IID of the issue to remove from the epic
+   * @return an EpicIssue instance containing info on the removed issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public EpicIssue removeIssue(final Object groupIdOrPath, final Long epicIid, final Long issueIid)
+      throws GitLabApiException {
+    final Response response =
+        delete(
+            Response.Status.OK,
+            null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid,
+            "issues",
+            issueIid);
+    return (response.readEntity(EpicIssue.class));
+  }
 
-    /**
-     * Updates an epic - issue association.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param epicIid the Epic IID that the issue is assigned to
-     * @param issueIid the issue IID to update
-     * @param moveBeforeId the ID of the issue - epic association that should be placed before the link in the question (optional)
-     * @param moveAfterId the ID of the issue - epic association that should be placed after the link in the question (optional)
-     * @return an EpicIssue instance containing info on the newly assigned epic issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public EpicIssue updateIssue(Object groupIdOrPath, Long epicIid, Long issueIid, Long moveBeforeId, Long moveAfterId) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm()
+  /**
+   * Updates an epic - issue association.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/epics/:epic_iid/issues/:issue_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param epicIid the Epic IID that the issue is assigned to
+   * @param issueIid the issue IID to update
+   * @param moveBeforeId the ID of the issue - epic association that should be placed before the
+   *     link in the question (optional)
+   * @param moveAfterId the ID of the issue - epic association that should be placed after the link
+   *     in the question (optional)
+   * @return an EpicIssue instance containing info on the newly assigned epic issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public EpicIssue updateIssue(
+      final Object groupIdOrPath,
+      final Long epicIid,
+      final Long issueIid,
+      final Long moveBeforeId,
+      final Long moveAfterId)
+      throws GitLabApiException {
+    final GitLabApiForm form =
+        new GitLabApiForm()
             .withParam("move_before_id", moveBeforeId)
             .withParam("move_after_id", moveAfterId);
-        Response response = post(Response.Status.OK, form,
-                "groups", getGroupIdOrPath(groupIdOrPath), "epics", epicIid, "issues", issueIid);
-        return (response.readEntity(EpicIssue.class));
-    }
+    final Response response =
+        post(
+            Response.Status.OK,
+            form,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "epics",
+            epicIid,
+            "issues",
+            issueIid);
+    return (response.readEntity(EpicIssue.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/EventsApi.java
+++ b/src/main/java/org/gitlab4j/api/EventsApi.java
@@ -3,10 +3,8 @@ package org.gitlab4j.api;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Event;
 
 /**
@@ -14,7 +12,7 @@ import org.gitlab4j.api.models.Event;
  */
 public class EventsApi extends AbstractApi {
 
-    public EventsApi(GitLabApi gitLabApi) {
+    public EventsApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -31,8 +29,8 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public List<Event> getAuthenticatedUserEvents(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage()).all());
     }
 
@@ -49,8 +47,8 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getAllAuthenticatedUserEvents(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public List<Event> getAllAuthenticatedUserEvents(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), EventScope.ALL).all());
     }
 
@@ -69,8 +67,8 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder, int page, int perPage) throws GitLabApiException {
+    public List<Event> getAuthenticatedUserEvents(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder, final int page, final int perPage) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, page, perPage, null));
     }
 
@@ -86,14 +84,14 @@ public class EventsApi extends AbstractApi {
      * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
      * @param page the page to get
      * @param perPage the number of projects per page
-     * @param scope include all events across a user’s projects, optional 
+     * @param scope include all events across a user’s projects, optional
      * @return a list of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder, int page, int perPage, EventScope scope) throws GitLabApiException {
+    public List<Event> getAuthenticatedUserEvents(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder, final int page, final int perPage, final EventScope scope) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -103,7 +101,7 @@ public class EventsApi extends AbstractApi {
                 .withParam(PER_PAGE_PARAM, perPage)
                 .withParam("scope", scope != null ? scope.toValue().toLowerCase() : null);
 
-        Response response = get(Response.Status.OK, formData.asMap(), "events");
+        final Response response = get(Response.Status.OK, formData.asMap(), "events");
         return (response.readEntity(new GenericType<List<Event>>() {}));
     }
 
@@ -121,8 +119,8 @@ public class EventsApi extends AbstractApi {
      * @return a Pager of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType, Date before, Date after,
-            SortOrder sortOrder, int itemsPerPage) throws GitLabApiException {
+    public Pager<Event> getAuthenticatedUserEvents(final ActionType action, final TargetType targetType, final Date before, final Date after,
+            final SortOrder sortOrder, final int itemsPerPage) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, itemsPerPage, null));
     }
 
@@ -137,14 +135,14 @@ public class EventsApi extends AbstractApi {
      * @param after include only events created after a particular date, optional
      * @param sortOrder sort events in ASC or DESC order by created_at. Default is DESC, optional
      * @param itemsPerPage the number of Event instances that will be fetched per page
-     * @param scope include all events across a user’s projects, optional 
+     * @param scope include all events across a user’s projects, optional
      * @return a Pager of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Event> getAuthenticatedUserEvents(ActionType action, TargetType targetType, Date before, Date after,
-            SortOrder sortOrder, int itemsPerPage, EventScope scope) throws GitLabApiException {
+    public Pager<Event> getAuthenticatedUserEvents(final ActionType action, final TargetType targetType, final Date before, final Date after,
+            final SortOrder sortOrder, final int itemsPerPage, final EventScope scope) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -168,8 +166,8 @@ public class EventsApi extends AbstractApi {
      * @return a Stream of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Event> getAuthenticatedUserEventsStream(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public Stream<Event> getAuthenticatedUserEventsStream(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), null).stream());
     }
 
@@ -186,8 +184,8 @@ public class EventsApi extends AbstractApi {
      * @return a Stream of events for the authenticated user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Event> getAllAuthenticatedUserEventsStream(ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public Stream<Event> getAllAuthenticatedUserEventsStream(final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getAuthenticatedUserEvents(action, targetType, before, after, sortOrder, getDefaultPerPage(), EventScope.ALL).stream());
     }
 
@@ -205,8 +203,8 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the specified user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getUserEvents(Object userIdOrUsername, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public List<Event> getUserEvents(final Object userIdOrUsername, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getUserEvents(userIdOrUsername, action, targetType, before, after, sortOrder, getDefaultPerPage()).all());
     }
 
@@ -226,10 +224,10 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the specified user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getUserEvents(Object userIdOrUsername, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder, int page, int perPage) throws GitLabApiException {
+    public List<Event> getUserEvents(final Object userIdOrUsername, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder, final int page, final int perPage) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -238,7 +236,7 @@ public class EventsApi extends AbstractApi {
                 .withParam(PAGE_PARAM,  page)
                 .withParam(PER_PAGE_PARAM, perPage);
 
-        Response response = get(Response.Status.OK, formData.asMap(),
+        final Response response = get(Response.Status.OK, formData.asMap(),
                 "users", getUserIdOrUsername(userIdOrUsername), "events");
         return (response.readEntity(new GenericType<List<Event>>() {}));
     }
@@ -258,10 +256,10 @@ public class EventsApi extends AbstractApi {
      * @return a Pager of events for the specified user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Event> getUserEvents(Object userIdOrUsername, ActionType action, TargetType targetType, Date before, Date after,
-            SortOrder sortOrder, int itemsPerPage) throws GitLabApiException {
+    public Pager<Event> getUserEvents(final Object userIdOrUsername, final ActionType action, final TargetType targetType, final Date before, final Date after,
+            final SortOrder sortOrder, final int itemsPerPage) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -286,8 +284,8 @@ public class EventsApi extends AbstractApi {
      * @return a Stream of events for the specified user and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Event> getUserEventsStream(Object userIdOrUsername, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public Stream<Event> getUserEventsStream(final Object userIdOrUsername, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getUserEvents(userIdOrUsername, action, targetType, before, after, sortOrder, getDefaultPerPage()).stream());
     }
 
@@ -305,8 +303,8 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the specified project and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getProjectEvents(Object projectIdOrPath, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public List<Event> getProjectEvents(final Object projectIdOrPath, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getProjectEvents(projectIdOrPath, action, targetType, before, after, sortOrder, getDefaultPerPage()).all());
     }
 
@@ -326,10 +324,10 @@ public class EventsApi extends AbstractApi {
      * @return a list of events for the specified project and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Event> getProjectEvents(Object projectIdOrPath, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder, int page, int perPage) throws GitLabApiException {
+    public List<Event> getProjectEvents(final Object projectIdOrPath, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder, final int page, final int perPage) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -338,7 +336,7 @@ public class EventsApi extends AbstractApi {
                 .withParam(PAGE_PARAM,  page)
                 .withParam(PER_PAGE_PARAM, perPage);
 
-        Response response = get(Response.Status.OK, formData.asMap(),
+        final Response response = get(Response.Status.OK, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "events");
         return (response.readEntity(new GenericType<List<Event>>() {}));
     }
@@ -358,10 +356,10 @@ public class EventsApi extends AbstractApi {
      * @return a Pager of events for the specified project and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Event> getProjectEvents(Object projectIdOrPath, ActionType action, TargetType targetType, Date before, Date after,
-            SortOrder sortOrder, int itemsPerPage) throws GitLabApiException {
+    public Pager<Event> getProjectEvents(final Object projectIdOrPath, final ActionType action, final TargetType targetType, final Date before, final Date after,
+            final SortOrder sortOrder, final int itemsPerPage) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action)
                 .withParam("target_type", targetType != null ? targetType.toValue().toLowerCase() : null)
                 .withParam("before", before)
@@ -386,8 +384,8 @@ public class EventsApi extends AbstractApi {
      * @return a Stream of events for the specified project and matching the supplied parameters
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Event> getProjectEventsStream(Object projectIdOrPath, ActionType action, TargetType targetType,
-            Date before, Date after, SortOrder sortOrder) throws GitLabApiException {
+    public Stream<Event> getProjectEventsStream(final Object projectIdOrPath, final ActionType action, final TargetType targetType,
+            final Date before, final Date after, final SortOrder sortOrder) throws GitLabApiException {
         return (getProjectEvents(projectIdOrPath, action, targetType, before, after, sortOrder, getDefaultPerPage()).stream());
     }
 }

--- a/src/main/java/org/gitlab4j/api/ExternalStatusCheckApi.java
+++ b/src/main/java/org/gitlab4j/api/ExternalStatusCheckApi.java
@@ -3,10 +3,8 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.ExternalStatusCheck;
 import org.gitlab4j.api.models.ExternalStatusCheckProtectedBranch;
 import org.gitlab4j.api.models.ExternalStatusCheckResult;
@@ -14,262 +12,398 @@ import org.gitlab4j.api.models.ExternalStatusCheckStatus;
 import org.gitlab4j.api.models.ExternalStatusCheckStatus.Status;
 
 /**
- * This class implements the client side API for the GitLab external status checks.
- * See <a href="https://docs.gitlab.com/ee/api/status_checks.html">External Status Checks API</a> for more information.
+ * This class implements the client side API for the GitLab external status checks. See <a
+ * href="https://docs.gitlab.com/ee/api/status_checks.html">External Status Checks API</a> for more
+ * information.
  */
 public class ExternalStatusCheckApi extends AbstractApi {
 
-    public ExternalStatusCheckApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public ExternalStatusCheckApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Gets a list of all external status checks for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a List of ExternalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ExternalStatusCheck> getExternalStatusChecks(Object projectIdOrPath) throws GitLabApiException {
-        return (getExternalStatusChecks(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets a list of all external status checks for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a List of ExternalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ExternalStatusCheck> getExternalStatusChecks(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getExternalStatusChecks(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Gets a Pager of all external status checks for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param itemsPerPage the number of ExternalStatusCheck instances that will be fetched per page
-     * @return the Pager of ExternalStatusCheck instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ExternalStatusCheck> getExternalStatusChecks(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<ExternalStatusCheck>(this, ExternalStatusCheck.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks"));
-    }
+  /**
+   * Gets a Pager of all external status checks for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param itemsPerPage the number of ExternalStatusCheck instances that will be fetched per page
+   * @return the Pager of ExternalStatusCheck instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ExternalStatusCheck> getExternalStatusChecks(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<ExternalStatusCheck>(
+        this,
+        ExternalStatusCheck.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "external_status_checks"));
+  }
 
-    /**
-     * Gets a Stream of all external status checks for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Stream of ExternalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ExternalStatusCheck> getExternalStatusChecksStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getExternalStatusChecks(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Gets a Stream of all external status checks for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/external_status_checks</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Stream of ExternalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ExternalStatusCheck> getExternalStatusChecksStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getExternalStatusChecks(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Creates a new external status check.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/external_status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name Display name of external status check (required)
-     * @param externalUrl URL of external status check resource (optional)
-     * @param protectedBranchIds IDs of protected branches to scope the rule by (optional)
-     * @return an ExternalStatusCheck instance containing info on the newly created externalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalStatusCheck createExternalStatusCheck(Object projectIdOrPath, String name, String externalUrl, List<Long> protectedBranchIds) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("external_url", externalUrl, true)
-                .withParam("protected_branch_ids", protectedBranchIds);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks");
-        return (response.readEntity(ExternalStatusCheck.class));
-    }
+  /**
+   * Creates a new external status check.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/external_status_checks</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name Display name of external status check (required)
+   * @param externalUrl URL of external status check resource (optional)
+   * @param protectedBranchIds IDs of protected branches to scope the rule by (optional)
+   * @return an ExternalStatusCheck instance containing info on the newly created
+   *     externalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalStatusCheck createExternalStatusCheck(
+      final Object projectIdOrPath,
+      final String name,
+      final String externalUrl,
+      final List<Long> protectedBranchIds)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("external_url", externalUrl, true)
+            .withParam("protected_branch_ids", protectedBranchIds);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "external_status_checks");
+    return (response.readEntity(ExternalStatusCheck.class));
+  }
 
-    /**
-     * Creates a new external status check using the information contained in the provided ExternalStatusCheck instance. Only the following
-     * fields from the ExternalStatusCheck instance are used:
-     * <pre><code>
-     *      name - Display name of external status check (required)
-     *      external url - URL of external status check resource (required)
-     *      protected branches - the id of the protected branches (optional)
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/external_status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param externalStatusCheck the ExternalStatusCheck instance with information for the new external status check
-     * @return an ExternalStatusCheck instance containing info on the newly created externalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalStatusCheck createExternalStatusCheck(Object projectIdOrPath, ExternalStatusCheck externalStatusCheck) throws GitLabApiException {
-        List<Long> protectedBranchIds;
-        if(externalStatusCheck.getProtectedBranches() == null) {
-            protectedBranchIds = null;
-        } else {
-            protectedBranchIds = externalStatusCheck.getProtectedBranches().stream().map(ExternalStatusCheckProtectedBranch::getId).collect(Collectors.toList());
-        }
-        Form formData = new GitLabApiForm()
-                .withParam("name", externalStatusCheck.getName(), true)
-                .withParam("external_url", externalStatusCheck.getExternalUrl(), true)
-                .withParam("protected_branch_ids", protectedBranchIds);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks");
-        return (response.readEntity(ExternalStatusCheck.class));
+  /**
+   * Creates a new external status check using the information contained in the provided
+   * ExternalStatusCheck instance. Only the following fields from the ExternalStatusCheck instance
+   * are used:
+   *
+   * <pre><code>
+   *      name - Display name of external status check (required)
+   *      external url - URL of external status check resource (required)
+   *      protected branches - the id of the protected branches (optional)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/external_status_checks</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param externalStatusCheck the ExternalStatusCheck instance with information for the new
+   *     external status check
+   * @return an ExternalStatusCheck instance containing info on the newly created
+   *     externalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalStatusCheck createExternalStatusCheck(
+      final Object projectIdOrPath, final ExternalStatusCheck externalStatusCheck)
+      throws GitLabApiException {
+    final List<Long> protectedBranchIds;
+    if (externalStatusCheck.getProtectedBranches() == null) {
+      protectedBranchIds = null;
+    } else {
+      protectedBranchIds =
+          externalStatusCheck.getProtectedBranches().stream()
+              .map(ExternalStatusCheckProtectedBranch::getId)
+              .collect(Collectors.toList());
     }
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", externalStatusCheck.getName(), true)
+            .withParam("external_url", externalStatusCheck.getExternalUrl(), true)
+            .withParam("protected_branch_ids", protectedBranchIds);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "external_status_checks");
+    return (response.readEntity(ExternalStatusCheck.class));
+  }
 
-    /**
-     * Updates an existing external status check.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/external_status_checks/:check_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param checkId ID of an external status check to update (required)
-     * @param name Display name of external status check (optional)
-     * @param externalUrl URL of external status check resource (optional)
-     * @param protectedBranchIds IDs of protected branches to scope the rule by (optional)
-     * @return an ExternalStatusCheck instance containing info on the newly created ExternalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalStatusCheck updateExternalStatusCheck(Object projectIdOrPath, Long checkId, String name, String externalUrl, List<Long> protectedBranchIds) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("name", name)
-                .withParam("external_url", externalUrl)
-                .withParam("protected_branch_ids", protectedBranchIds);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks", checkId);
-        return (response.readEntity(ExternalStatusCheck.class));
+  /**
+   * Updates an existing external status check.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/external_status_checks/:check_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param checkId ID of an external status check to update (required)
+   * @param name Display name of external status check (optional)
+   * @param externalUrl URL of external status check resource (optional)
+   * @param protectedBranchIds IDs of protected branches to scope the rule by (optional)
+   * @return an ExternalStatusCheck instance containing info on the newly created
+   *     ExternalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalStatusCheck updateExternalStatusCheck(
+      final Object projectIdOrPath,
+      final Long checkId,
+      final String name,
+      final String externalUrl,
+      final List<Long> protectedBranchIds)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name)
+            .withParam("external_url", externalUrl)
+            .withParam("protected_branch_ids", protectedBranchIds);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "external_status_checks",
+            checkId);
+    return (response.readEntity(ExternalStatusCheck.class));
+  }
+
+  /**
+   * Updates an external status check using the information contained in the provided
+   * ExternalStatusCheck instance. Only the following fields from the ExternalStatusCheck instance
+   * are used:
+   *
+   * <pre><code>
+   *      id - the id of the external status check (required)
+   *      name - Display name of external status check (optional)
+   *      external url - URL of external status check resource (optional)
+   *      protected branches - the id of the protected branches (optional)
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/external_status_checks/:check_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param externalStatusCheck the ExternalStatusCheck instance with update information
+   * @return an ExternalStatusCheck instance containing info on the updated ExternalStatusCheck
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalStatusCheck updateExternalStatusCheck(
+      final Object projectIdOrPath, final ExternalStatusCheck externalStatusCheck)
+      throws GitLabApiException {
+    if (externalStatusCheck == null || externalStatusCheck.getId() == null) {
+      throw new GitLabApiException("the specified external status check is null or has no id");
     }
+    final List<Long> protectedBranchIds = getProtectedBranchIds(externalStatusCheck);
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", externalStatusCheck.getName())
+            .withParam("external_url", externalStatusCheck.getExternalUrl())
+            .withParam("protected_branch_ids", protectedBranchIds);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "external_status_checks",
+            externalStatusCheck.getId());
+    return (response.readEntity(ExternalStatusCheck.class));
+  }
 
-    /**
-     * Updates an external status check using the information contained in the provided ExternalStatusCheck instance. Only the following
-     * fields from the ExternalStatusCheck instance are used:
-     * <pre><code>
-     *      id - the id of the external status check (required)
-     *      name - Display name of external status check (optional)
-     *      external url - URL of external status check resource (optional)
-     *      protected branches - the id of the protected branches (optional)
-     * </code></pre>
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/external_status_checks/:check_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param externalStatusCheck the ExternalStatusCheck instance with update information
-     * @return an ExternalStatusCheck instance containing info on the updated ExternalStatusCheck
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalStatusCheck updateExternalStatusCheck(Object projectIdOrPath, ExternalStatusCheck externalStatusCheck) throws GitLabApiException {
-        if (externalStatusCheck == null || externalStatusCheck.getId() == null) {
-            throw new GitLabApiException("the specified external status check is null or has no id");
-        }
-        List<Long> protectedBranchIds = getProtectedBranchIds(externalStatusCheck);
-        Form formData = new GitLabApiForm()
-                .withParam("name", externalStatusCheck.getName())
-                .withParam("external_url", externalStatusCheck.getExternalUrl())
-                .withParam("protected_branch_ids", protectedBranchIds);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks", externalStatusCheck.getId());
-        return (response.readEntity(ExternalStatusCheck.class));
+  private List<Long> getProtectedBranchIds(final ExternalStatusCheck externalStatusCheck) {
+    if (externalStatusCheck.getProtectedBranches() == null) {
+      return null;
     }
+    return externalStatusCheck.getProtectedBranches().stream()
+        .map(ExternalStatusCheckProtectedBranch::getId)
+        .collect(Collectors.toList());
+  }
 
-    private List<Long> getProtectedBranchIds(ExternalStatusCheck externalStatusCheck) {
-        if(externalStatusCheck.getProtectedBranches() == null) {
-            return null;
-        }
-        return externalStatusCheck.getProtectedBranches().stream().map(ExternalStatusCheckProtectedBranch::getId).collect(Collectors.toList());
-    }
+  /**
+   * Deletes an external status check.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/external_status_checks/:check_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param checkId ID of an external status check
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteExternalStatusCheck(final Object projectIdOrPath, final Long checkId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "external_status_checks",
+        checkId);
+  }
 
-    /**
-     * Deletes an external status check.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/external_status_checks/:check_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param checkId ID of an external status check
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteExternalStatusCheck(Object projectIdOrPath, Long checkId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "external_status_checks", checkId);
-    }
+  /**
+   * Gets a list of all statuses of the external status checks for a given merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the statuses
+   * @return a List of ExternalStatusCheckStatus
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ExternalStatusCheckStatus> getExternalStatusCheckStatuses(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getExternalStatusCheckStatuses(projectIdOrPath, mergeRequestIid, getDefaultPerPage())
+        .all());
+  }
 
-    /**
-     * Gets a list of all statuses of the external status checks for a given merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the statuses
-     * @return a List of ExternalStatusCheckStatus
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ExternalStatusCheckStatus> getExternalStatusCheckStatuses(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getExternalStatusCheckStatuses(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets a Pager of all statuses of the external status checks for a given merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the statuses
+   * @param itemsPerPage the number of ExternalStatusCheckStatus instances that will be fetched per
+   *     page
+   * @return the Pager of ExternalStatusCheckStatus instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ExternalStatusCheckStatus> getExternalStatusCheckStatuses(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<ExternalStatusCheckStatus>(
+        this,
+        ExternalStatusCheckStatus.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "status_checks"));
+  }
 
-    /**
-     * Gets a Pager of all statuses of the external status checks for a given merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the statuses
-     * @param itemsPerPage the number of ExternalStatusCheckStatus instances that will be fetched per page
-     * @return the Pager of ExternalStatusCheckStatus instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ExternalStatusCheckStatus> getExternalStatusCheckStatuses(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<ExternalStatusCheckStatus>(this, ExternalStatusCheckStatus.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "status_checks"));
-    }
+  /**
+   * Gets a Stream of all statuses of the external status checks for a given merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the statuses
+   * @return a Stream of ExternalStatusCheckStatus
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ExternalStatusCheckStatus> getExternalStatusCheckStatusesStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getExternalStatusCheckStatuses(projectIdOrPath, mergeRequestIid, getDefaultPerPage())
+        .stream());
+  }
 
-    /**
-     * Gets a Stream of all statuses of the external status checks for a given merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/status_checks</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the statuses
-     * @return a Stream of ExternalStatusCheckStatus
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ExternalStatusCheckStatus> getExternalStatusCheckStatusesStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getExternalStatusCheckStatuses(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
+  /**
+   * Set the status of an external status check for a given merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/status_check_responses</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the statuses
+   * @param sha the commit SHA to set the status for (required)
+   * @param externalStatusCheckId ID of an external status check (required)
+   * @param status the status to set (optional)
+   * @return an ExternalStatusCheckResult instance containing info on the newly created status
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalStatusCheckResult setStatusOfExternalStatusCheck(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String sha,
+      final Long externalStatusCheckId,
+      final Status status)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("sha", sha)
+            .withParam("external_status_check_id", externalStatusCheckId)
+            .withParam("status", status);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "status_check_responses");
+    return (response.readEntity(ExternalStatusCheckResult.class));
+  }
 
-    /**
-     * Set the status of an external status check for a given merge request.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/status_check_responses</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the statuses
-     * @param sha the commit SHA to set the status for (required)
-     * @param externalStatusCheckId ID of an external status check (required)
-     * @param status the status to set (optional)
-     * @return an ExternalStatusCheckResult instance containing info on the newly created status
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalStatusCheckResult setStatusOfExternalStatusCheck(Object projectIdOrPath, Long mergeRequestIid, String sha, Long externalStatusCheckId, Status status) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("sha", sha)
-                .withParam("external_status_check_id", externalStatusCheckId)
-                .withParam("status", status);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "status_check_responses");
-        return (response.readEntity(ExternalStatusCheckResult.class));
-    }
-
-    /**
-     * Retry the specified failed external status check for a single merge request. Even though the merge request hasn’t changed, this endpoint resends the current state of merge request to the defined external service.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/status_checks/:external_status_check_id/retry</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the merge request IID to get the statuses
-     * @param externalStatusCheckId ID of an external status check
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void retryExternalStatusCheck(Object projectIdOrPath, Long mergeRequestIid, Long externalStatusCheckId) throws GitLabApiException {
-        post(Response.Status.ACCEPTED, (Form)null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "status_checks", externalStatusCheckId, "retry");
-    }
-
+  /**
+   * Retry the specified failed external status check for a single merge request. Even though the
+   * merge request hasn’t changed, this endpoint resends the current state of merge request to the
+   * defined external service.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/status_checks/:external_status_check_id/retry</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the merge request IID to get the statuses
+   * @param externalStatusCheckId ID of an external status check
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void retryExternalStatusCheck(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long externalStatusCheckId)
+      throws GitLabApiException {
+    post(
+        Response.Status.ACCEPTED,
+        (Form) null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "status_checks",
+        externalStatusCheckId,
+        "retry");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -8,10 +8,8 @@ import java.util.WeakHashMap;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.Constants.TokenType;
 import org.gitlab4j.api.models.OauthTokenResponse;
 import org.gitlab4j.api.models.User;
@@ -26,1741 +24,1928 @@ import org.gitlab4j.api.utils.SecretString;
  */
 public class GitLabApi implements AutoCloseable {
 
-    private final static Logger LOGGER = Logger.getLogger(GitLabApi.class.getName());
+  private static final Logger LOGGER = Logger.getLogger(GitLabApi.class.getName());
 
-    /** GitLab4J default per page.  GitLab will ignore anything over 100. */
-    public static final int DEFAULT_PER_PAGE = 96;
+  /** GitLab4J default per page. GitLab will ignore anything over 100. */
+  public static final int DEFAULT_PER_PAGE = 96;
 
-    /** Specifies the version of the GitLab API to communicate with. */
-    public enum ApiVersion {
-        V3, V4;
+  /** Specifies the version of the GitLab API to communicate with. */
+  public enum ApiVersion {
+    V3,
+    V4;
 
-        public String getApiNamespace() {
-            return ("/api/" + name().toLowerCase());
-        }
+    public String getApiNamespace() {
+      return ("/api/" + name().toLowerCase());
+    }
+  }
+
+  // Used to keep track of GitLabApiExceptions on calls that return Optional<?>
+  private static final Map<Integer, GitLabApiException> optionalExceptionMap =
+      Collections.synchronizedMap(new WeakHashMap<Integer, GitLabApiException>());
+
+  GitLabApiClient apiClient;
+  private final ApiVersion apiVersion;
+  private final String gitLabServerUrl;
+  private final Map<String, Object> clientConfigProperties;
+  private int defaultPerPage = DEFAULT_PER_PAGE;
+
+  private ApplicationsApi applicationsApi;
+  private ApplicationSettingsApi applicationSettingsApi;
+  private AuditEventApi auditEventApi;
+  private AwardEmojiApi awardEmojiApi;
+  private BoardsApi boardsApi;
+  private CommitsApi commitsApi;
+  private ContainerRegistryApi containerRegistryApi;
+  private DiscussionsApi discussionsApi;
+  private DeployKeysApi deployKeysApi;
+  private DeploymentsApi deploymentsApi;
+  private DeployTokensApi deployTokensApi;
+  private EnvironmentsApi environmentsApi;
+  private EpicsApi epicsApi;
+  private EventsApi eventsApi;
+  private ExternalStatusCheckApi externalStatusCheckApi;
+  private GroupApi groupApi;
+  private HealthCheckApi healthCheckApi;
+  private ImportExportApi importExportApi;
+  private IssuesApi issuesApi;
+  private JobApi jobApi;
+  private LabelsApi labelsApi;
+  private LicenseApi licenseApi;
+  private LicenseTemplatesApi licenseTemplatesApi;
+  private MarkdownApi markdownApi;
+  private MergeRequestApi mergeRequestApi;
+  private MilestonesApi milestonesApi;
+  private NamespaceApi namespaceApi;
+  private NotesApi notesApi;
+  private NotificationSettingsApi notificationSettingsApi;
+  private PackagesApi packagesApi;
+  private PipelineApi pipelineApi;
+  private ProjectApi projectApi;
+  private ProtectedBranchesApi protectedBranchesApi;
+  private ReleasesApi releasesApi;
+  private RepositoryApi repositoryApi;
+  private RepositoryFileApi repositoryFileApi;
+  private ResourceLabelEventsApi resourceLabelEventsApi;
+  private ResourceStateEventsApi resourceStateEventsApi;
+  private RunnersApi runnersApi;
+  private SearchApi searchApi;
+  private ServicesApi servicesApi;
+  private SnippetsApi snippetsApi;
+  private SystemHooksApi systemHooksApi;
+  private TagsApi tagsApi;
+  private TodosApi todosApi;
+  private UserApi userApi;
+  private WikisApi wikisApi;
+  private KeysApi keysApi;
+
+  /**
+   * Get the GitLab4J shared Logger instance.
+   *
+   * @return the GitLab4J shared Logger instance
+   */
+  public static final Logger getLogger() {
+    return (LOGGER);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4. This is the primary way to authenticate with the GitLab REST API.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   */
+  public GitLabApi(final String hostUrl, final String personalAccessToken) {
+    this(ApiVersion.V4, hostUrl, personalAccessToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApi(
+      final String hostUrl, final String personalAccessToken, final String secretToken) {
+    this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, personalAccessToken, secretToken);
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a CharSequence containing the password for a given {@code username}
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url, final String username, final CharSequence password)
+      throws GitLabApiException {
+    return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, password, null, null, false));
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a char array holding the password for a given {@code username}
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url, final String username, final char[] password) throws GitLabApiException {
+
+    try (final SecretString secretPassword = new SecretString(password)) {
+      return (GitLabApi.oauth2Login(
+          ApiVersion.V4, url, username, secretPassword, null, null, false));
+    }
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a CharSequence containing the password for a given {@code username}
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url,
+      final String username,
+      final CharSequence password,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+    return (GitLabApi.oauth2Login(
+        ApiVersion.V4, url, username, password, null, null, ignoreCertificateErrors));
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a char array holding the password for a given {@code username}
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url,
+      final String username,
+      final char[] password,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+
+    try (final SecretString secretPassword = new SecretString(password)) {
+      return (GitLabApi.oauth2Login(
+          ApiVersion.V4, url, username, secretPassword, null, null, ignoreCertificateErrors));
+    }
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a CharSequence containing the password for a given {@code username}
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url,
+      final String username,
+      final CharSequence password,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+    return (GitLabApi.oauth2Login(
+        ApiVersion.V4,
+        url,
+        username,
+        password,
+        secretToken,
+        clientConfigProperties,
+        ignoreCertificateErrors));
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param username user name for which private token should be obtained
+   * @param password a char array holding the password for a given {@code username}
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final String url,
+      final String username,
+      final char[] password,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+
+    try (final SecretString secretPassword = new SecretString(password)) {
+      return (GitLabApi.oauth2Login(
+          ApiVersion.V4,
+          url,
+          username,
+          secretPassword,
+          secretToken,
+          clientConfigProperties,
+          ignoreCertificateErrors));
+    }
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param username user name for which private token should be obtained
+   * @param password a char array holding the password for a given {@code username}
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final ApiVersion apiVersion,
+      final String url,
+      final String username,
+      final char[] password,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+
+    try (final SecretString secretPassword = new SecretString(password)) {
+      return (GitLabApi.oauth2Login(
+          apiVersion,
+          url,
+          username,
+          secretPassword,
+          secretToken,
+          clientConfigProperties,
+          ignoreCertificateErrors));
+    }
+  }
+
+  /**
+   * Logs into GitLab using OAuth2 with the provided {@code username} and {@code password}, and
+   * creates a new {@code GitLabApi} instance using returned access token.
+   *
+   * @param url GitLab URL
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param username user name for which private token should be obtained
+   * @param password password for a given {@code username}
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   * @return new {@code GitLabApi} instance configured for a user-specific token
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public static GitLabApi oauth2Login(
+      final ApiVersion apiVersion,
+      final String url,
+      final String username,
+      final CharSequence password,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties,
+      final boolean ignoreCertificateErrors)
+      throws GitLabApiException {
+
+    if (username == null || username.trim().length() == 0) {
+      throw new IllegalArgumentException("both username and email cannot be empty or null");
     }
 
-    // Used to keep track of GitLabApiExceptions on calls that return Optional<?>
-    private static final Map<Integer, GitLabApiException> optionalExceptionMap =
-            Collections.synchronizedMap(new WeakHashMap<Integer, GitLabApiException>());
+    // Create a GitLabApi instance set up to be used to do an OAUTH2 login.
+    GitLabApi gitLabApi = new GitLabApi(apiVersion, url, (String) null);
+    gitLabApi.apiClient.setHostUrlToBaseUrl();
 
-    GitLabApiClient apiClient;
-    private ApiVersion apiVersion;
-    private String gitLabServerUrl;
-    private Map<String, Object> clientConfigProperties;
-    private int defaultPerPage = DEFAULT_PER_PAGE;
-
-    private ApplicationsApi applicationsApi;
-    private ApplicationSettingsApi applicationSettingsApi;
-    private AuditEventApi auditEventApi;
-    private AwardEmojiApi awardEmojiApi;
-    private BoardsApi boardsApi;
-    private CommitsApi commitsApi;
-    private ContainerRegistryApi containerRegistryApi;
-    private DiscussionsApi discussionsApi;
-    private DeployKeysApi deployKeysApi;
-    private DeploymentsApi deploymentsApi;
-    private DeployTokensApi deployTokensApi;
-    private EnvironmentsApi environmentsApi;
-    private EpicsApi epicsApi;
-    private EventsApi eventsApi;
-    private ExternalStatusCheckApi externalStatusCheckApi;
-    private GroupApi groupApi;
-    private HealthCheckApi healthCheckApi;
-    private ImportExportApi importExportApi;
-    private IssuesApi issuesApi;
-    private JobApi jobApi;
-    private LabelsApi labelsApi;
-    private LicenseApi licenseApi;
-    private LicenseTemplatesApi licenseTemplatesApi;
-    private MarkdownApi markdownApi;
-    private MergeRequestApi mergeRequestApi;
-    private MilestonesApi milestonesApi;
-    private NamespaceApi namespaceApi;
-    private NotesApi notesApi;
-    private NotificationSettingsApi notificationSettingsApi;
-    private PackagesApi packagesApi;
-    private PipelineApi pipelineApi;
-    private ProjectApi projectApi;
-    private ProtectedBranchesApi protectedBranchesApi;
-    private ReleasesApi releasesApi;
-    private RepositoryApi repositoryApi;
-    private RepositoryFileApi repositoryFileApi;
-    private ResourceLabelEventsApi resourceLabelEventsApi;
-    private ResourceStateEventsApi resourceStateEventsApi;
-    private RunnersApi runnersApi;
-    private SearchApi searchApi;
-    private ServicesApi servicesApi;
-    private SnippetsApi snippetsApi;
-    private SystemHooksApi systemHooksApi;
-    private TagsApi tagsApi;
-    private TodosApi todosApi;
-    private UserApi userApi;
-    private WikisApi wikisApi;
-    private KeysApi keysApi;
-
-    /**
-     * Get the GitLab4J shared Logger instance.
-     *
-     * @return the GitLab4J shared Logger instance
-     */
-    public static final Logger getLogger() {
-        return (LOGGER);
+    if (ignoreCertificateErrors) {
+      gitLabApi.setIgnoreCertificateErrors(true);
     }
 
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server
-     * using GitLab API version 4.  This is the primary way to authenticate with
-     * the GitLab REST API.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken the private token to use for access to the API
-     */
-    public GitLabApi(String hostUrl, String personalAccessToken) {
-        this(ApiVersion.V4, hostUrl, personalAccessToken, null);
+    class Oauth2Api extends AbstractApi {
+      Oauth2Api(final GitLabApi gitlabApi) {
+        super(gitlabApi);
+      }
     }
 
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken the private token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApi(String hostUrl, String personalAccessToken, String secretToken) {
-        this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, personalAccessToken, secretToken);
+    try (final Oauth2LoginStreamingOutput stream =
+        new Oauth2LoginStreamingOutput(username, password)) {
+
+      final Response response =
+          new Oauth2Api(gitLabApi)
+              .post(Response.Status.OK, stream, MediaType.APPLICATION_JSON, "oauth", "token");
+      final OauthTokenResponse oauthToken = response.readEntity(OauthTokenResponse.class);
+      gitLabApi =
+          new GitLabApi(
+              apiVersion,
+              url,
+              TokenType.OAUTH2_ACCESS,
+              oauthToken.getAccessToken(),
+              secretToken,
+              clientConfigProperties);
+      if (ignoreCertificateErrors) {
+        gitLabApi.setIgnoreCertificateErrors(true);
+      }
+
+      return (gitLabApi);
+    }
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified
+   * GitLab API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion, final String hostUrl, final String personalAccessToken) {
+    this(apiVersion, hostUrl, personalAccessToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified
+   * GitLab API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final String personalAccessToken,
+      final String secretToken) {
+    this(apiVersion, hostUrl, personalAccessToken, secretToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified
+   * GitLab API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to use for access to the API
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken) {
+    this(apiVersion, hostUrl, tokenType, authToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to use for access to the API
+   */
+  public GitLabApi(final String hostUrl, final TokenType tokenType, final String authToken) {
+    this(ApiVersion.V4, hostUrl, tokenType, authToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified
+   * GitLab API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      final String secretToken) {
+    this(apiVersion, hostUrl, tokenType, authToken, secretToken, null);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApi(
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      final String secretToken) {
+    this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server specified by GitLab
+   * API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken to private token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final String personalAccessToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(
+        apiVersion,
+        hostUrl,
+        TokenType.PRIVATE,
+        personalAccessToken,
+        secretToken,
+        clientConfigProperties);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   */
+  public GitLabApi(
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken, clientConfigProperties);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   */
+  public GitLabApi(
+      final String hostUrl,
+      final String personalAccessToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(
+        ApiVersion.V4,
+        hostUrl,
+        TokenType.PRIVATE,
+        personalAccessToken,
+        secretToken,
+        clientConfigProperties);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API
+   * version 4.
+   *
+   * @param hostUrl the URL of the GitLab server
+   * @param personalAccessToken the private token to use for access to the API
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   */
+  public GitLabApi(
+      final String hostUrl,
+      final String personalAccessToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(
+        ApiVersion.V4,
+        hostUrl,
+        TokenType.PRIVATE,
+        personalAccessToken,
+        null,
+        clientConfigProperties);
+  }
+
+  /**
+   * Constructs a GitLabApi instance set up to interact with the GitLab server specified by GitLab
+   * API version.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL of the GitLab server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken to token to use for access to the API
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties Map instance with additional properties for the Jersey client
+   *     connection
+   */
+  public GitLabApi(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this.apiVersion = apiVersion;
+    this.gitLabServerUrl = hostUrl;
+    this.clientConfigProperties = clientConfigProperties;
+    apiClient =
+        new GitLabApiClient(
+            apiVersion, hostUrl, tokenType, authToken, secretToken, clientConfigProperties);
+  }
+
+  /**
+   * Create a new GitLabApi instance that is logically a duplicate of this instance, with the
+   * exception of sudo state.
+   *
+   * @return a new GitLabApi instance that is logically a duplicate of this instance, with the
+   *     exception of sudo state.
+   */
+  public final GitLabApi duplicate() {
+
+    final Long sudoUserId = this.getSudoAsId();
+    final GitLabApi gitLabApi =
+        new GitLabApi(
+            apiVersion,
+            gitLabServerUrl,
+            getTokenType(),
+            getAuthToken(),
+            getSecretToken(),
+            clientConfigProperties);
+    if (sudoUserId != null) {
+      gitLabApi.apiClient.setSudoAsId(sudoUserId);
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a CharSequence containing the password for a given {@code username}
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, CharSequence password) throws GitLabApiException {
-        return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, password, null, null, false));
+    if (getIgnoreCertificateErrors()) {
+      gitLabApi.setIgnoreCertificateErrors(true);
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a char array holding the password for a given {@code username}
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, char[] password) throws GitLabApiException {
+    gitLabApi.defaultPerPage = this.defaultPerPage;
+    return (gitLabApi);
+  }
 
-        try (SecretString secretPassword = new SecretString(password)) {
-            return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, secretPassword, null, null, false));
-        }
+  /** Close the underlying {@link jakarta.ws.rs.client.Client} and its associated resources. */
+  @Override
+  public void close() {
+    if (apiClient != null) {
+      apiClient.close();
+    }
+  }
+
+  /**
+   * Sets the per request connect and read timeout.
+   *
+   * @param connectTimeout the per request connect timeout in milliseconds, can be null to use
+   *     default
+   * @param readTimeout the per request read timeout in milliseconds, can be null to use default
+   */
+  public void setRequestTimeout(final Integer connectTimeout, final Integer readTimeout) {
+    apiClient.setRequestTimeout(connectTimeout, readTimeout);
+  }
+
+  /**
+   * Fluent method that sets the per request connect and read timeout.
+   *
+   * @param connectTimeout the per request connect timeout in milliseconds, can be null to use
+   *     default
+   * @param readTimeout the per request read timeout in milliseconds, can be null to use default
+   * @return this GitLabApi instance
+   */
+  public GitLabApi withRequestTimeout(final Integer connectTimeout, final Integer readTimeout) {
+    apiClient.setRequestTimeout(connectTimeout, readTimeout);
+    return (this);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance and Level.FINE as the level.
+   *
+   * @return this GitLabApi instance
+   */
+  public GitLabApi withRequestResponseLogging() {
+    enableRequestResponseLogging();
+    return (this);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance.
+   *
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @return this GitLabApi instance
+   */
+  public GitLabApi withRequestResponseLogging(final Level level) {
+    enableRequestResponseLogging(level);
+    return (this);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API.
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @return this GitLabApi instance
+   */
+  public GitLabApi withRequestResponseLogging(final Logger logger, final Level level) {
+    enableRequestResponseLogging(logger, level);
+    return (this);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance and Level.FINE as the level.
+   */
+  public void enableRequestResponseLogging() {
+    enableRequestResponseLogging(LOGGER, Level.FINE);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance. Logging will NOT include entity logging and will mask
+   * PRIVATE-TOKEN and Authorization headers.
+   *
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   */
+  public void enableRequestResponseLogging(final Level level) {
+    enableRequestResponseLogging(LOGGER, level, 0);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * specified logger. Logging will NOT include entity logging and will mask PRIVATE-TOKEN and
+   * Authorization headers..
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   */
+  public void enableRequestResponseLogging(final Logger logger, final Level level) {
+    enableRequestResponseLogging(logger, level, 0);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance. Logging will mask PRIVATE-TOKEN and Authorization headers.
+   *
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   */
+  public void enableRequestResponseLogging(final Level level, final int maxEntitySize) {
+    enableRequestResponseLogging(LOGGER, level, maxEntitySize);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * specified logger. Logging will mask PRIVATE-TOKEN and Authorization headers.
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   */
+  public void enableRequestResponseLogging(
+      final Logger logger, final Level level, final int maxEntitySize) {
+    enableRequestResponseLogging(
+        logger, level, maxEntitySize, MaskingLoggingFilter.DEFAULT_MASKED_HEADER_NAMES);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance.
+   *
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public void enableRequestResponseLogging(
+      final Level level, final List<String> maskedHeaderNames) {
+    apiClient.enableRequestResponseLogging(LOGGER, level, 0, maskedHeaderNames);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * specified logger.
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public void enableRequestResponseLogging(
+      final Logger logger, final Level level, final List<String> maskedHeaderNames) {
+    apiClient.enableRequestResponseLogging(logger, level, 0, maskedHeaderNames);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * GitLab4J shared Logger instance.
+   *
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public void enableRequestResponseLogging(
+      final Level level, final int maxEntitySize, final List<String> maskedHeaderNames) {
+    apiClient.enableRequestResponseLogging(LOGGER, level, maxEntitySize, maskedHeaderNames);
+  }
+
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API using the
+   * specified logger.
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public void enableRequestResponseLogging(
+      final Logger logger,
+      final Level level,
+      final int maxEntitySize,
+      final List<String> maskedHeaderNames) {
+    apiClient.enableRequestResponseLogging(logger, level, maxEntitySize, maskedHeaderNames);
+  }
+
+  /**
+   * Sets up all future calls to the GitLab API to be done as another user specified by
+   * sudoAsUsername. To revert back to normal non-sudo operation you must call unsudo(), or pass
+   * null as the username.
+   *
+   * @param sudoAsUsername the username to sudo as, null will turn off sudo
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void sudo(final String sudoAsUsername) throws GitLabApiException {
+
+    if (sudoAsUsername == null || sudoAsUsername.trim().length() == 0) {
+      apiClient.setSudoAsId(null);
+      return;
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a CharSequence containing the password for a given {@code username}
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, CharSequence password, boolean ignoreCertificateErrors) throws GitLabApiException {
-        return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, password, null, null, ignoreCertificateErrors));
+    // Get the User specified by username, if you are not an admin or the username is not found,
+    // this will fail
+    final User user = getUserApi().getUser(sudoAsUsername);
+    if (user == null || user.getId() == null) {
+      throw new GitLabApiException("the specified username was not found");
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a char array holding the password for a given {@code username}
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, char[] password, boolean ignoreCertificateErrors) throws GitLabApiException {
+    final Long sudoAsId = user.getId();
+    apiClient.setSudoAsId(sudoAsId);
+  }
 
-        try (SecretString secretPassword = new SecretString(password)) {
-            return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, secretPassword, null, null, ignoreCertificateErrors));
-        }
+  /** Turns off the currently configured sudo as ID. */
+  public void unsudo() {
+    apiClient.setSudoAsId(null);
+  }
+
+  /**
+   * Sets up all future calls to the GitLab API to be done as another user specified by provided
+   * user ID. To revert back to normal non-sudo operation you must call unsudo(), or pass null as
+   * the sudoAsId.
+   *
+   * @param sudoAsId the ID of the user to sudo as, null will turn off sudo
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void setSudoAsId(final Long sudoAsId) throws GitLabApiException {
+
+    if (sudoAsId == null) {
+      apiClient.setSudoAsId(null);
+      return;
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a CharSequence containing the password for a given {@code username}
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, CharSequence password, String secretToken,
-            Map<String, Object> clientConfigProperties, boolean ignoreCertificateErrors) throws GitLabApiException {
-        return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, password, secretToken, clientConfigProperties, ignoreCertificateErrors));
+    // Get the User specified by the sudoAsId, if you are not an admin or the username is not found,
+    // this will fail
+    final User user = getUserApi().getUser(sudoAsId);
+    if (user == null || !user.getId().equals(sudoAsId)) {
+      throw new GitLabApiException("the specified user ID was not found");
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param username user name for which private token should be obtained
-     * @param password a char array holding the password for a given {@code username}
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(String url, String username, char[] password, String secretToken,
-            Map<String, Object> clientConfigProperties, boolean ignoreCertificateErrors) throws GitLabApiException {
+    apiClient.setSudoAsId(sudoAsId);
+  }
 
-        try (SecretString secretPassword = new SecretString(password)) {
-            return (GitLabApi.oauth2Login(ApiVersion.V4, url, username, secretPassword,
-                secretToken, clientConfigProperties, ignoreCertificateErrors));
-        }
+  /**
+   * Get the current sudo as ID, will return null if not in sudo mode.
+   *
+   * @return the current sudo as ID, will return null if not in sudo mode
+   */
+  public Long getSudoAsId() {
+    return (apiClient.getSudoAsId());
+  }
+
+  /**
+   * Get the auth token being used by this client.
+   *
+   * @return the auth token being used by this client
+   */
+  public String getAuthToken() {
+    return (apiClient.getAuthToken());
+  }
+
+  /**
+   * Set auth token supplier for gitlab api client.
+   *
+   * @param authTokenSupplier - supplier which provide actual auth token
+   */
+  public void setAuthTokenSupplier(final Supplier<String> authTokenSupplier) {
+    apiClient.setAuthTokenSupplier(authTokenSupplier);
+  }
+
+  /**
+   * Get the secret token.
+   *
+   * @return the secret token
+   */
+  public String getSecretToken() {
+    return (apiClient.getSecretToken());
+  }
+
+  /**
+   * Get the TokenType this client is using.
+   *
+   * @return the TokenType this client is using
+   */
+  public TokenType getTokenType() {
+    return (apiClient.getTokenType());
+  }
+
+  /**
+   * Return the GitLab API version that this instance is using.
+   *
+   * @return the GitLab API version that this instance is using
+   */
+  public ApiVersion getApiVersion() {
+    return (apiVersion);
+  }
+
+  /**
+   * Get the URL to the GitLab server.
+   *
+   * @return the URL to the GitLab server
+   */
+  public String getGitLabServerUrl() {
+    return (gitLabServerUrl);
+  }
+
+  /**
+   * Get the default number per page for calls that return multiple items.
+   *
+   * @return the default number per page for calls that return multiple item
+   */
+  public int getDefaultPerPage() {
+    return (defaultPerPage);
+  }
+
+  /**
+   * Set the default number per page for calls that return multiple items.
+   *
+   * @param defaultPerPage the new default number per page for calls that return multiple item
+   */
+  public void setDefaultPerPage(final int defaultPerPage) {
+    this.defaultPerPage = defaultPerPage;
+  }
+
+  /**
+   * Return the GitLabApiClient associated with this instance. This is used by all the sub API
+   * classes to communicate with the GitLab API.
+   *
+   * @return the GitLabApiClient associated with this instance
+   */
+  GitLabApiClient getApiClient() {
+    return (apiClient);
+  }
+
+  /**
+   * Returns true if the API is setup to ignore SSL certificate errors, otherwise returns false.
+   *
+   * @return true if the API is setup to ignore SSL certificate errors, otherwise returns false
+   */
+  public boolean getIgnoreCertificateErrors() {
+    return (apiClient.getIgnoreCertificateErrors());
+  }
+
+  /**
+   * Sets up the Jersey system ignore SSL certificate errors or not.
+   *
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   */
+  public void setIgnoreCertificateErrors(final boolean ignoreCertificateErrors) {
+    apiClient.setIgnoreCertificateErrors(ignoreCertificateErrors);
+  }
+
+  /**
+   * Get the version info for the GitLab server using the GitLab Version API.
+   *
+   * @return the version info for the GitLab server
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Version getVersion() throws GitLabApiException {
+
+    class VersionApi extends AbstractApi {
+      VersionApi(final GitLabApi gitlabApi) {
+        super(gitlabApi);
+      }
     }
 
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param username user name for which private token should be obtained
-     * @param password a char array holding the password for a given {@code username}
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(ApiVersion apiVersion, String url, String username, char[] password, String secretToken,
-            Map<String, Object> clientConfigProperties, boolean ignoreCertificateErrors) throws GitLabApiException {
-
-        try (SecretString secretPassword = new SecretString(password)) {
-            return (GitLabApi.oauth2Login(apiVersion, url, username, secretPassword,
-                secretToken, clientConfigProperties, ignoreCertificateErrors));
-        }
-    }
-
-    /**
-     * <p>Logs into GitLab using OAuth2 with the provided {@code username} and {@code password},
-     * and creates a new {@code GitLabApi} instance using returned access token.</p>
-     *
-     * @param url GitLab URL
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param username user name for which private token should be obtained
-     * @param password password for a given {@code username}
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     * @return new {@code GitLabApi} instance configured for a user-specific token
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public static GitLabApi oauth2Login(ApiVersion apiVersion, String url, String username, CharSequence password,
-            String secretToken, Map<String, Object> clientConfigProperties, boolean ignoreCertificateErrors) throws GitLabApiException {
-
-        if (username == null || username.trim().length() == 0) {
-            throw new IllegalArgumentException("both username and email cannot be empty or null");
-        }
-
-        // Create a GitLabApi instance set up to be used to do an OAUTH2 login.
-        GitLabApi gitLabApi = new GitLabApi(apiVersion, url, (String)null);
-        gitLabApi.apiClient.setHostUrlToBaseUrl();
-
-        if (ignoreCertificateErrors) {
-            gitLabApi.setIgnoreCertificateErrors(true);
-        }
-
-        class Oauth2Api extends AbstractApi {
-            Oauth2Api(GitLabApi gitlabApi) {
-                super(gitlabApi);
-            }
-        }
-
-        try (Oauth2LoginStreamingOutput stream = new Oauth2LoginStreamingOutput(username, password)) {
-
-            Response response = new Oauth2Api(gitLabApi).post(Response.Status.OK, stream, MediaType.APPLICATION_JSON, "oauth", "token");
-            OauthTokenResponse oauthToken = response.readEntity(OauthTokenResponse.class);
-            gitLabApi = new GitLabApi(apiVersion, url, TokenType.OAUTH2_ACCESS, oauthToken.getAccessToken(), secretToken, clientConfigProperties);
-            if (ignoreCertificateErrors) {
-                gitLabApi.setIgnoreCertificateErrors(true);
-            }
-
-            return (gitLabApi);
-        }
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken the private token to use for access to the API
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, String personalAccessToken) {
-        this(apiVersion, hostUrl, personalAccessToken, null);
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken the private token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, String personalAccessToken, String secretToken) {
-        this(apiVersion, hostUrl, personalAccessToken, secretToken, null);
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to use for access to the API
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken) {
-        this(apiVersion, hostUrl, tokenType, authToken, null);
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to use for access to the API
-     */
-    public GitLabApi(String hostUrl, TokenType tokenType, String authToken) {
-        this(ApiVersion.V4, hostUrl, tokenType, authToken, null);
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using the specified GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken, String secretToken) {
-        this(apiVersion, hostUrl, tokenType, authToken, secretToken, null);
-    }
-
-    /**
-     * Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApi(String hostUrl, TokenType tokenType, String authToken, String secretToken) {
-        this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken);
-    }
-
-    /**
-     *  Constructs a GitLabApi instance set up to interact with the GitLab server specified by GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken to private token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, String personalAccessToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this(apiVersion, hostUrl, TokenType.PRIVATE, personalAccessToken, secretToken, clientConfigProperties);
-    }
-
-    /**
-     *  Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     */
-    public GitLabApi(String hostUrl, TokenType tokenType, String authToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken, clientConfigProperties);
-    }
-
-   /**
-     *  Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-     *
-     * @param hostUrl the URL of the GitLab server
-     * @param personalAccessToken the private token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     */
-    public GitLabApi(String hostUrl, String personalAccessToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, personalAccessToken, secretToken, clientConfigProperties);
-    }
-
-    /**
-      *  Constructs a GitLabApi instance set up to interact with the GitLab server using GitLab API version 4.
-      *
-      * @param hostUrl the URL of the GitLab server
-      * @param personalAccessToken the private token to use for access to the API
-      * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-      */
-     public GitLabApi(String hostUrl, String personalAccessToken, Map<String, Object> clientConfigProperties) {
-         this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, personalAccessToken, null, clientConfigProperties);
-     }
-
-    /**
-     *  Constructs a GitLabApi instance set up to interact with the GitLab server specified by GitLab API version.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL of the GitLab server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken to token to use for access to the API
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties Map instance with additional properties for the Jersey client connection
-     */
-    public GitLabApi(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this.apiVersion = apiVersion;
-        this.gitLabServerUrl = hostUrl;
-        this.clientConfigProperties = clientConfigProperties;
-        apiClient = new GitLabApiClient(apiVersion, hostUrl, tokenType, authToken, secretToken, clientConfigProperties);
-    }
-
-    /**
-     * Create a new GitLabApi instance that is logically a duplicate of this instance, with the exception of sudo state.
-     *
-     * @return a new GitLabApi instance that is logically a duplicate of this instance, with the exception of sudo state.
-     */
-    public final GitLabApi duplicate() {
-
-        Long sudoUserId = this.getSudoAsId();
-        GitLabApi gitLabApi = new GitLabApi(apiVersion, gitLabServerUrl,
-                getTokenType(), getAuthToken(), getSecretToken(), clientConfigProperties);
-        if (sudoUserId != null) {
-            gitLabApi.apiClient.setSudoAsId(sudoUserId);
-        }
-
-        if (getIgnoreCertificateErrors()) {
-            gitLabApi.setIgnoreCertificateErrors(true);
-        }
-
-        gitLabApi.defaultPerPage = this.defaultPerPage;
-        return (gitLabApi);
-    }
-
-    /**
-     * Close the underlying {@link javax.ws.rs.client.Client} and its associated resources.
-     */
-    @Override
-    public void close() {
-        if (apiClient != null) {
-            apiClient.close();
-        }
-    }
-
-    /**
-     * Sets the per request connect and read timeout.
-     *
-     * @param connectTimeout the per request connect timeout in milliseconds, can be null to use default
-     * @param readTimeout the per request read timeout in milliseconds, can be null to use default
-     */
-    public void setRequestTimeout(Integer connectTimeout, Integer readTimeout) {
-	apiClient.setRequestTimeout(connectTimeout, readTimeout);
-    }
-
-    /**
-     * Fluent method that sets the per request connect and read timeout.
-     *
-     * @param connectTimeout the per request connect timeout in milliseconds, can be null to use default
-     * @param readTimeout the per request read timeout in milliseconds, can be null to use default
-     * @return this GitLabApi instance
-     */
-    public GitLabApi withRequestTimeout(Integer connectTimeout, Integer readTimeout) {
-	apiClient.setRequestTimeout(connectTimeout, readTimeout);
-	return (this);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API
-     * using the GitLab4J shared Logger instance and Level.FINE as the level.
-     *
-     * @return this GitLabApi instance
-     */
-    public GitLabApi withRequestResponseLogging() {
-        enableRequestResponseLogging();
-        return (this);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API
-     * using the GitLab4J shared Logger instance.
-     *
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @return this GitLabApi instance
-     */
-    public GitLabApi withRequestResponseLogging(Level level) {
-        enableRequestResponseLogging(level);
-        return (this);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API.
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @return this GitLabApi instance
-     */
-    public GitLabApi withRequestResponseLogging(Logger logger, Level level) {
-        enableRequestResponseLogging(logger, level);
-        return (this);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API
-     * using the GitLab4J shared Logger instance and Level.FINE as the level.
-     */
-    public void enableRequestResponseLogging() {
-        enableRequestResponseLogging(LOGGER, Level.FINE);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API
-     * using the GitLab4J shared Logger instance. Logging will NOT include entity logging and
-     * will mask PRIVATE-TOKEN and Authorization headers.
-     *
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     */
-    public void enableRequestResponseLogging(Level level) {
-        enableRequestResponseLogging(LOGGER, level, 0);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * specified logger. Logging will NOT include entity logging and will mask PRIVATE-TOKEN
-     * and Authorization headers..
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     */
-    public void enableRequestResponseLogging(Logger logger, Level level) {
-        enableRequestResponseLogging(logger, level, 0);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * GitLab4J shared Logger instance. Logging will mask PRIVATE-TOKEN and Authorization headers.
-     *
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     */
-    public void enableRequestResponseLogging(Level level, int maxEntitySize) {
-        enableRequestResponseLogging(LOGGER, level, maxEntitySize);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * specified logger. Logging will mask PRIVATE-TOKEN and Authorization headers.
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     */
-    public void enableRequestResponseLogging(Logger logger, Level level, int maxEntitySize) {
-        enableRequestResponseLogging(logger, level, maxEntitySize, MaskingLoggingFilter.DEFAULT_MASKED_HEADER_NAMES);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * GitLab4J shared Logger instance.
-     *
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public void enableRequestResponseLogging(Level level, List<String> maskedHeaderNames) {
-        apiClient.enableRequestResponseLogging(LOGGER, level, 0, maskedHeaderNames);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * specified logger.
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public void enableRequestResponseLogging(Logger logger, Level level, List<String> maskedHeaderNames) {
-        apiClient.enableRequestResponseLogging(logger, level, 0, maskedHeaderNames);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * GitLab4J shared Logger instance.
-     *
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public void enableRequestResponseLogging(Level level, int maxEntitySize, List<String> maskedHeaderNames) {
-        apiClient.enableRequestResponseLogging(LOGGER, level, maxEntitySize, maskedHeaderNames);
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API using the
-     * specified logger.
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public void enableRequestResponseLogging(Logger logger, Level level, int maxEntitySize, List<String> maskedHeaderNames) {
-        apiClient.enableRequestResponseLogging(logger, level, maxEntitySize, maskedHeaderNames);
-    }
-
-    /**
-     * Sets up all future calls to the GitLab API to be done as another user specified by sudoAsUsername.
-     * To revert back to normal non-sudo operation you must call unsudo(), or pass null as the username.
-     *
-     * @param sudoAsUsername the username to sudo as, null will turn off sudo
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void sudo(String sudoAsUsername) throws GitLabApiException {
-
-        if (sudoAsUsername == null || sudoAsUsername.trim().length() == 0) {
-            apiClient.setSudoAsId(null);
-            return;
-        }
-
-        // Get the User specified by username, if you are not an admin or the username is not found, this will fail
-        User user = getUserApi().getUser(sudoAsUsername);
-        if (user == null || user.getId() == null) {
-            throw new GitLabApiException("the specified username was not found");
-        }
-
-        Long sudoAsId = user.getId();
-        apiClient.setSudoAsId(sudoAsId);
-    }
-
-    /**
-     * Turns off the currently configured sudo as ID.
-     */
-    public void unsudo() {
-        apiClient.setSudoAsId(null);
-    }
-
-    /**
-     * Sets up all future calls to the GitLab API to be done as another user specified by provided user ID.
-     * To revert back to normal non-sudo operation you must call unsudo(), or pass null as the sudoAsId.
-     *
-     * @param sudoAsId the ID of the user to sudo as, null will turn off sudo
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void setSudoAsId(Long sudoAsId) throws GitLabApiException {
-
-        if (sudoAsId == null) {
-            apiClient.setSudoAsId(null);
-            return;
-        }
-
-        // Get the User specified by the sudoAsId, if you are not an admin or the username is not found, this will fail
-        User user = getUserApi().getUser(sudoAsId);
-        if (user == null || !user.getId().equals(sudoAsId)) {
-            throw new GitLabApiException("the specified user ID was not found");
-        }
-
-        apiClient.setSudoAsId(sudoAsId);
-    }
-
-    /**
-     * Get the current sudo as ID, will return null if not in sudo mode.
-     *
-     * @return the current sudo as ID, will return null if not in sudo mode
-     */
-    public Long getSudoAsId() {
-        return (apiClient.getSudoAsId());
-    }
-
-    /**
-     * Get the auth token being used by this client.
-     *
-     * @return the auth token being used by this client
-     */
-    public String getAuthToken() {
-        return (apiClient.getAuthToken());
-    }
-
-    /**
-     * Set auth token supplier for gitlab api client.
-     * @param authTokenSupplier - supplier which provide actual auth token
-     */
-    public void setAuthTokenSupplier(Supplier<String> authTokenSupplier) {
-        apiClient.setAuthTokenSupplier(authTokenSupplier);
-    }
-
-    /**
-     * Get the secret token.
-     *
-     * @return the secret token
-     */
-    public String getSecretToken() {
-        return (apiClient.getSecretToken());
-    }
-
-    /**
-     * Get the TokenType this client is using.
-     *
-     * @return the TokenType this client is using
-     */
-    public TokenType getTokenType() {
-        return (apiClient.getTokenType());
-    }
-
-    /**
-     * Return the GitLab API version that this instance is using.
-     *
-     * @return the GitLab API version that this instance is using
-     */
-    public ApiVersion getApiVersion() {
-        return (apiVersion);
-    }
-
-    /**
-     * Get the URL to the GitLab server.
-     *
-     * @return the URL to the GitLab server
-     */
-    public String getGitLabServerUrl() {
-        return (gitLabServerUrl);
-    }
-
-    /**
-     * Get the default number per page for calls that return multiple items.
-     *
-     * @return the default number per page for calls that return multiple item
-     */
-    public int getDefaultPerPage() {
-        return (defaultPerPage);
-    }
-
-    /**
-     * Set the default number per page for calls that return multiple items.
-     *
-     * @param defaultPerPage the new default number per page for calls that return multiple item
-     */
-    public void setDefaultPerPage(int defaultPerPage) {
-        this.defaultPerPage = defaultPerPage;
-    }
-
-    /**
-     * Return the GitLabApiClient associated with this instance. This is used by all the sub API classes
-     * to communicate with the GitLab API.
-     *
-     * @return the GitLabApiClient associated with this instance
-     */
-    GitLabApiClient getApiClient() {
-        return (apiClient);
-    }
-
-    /**
-     * Returns true if the API is setup to ignore SSL certificate errors, otherwise returns false.
-     *
-     * @return true if the API is setup to ignore SSL certificate errors, otherwise returns false
-     */
-    public boolean getIgnoreCertificateErrors() {
-        return (apiClient.getIgnoreCertificateErrors());
-    }
-
-    /**
-     * Sets up the Jersey system ignore SSL certificate errors or not.
-     *
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     */
-    public void setIgnoreCertificateErrors(boolean ignoreCertificateErrors) {
-        apiClient.setIgnoreCertificateErrors(ignoreCertificateErrors);
-    }
-
-    /**
-     * Get the version info for the GitLab server using the GitLab Version API.
-     *
-     * @return the version info for the GitLab server
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Version getVersion() throws GitLabApiException {
-
-        class VersionApi extends AbstractApi {
-            VersionApi(GitLabApi gitlabApi) {
-                super(gitlabApi);
-            }
-        }
-
-        Response response = new VersionApi(this).get(Response.Status.OK, null, "version");
-        return (response.readEntity(Version.class));
-    }
-
-    /**
-     * Gets the ApplicationsApi instance owned by this GitLabApi instance. The ApplicationsApi is used
-     * to perform all OAUTH application related API calls.
-     *
-     * @return the ApplicationsApi instance owned by this GitLabApi instance
-     */
-    public ApplicationsApi getApplicationsApi() {
-
+    final Response response = new VersionApi(this).get(Response.Status.OK, null, "version");
+    return (response.readEntity(Version.class));
+  }
+
+  /**
+   * Gets the ApplicationsApi instance owned by this GitLabApi instance. The ApplicationsApi is used
+   * to perform all OAUTH application related API calls.
+   *
+   * @return the ApplicationsApi instance owned by this GitLabApi instance
+   */
+  public ApplicationsApi getApplicationsApi() {
+
+    if (applicationsApi == null) {
+      synchronized (this) {
         if (applicationsApi == null) {
-            synchronized (this) {
-                if (applicationsApi == null) {
-                    applicationsApi = new ApplicationsApi(this);
-                }
-            }
+          applicationsApi = new ApplicationsApi(this);
         }
-
-        return (applicationsApi);
+      }
     }
 
-    /**
-     * Gets the ApplicationSettingsApi instance owned by this GitLabApi instance. The ApplicationSettingsApi is used
-     * to perform all application settingsrelated API calls.
-     *
-     * @return the ApplicationsApi instance owned by this GitLabApi instance
-     */
-    public ApplicationSettingsApi getApplicationSettingsApi() {
+    return (applicationsApi);
+  }
 
+  /**
+   * Gets the ApplicationSettingsApi instance owned by this GitLabApi instance. The
+   * ApplicationSettingsApi is used to perform all application settingsrelated API calls.
+   *
+   * @return the ApplicationsApi instance owned by this GitLabApi instance
+   */
+  public ApplicationSettingsApi getApplicationSettingsApi() {
+
+    if (applicationSettingsApi == null) {
+      synchronized (this) {
         if (applicationSettingsApi == null) {
-            synchronized (this) {
-                if (applicationSettingsApi == null) {
-                    applicationSettingsApi = new ApplicationSettingsApi(this);
-                }
-            }
+          applicationSettingsApi = new ApplicationSettingsApi(this);
         }
-
-        return (applicationSettingsApi);
+      }
     }
 
-    /**
-     * Gets the AuditEventApi instance owned by this GitLabApi instance. The AuditEventApi is used
-     * to perform all instance audit event API calls.
-     *
-     * @return the AuditEventApi instance owned by this GitLabApi instance
-     */
-    public AuditEventApi getAuditEventApi() {
+    return (applicationSettingsApi);
+  }
 
+  /**
+   * Gets the AuditEventApi instance owned by this GitLabApi instance. The AuditEventApi is used to
+   * perform all instance audit event API calls.
+   *
+   * @return the AuditEventApi instance owned by this GitLabApi instance
+   */
+  public AuditEventApi getAuditEventApi() {
+
+    if (auditEventApi == null) {
+      synchronized (this) {
         if (auditEventApi == null) {
-            synchronized (this) {
-                if (auditEventApi == null) {
-                    auditEventApi = new AuditEventApi(this);
-                }
-            }
+          auditEventApi = new AuditEventApi(this);
         }
-
-        return (auditEventApi);
+      }
     }
 
-    /**
-     * Gets the AwardEmojiApi instance owned by this GitLabApi instance. The AwardEmojiApi is used
-     * to perform all award emoji related API calls.
-     *
-     * @return the AwardEmojiApi instance owned by this GitLabApi instance
-     */
-    public AwardEmojiApi getAwardEmojiApi() {
+    return (auditEventApi);
+  }
 
+  /**
+   * Gets the AwardEmojiApi instance owned by this GitLabApi instance. The AwardEmojiApi is used to
+   * perform all award emoji related API calls.
+   *
+   * @return the AwardEmojiApi instance owned by this GitLabApi instance
+   */
+  public AwardEmojiApi getAwardEmojiApi() {
+
+    if (awardEmojiApi == null) {
+      synchronized (this) {
         if (awardEmojiApi == null) {
-            synchronized (this) {
-                if (awardEmojiApi == null) {
-                    awardEmojiApi = new AwardEmojiApi(this);
-                }
-            }
+          awardEmojiApi = new AwardEmojiApi(this);
         }
-
-        return (awardEmojiApi);
+      }
     }
 
-    /**
-     * Gets the BoardsApi instance owned by this GitLabApi instance. The BoardsApi is used
-     * to perform all Issue Boards related API calls.
-     *
-     * @return the BoardsApi instance owned by this GitLabApi instance
-     */
-    public BoardsApi getBoardsApi() {
+    return (awardEmojiApi);
+  }
 
+  /**
+   * Gets the BoardsApi instance owned by this GitLabApi instance. The BoardsApi is used to perform
+   * all Issue Boards related API calls.
+   *
+   * @return the BoardsApi instance owned by this GitLabApi instance
+   */
+  public BoardsApi getBoardsApi() {
+
+    if (boardsApi == null) {
+      synchronized (this) {
         if (boardsApi == null) {
-            synchronized (this) {
-                if (boardsApi == null) {
-                    boardsApi = new BoardsApi(this);
-                }
-            }
+          boardsApi = new BoardsApi(this);
         }
-
-        return (boardsApi);
+      }
     }
 
-    /**
-     * Gets the CommitsApi instance owned by this GitLabApi instance. The CommitsApi is used
-     * to perform all commit related API calls.
-     *
-     * @return the CommitsApi instance owned by this GitLabApi instance
-     */
-    public CommitsApi getCommitsApi() {
+    return (boardsApi);
+  }
 
+  /**
+   * Gets the CommitsApi instance owned by this GitLabApi instance. The CommitsApi is used to
+   * perform all commit related API calls.
+   *
+   * @return the CommitsApi instance owned by this GitLabApi instance
+   */
+  public CommitsApi getCommitsApi() {
+
+    if (commitsApi == null) {
+      synchronized (this) {
         if (commitsApi == null) {
-            synchronized (this) {
-                if (commitsApi == null) {
-                    commitsApi = new CommitsApi(this);
-                }
-            }
+          commitsApi = new CommitsApi(this);
         }
-
-        return (commitsApi);
+      }
     }
 
-    /**
-     * Gets the ContainerRegistryApi instance owned by this GitLabApi instance. The ContainerRegistryApi is used
-     * to perform all Docker Registry related API calls.
-     *
-     * @return the ContainerRegistryApi instance owned by this GitLabApi instance
-     */
-    public ContainerRegistryApi getContainerRegistryApi() {
+    return (commitsApi);
+  }
 
+  /**
+   * Gets the ContainerRegistryApi instance owned by this GitLabApi instance. The
+   * ContainerRegistryApi is used to perform all Docker Registry related API calls.
+   *
+   * @return the ContainerRegistryApi instance owned by this GitLabApi instance
+   */
+  public ContainerRegistryApi getContainerRegistryApi() {
+
+    if (containerRegistryApi == null) {
+      synchronized (this) {
         if (containerRegistryApi == null) {
-            synchronized (this) {
-                if (containerRegistryApi == null) {
-                    containerRegistryApi = new ContainerRegistryApi(this);
-                }
-            }
+          containerRegistryApi = new ContainerRegistryApi(this);
         }
-
-        return (containerRegistryApi);
+      }
     }
 
-    /**
-     * Gets the DeployKeysApi instance owned by this GitLabApi instance. The DeployKeysApi is used
-     * to perform all deploy key related API calls.
-     *
-     * @return the DeployKeysApi instance owned by this GitLabApi instance
-     */
-    public DeployKeysApi getDeployKeysApi() {
+    return (containerRegistryApi);
+  }
 
+  /**
+   * Gets the DeployKeysApi instance owned by this GitLabApi instance. The DeployKeysApi is used to
+   * perform all deploy key related API calls.
+   *
+   * @return the DeployKeysApi instance owned by this GitLabApi instance
+   */
+  public DeployKeysApi getDeployKeysApi() {
+
+    if (deployKeysApi == null) {
+      synchronized (this) {
         if (deployKeysApi == null) {
-            synchronized (this) {
-                if (deployKeysApi == null) {
-                    deployKeysApi = new DeployKeysApi(this);
-                }
-            }
+          deployKeysApi = new DeployKeysApi(this);
         }
-
-        return (deployKeysApi);
+      }
     }
 
-    /**
-     * Gets the DeployKeysApi instance owned by this GitLabApi instance. The DeploymentsApi is used
-     * to perform all deployment related API calls.
-     *
-     * @return the DeploymentsApi instance owned by this GitLabApi instance
-     */
-    public DeploymentsApi getDeploymentsApi() {
+    return (deployKeysApi);
+  }
 
+  /**
+   * Gets the DeployKeysApi instance owned by this GitLabApi instance. The DeploymentsApi is used to
+   * perform all deployment related API calls.
+   *
+   * @return the DeploymentsApi instance owned by this GitLabApi instance
+   */
+  public DeploymentsApi getDeploymentsApi() {
+
+    if (deploymentsApi == null) {
+      synchronized (this) {
         if (deploymentsApi == null) {
-            synchronized (this) {
-                if (deploymentsApi == null) {
-                    deploymentsApi = new DeploymentsApi(this);
-                }
-            }
+          deploymentsApi = new DeploymentsApi(this);
         }
-
-        return (deploymentsApi);
+      }
     }
 
-    /**
-     * Gets the DeployTokensApi instance owned by this GitLabApi instance. The DeployTokensApi is used
-     * to perform all deploy token related API calls.
-     *
-     * @return the DeployTokensApi instance owned by this GitLabApi instance
-     */
-    public DeployTokensApi getDeployTokensApi(){
+    return (deploymentsApi);
+  }
 
+  /**
+   * Gets the DeployTokensApi instance owned by this GitLabApi instance. The DeployTokensApi is used
+   * to perform all deploy token related API calls.
+   *
+   * @return the DeployTokensApi instance owned by this GitLabApi instance
+   */
+  public DeployTokensApi getDeployTokensApi() {
+
+    if (deployTokensApi == null) {
+      synchronized (this) {
         if (deployTokensApi == null) {
-            synchronized (this) {
-                if (deployTokensApi == null) {
-                    deployTokensApi = new DeployTokensApi(this);
-                }
-            }
+          deployTokensApi = new DeployTokensApi(this);
         }
-
-        return (deployTokensApi);
+      }
     }
 
-    /**
-     * Gets the DiscussionsApi instance owned by this GitLabApi instance. The DiscussionsApi is used
-     * to perform all discussion related API calls.
-     *
-     * @return the DiscussionsApi instance owned by this GitLabApi instance
-     */
-    public DiscussionsApi getDiscussionsApi() {
+    return (deployTokensApi);
+  }
 
+  /**
+   * Gets the DiscussionsApi instance owned by this GitLabApi instance. The DiscussionsApi is used
+   * to perform all discussion related API calls.
+   *
+   * @return the DiscussionsApi instance owned by this GitLabApi instance
+   */
+  public DiscussionsApi getDiscussionsApi() {
+
+    if (discussionsApi == null) {
+      synchronized (this) {
         if (discussionsApi == null) {
-            synchronized (this) {
-                if (discussionsApi == null) {
-                    discussionsApi = new DiscussionsApi(this);
-                }
-            }
+          discussionsApi = new DiscussionsApi(this);
         }
-
-        return (discussionsApi);
+      }
     }
 
-    /**
-     * Gets the EnvironmentsApi instance owned by this GitLabApi instance. The EnvironmentsApi is used
-     * to perform all environment related API calls.
-     *
-     * @return the EnvironmentsApi instance owned by this GitLabApi instance
-     */
-    public EnvironmentsApi getEnvironmentsApi() {
+    return (discussionsApi);
+  }
 
+  /**
+   * Gets the EnvironmentsApi instance owned by this GitLabApi instance. The EnvironmentsApi is used
+   * to perform all environment related API calls.
+   *
+   * @return the EnvironmentsApi instance owned by this GitLabApi instance
+   */
+  public EnvironmentsApi getEnvironmentsApi() {
+
+    if (environmentsApi == null) {
+      synchronized (this) {
         if (environmentsApi == null) {
-            synchronized (this) {
-                if (environmentsApi == null) {
-                    environmentsApi = new EnvironmentsApi(this);
-                }
-            }
+          environmentsApi = new EnvironmentsApi(this);
         }
-
-        return (environmentsApi);
+      }
     }
 
-    /**
-     * Gets the EpicsApi instance owned by this GitLabApi instance. The EpicsApi is used
-     * to perform all Epics and Epic Issues related API calls.
-     *
-     * @return the EpicsApi instance owned by this GitLabApi instance
-     */
-    public EpicsApi getEpicsApi() {
+    return (environmentsApi);
+  }
 
+  /**
+   * Gets the EpicsApi instance owned by this GitLabApi instance. The EpicsApi is used to perform
+   * all Epics and Epic Issues related API calls.
+   *
+   * @return the EpicsApi instance owned by this GitLabApi instance
+   */
+  public EpicsApi getEpicsApi() {
+
+    if (epicsApi == null) {
+      synchronized (this) {
         if (epicsApi == null) {
-            synchronized (this) {
-                if (epicsApi == null) {
-                    epicsApi = new EpicsApi(this);
-                }
-            }
+          epicsApi = new EpicsApi(this);
         }
-
-        return (epicsApi);
+      }
     }
 
-    /**
-     * Gets the EventsApi instance owned by this GitLabApi instance. The EventsApi is used
-     * to perform all events related API calls.
-     *
-     * @return the EventsApi instance owned by this GitLabApi instance
-     */
-    public EventsApi getEventsApi() {
+    return (epicsApi);
+  }
 
+  /**
+   * Gets the EventsApi instance owned by this GitLabApi instance. The EventsApi is used to perform
+   * all events related API calls.
+   *
+   * @return the EventsApi instance owned by this GitLabApi instance
+   */
+  public EventsApi getEventsApi() {
+
+    if (eventsApi == null) {
+      synchronized (this) {
         if (eventsApi == null) {
-            synchronized (this) {
-                if (eventsApi == null) {
-                    eventsApi = new EventsApi(this);
-                }
-            }
+          eventsApi = new EventsApi(this);
         }
-
-        return (eventsApi);
+      }
     }
 
-    /**
-     * Gets the ExternalStatusCheckApi instance owned by this GitLabApi instance. The ExternalStatusCheckApi is used
-     * to perform all the external status checks related API calls.
-     *
-     * @return the ExternalStatusCheckApi instance owned by this GitLabApi instance
-     */
-    public ExternalStatusCheckApi getExternalStatusCheckApi() {
+    return (eventsApi);
+  }
 
+  /**
+   * Gets the ExternalStatusCheckApi instance owned by this GitLabApi instance. The
+   * ExternalStatusCheckApi is used to perform all the external status checks related API calls.
+   *
+   * @return the ExternalStatusCheckApi instance owned by this GitLabApi instance
+   */
+  public ExternalStatusCheckApi getExternalStatusCheckApi() {
+
+    if (externalStatusCheckApi == null) {
+      synchronized (this) {
         if (externalStatusCheckApi == null) {
-            synchronized (this) {
-                if (externalStatusCheckApi == null) {
-                    externalStatusCheckApi = new ExternalStatusCheckApi(this);
-                }
-            }
+          externalStatusCheckApi = new ExternalStatusCheckApi(this);
         }
-
-        return (externalStatusCheckApi);
+      }
     }
 
+    return (externalStatusCheckApi);
+  }
 
-    /**
-     * Gets the GroupApi instance owned by this GitLabApi instance. The GroupApi is used
-     * to perform all group related API calls.
-     *
-     * @return the GroupApi instance owned by this GitLabApi instance
-     */
-    public GroupApi getGroupApi() {
+  /**
+   * Gets the GroupApi instance owned by this GitLabApi instance. The GroupApi is used to perform
+   * all group related API calls.
+   *
+   * @return the GroupApi instance owned by this GitLabApi instance
+   */
+  public GroupApi getGroupApi() {
 
+    if (groupApi == null) {
+      synchronized (this) {
         if (groupApi == null) {
-            synchronized (this) {
-                if (groupApi == null) {
-                    groupApi = new GroupApi(this);
-                }
-            }
+          groupApi = new GroupApi(this);
         }
-
-        return (groupApi);
+      }
     }
 
-    /**
-     * Gets the HealthCheckApi instance owned by this GitLabApi instance. The HealthCheckApi is used
-     * to perform all admin level gitlab health monitoring.
-     *
-     * @return the HealthCheckApi instance owned by this GitLabApi instance
-     */
-    public HealthCheckApi getHealthCheckApi() {
+    return (groupApi);
+  }
 
+  /**
+   * Gets the HealthCheckApi instance owned by this GitLabApi instance. The HealthCheckApi is used
+   * to perform all admin level gitlab health monitoring.
+   *
+   * @return the HealthCheckApi instance owned by this GitLabApi instance
+   */
+  public HealthCheckApi getHealthCheckApi() {
+
+    if (healthCheckApi == null) {
+      synchronized (this) {
         if (healthCheckApi == null) {
-            synchronized (this) {
-                if (healthCheckApi == null) {
-                    healthCheckApi = new HealthCheckApi(this);
-                }
-            }
+          healthCheckApi = new HealthCheckApi(this);
         }
-
-        return (healthCheckApi);
+      }
     }
 
-    /**
-     * Gets the ImportExportApi instance owned by this GitLabApi instance. The ImportExportApi is used
-     * to perform all project import/export related API calls.
-     *
-     * @return the ImportExportApi instance owned by this GitLabApi instance
-     */
-    public ImportExportApi getImportExportApi() {
+    return (healthCheckApi);
+  }
 
+  /**
+   * Gets the ImportExportApi instance owned by this GitLabApi instance. The ImportExportApi is used
+   * to perform all project import/export related API calls.
+   *
+   * @return the ImportExportApi instance owned by this GitLabApi instance
+   */
+  public ImportExportApi getImportExportApi() {
+
+    if (importExportApi == null) {
+      synchronized (this) {
         if (importExportApi == null) {
-            synchronized (this) {
-                if (importExportApi == null) {
-                    importExportApi = new ImportExportApi(this);
-                }
-            }
+          importExportApi = new ImportExportApi(this);
         }
-
-        return (importExportApi);
+      }
     }
 
-    /**
-     * Gets the IssuesApi instance owned by this GitLabApi instance. The IssuesApi is used
-     * to perform all issue related API calls.
-     *
-     * @return the IssuesApi instance owned by this GitLabApi instance
-     */
-    public IssuesApi getIssuesApi() {
+    return (importExportApi);
+  }
 
+  /**
+   * Gets the IssuesApi instance owned by this GitLabApi instance. The IssuesApi is used to perform
+   * all issue related API calls.
+   *
+   * @return the IssuesApi instance owned by this GitLabApi instance
+   */
+  public IssuesApi getIssuesApi() {
+
+    if (issuesApi == null) {
+      synchronized (this) {
         if (issuesApi == null) {
-            synchronized (this) {
-                if (issuesApi == null) {
-                    issuesApi = new IssuesApi(this);
-                }
-            }
+          issuesApi = new IssuesApi(this);
         }
-
-        return (issuesApi);
+      }
     }
 
-    /**
-     * Gets the JobApi instance owned by this GitLabApi instance. The JobApi is used
-     * to perform all jobs related API calls.
-     *
-     * @return the JobsApi instance owned by this GitLabApi instance
-     */
-    public JobApi getJobApi() {
+    return (issuesApi);
+  }
 
+  /**
+   * Gets the JobApi instance owned by this GitLabApi instance. The JobApi is used to perform all
+   * jobs related API calls.
+   *
+   * @return the JobsApi instance owned by this GitLabApi instance
+   */
+  public JobApi getJobApi() {
+
+    if (jobApi == null) {
+      synchronized (this) {
         if (jobApi == null) {
-            synchronized (this) {
-                if (jobApi == null) {
-                    jobApi = new JobApi(this);
-                }
-            }
+          jobApi = new JobApi(this);
         }
-
-        return (jobApi);
+      }
     }
 
-    public LabelsApi getLabelsApi() {
+    return (jobApi);
+  }
 
+  public LabelsApi getLabelsApi() {
+
+    if (labelsApi == null) {
+      synchronized (this) {
         if (labelsApi == null) {
-            synchronized (this) {
-                if (labelsApi == null) {
-                    labelsApi = new LabelsApi(this);
-                }
-            }
+          labelsApi = new LabelsApi(this);
         }
-
-        return (labelsApi);
+      }
     }
 
-    /**
-     * Gets the LicenseApi instance owned by this GitLabApi instance. The LicenseApi is used
-     * to perform all license related API calls.
-     *
-     * @return the LicenseApi instance owned by this GitLabApi instance
-     */
-    public LicenseApi getLicenseApi() {
+    return (labelsApi);
+  }
 
+  /**
+   * Gets the LicenseApi instance owned by this GitLabApi instance. The LicenseApi is used to
+   * perform all license related API calls.
+   *
+   * @return the LicenseApi instance owned by this GitLabApi instance
+   */
+  public LicenseApi getLicenseApi() {
+
+    if (licenseApi == null) {
+      synchronized (this) {
         if (licenseApi == null) {
-            synchronized (this) {
-                if (licenseApi == null) {
-                    licenseApi = new LicenseApi(this);
-                }
-            }
+          licenseApi = new LicenseApi(this);
         }
-
-        return (licenseApi);
+      }
     }
 
-    /**
-     * Gets the LicenseTemplatesApi instance owned by this GitLabApi instance. The LicenseTemplatesApi is used
-     * to perform all license template related API calls.
-     *
-     * @return the LicenseTemplatesApi instance owned by this GitLabApi instance
-     */
-    public LicenseTemplatesApi getLicenseTemplatesApi() {
+    return (licenseApi);
+  }
 
+  /**
+   * Gets the LicenseTemplatesApi instance owned by this GitLabApi instance. The LicenseTemplatesApi
+   * is used to perform all license template related API calls.
+   *
+   * @return the LicenseTemplatesApi instance owned by this GitLabApi instance
+   */
+  public LicenseTemplatesApi getLicenseTemplatesApi() {
+
+    if (licenseTemplatesApi == null) {
+      synchronized (this) {
         if (licenseTemplatesApi == null) {
-            synchronized (this) {
-                if (licenseTemplatesApi == null) {
-                    licenseTemplatesApi = new LicenseTemplatesApi(this);
-                }
-            }
+          licenseTemplatesApi = new LicenseTemplatesApi(this);
         }
-
-        return (licenseTemplatesApi);
+      }
     }
 
+    return (licenseTemplatesApi);
+  }
 
-    /**
-     * Gets the MarkdownApi instance owned by this GitLabApi instance. The MarkdownApi is used
-     * to perform all markdown related API calls.
-     *
-     * @return the MarkdownApi instance owned by this GitLabApi instance
-     */
-    public MarkdownApi getMarkdownApi() {
+  /**
+   * Gets the MarkdownApi instance owned by this GitLabApi instance. The MarkdownApi is used to
+   * perform all markdown related API calls.
+   *
+   * @return the MarkdownApi instance owned by this GitLabApi instance
+   */
+  public MarkdownApi getMarkdownApi() {
 
+    if (markdownApi == null) {
+      synchronized (this) {
         if (markdownApi == null) {
-            synchronized (this) {
-                if (markdownApi == null) {
-                    markdownApi = new MarkdownApi(this);
-                }
-            }
+          markdownApi = new MarkdownApi(this);
         }
-
-        return (markdownApi);
+      }
     }
 
-    /**
-     * Gets the MergeRequestApi instance owned by this GitLabApi instance. The MergeRequestApi is used
-     * to perform all merge request related API calls.
-     *
-     * @return the MergeRequestApi instance owned by this GitLabApi instance
-     */
-    public MergeRequestApi getMergeRequestApi() {
+    return (markdownApi);
+  }
 
+  /**
+   * Gets the MergeRequestApi instance owned by this GitLabApi instance. The MergeRequestApi is used
+   * to perform all merge request related API calls.
+   *
+   * @return the MergeRequestApi instance owned by this GitLabApi instance
+   */
+  public MergeRequestApi getMergeRequestApi() {
+
+    if (mergeRequestApi == null) {
+      synchronized (this) {
         if (mergeRequestApi == null) {
-            synchronized (this) {
-                if (mergeRequestApi == null) {
-                    mergeRequestApi = new MergeRequestApi(this);
-                }
-            }
+          mergeRequestApi = new MergeRequestApi(this);
         }
-
-        return (mergeRequestApi);
+      }
     }
 
-    /**
-     * Gets the MilsestonesApi instance owned by this GitLabApi instance.
-     *
-     * @return the MilsestonesApi instance owned by this GitLabApi instance
-     */
-    public MilestonesApi getMilestonesApi() {
+    return (mergeRequestApi);
+  }
 
+  /**
+   * Gets the MilsestonesApi instance owned by this GitLabApi instance.
+   *
+   * @return the MilsestonesApi instance owned by this GitLabApi instance
+   */
+  public MilestonesApi getMilestonesApi() {
+
+    if (milestonesApi == null) {
+      synchronized (this) {
         if (milestonesApi == null) {
-            synchronized (this) {
-                if (milestonesApi == null) {
-                    milestonesApi = new MilestonesApi(this);
-                }
-            }
+          milestonesApi = new MilestonesApi(this);
         }
-
-        return (milestonesApi);
+      }
     }
 
-    /**
-     * Gets the NamespaceApi instance owned by this GitLabApi instance. The NamespaceApi is used
-     * to perform all namespace related API calls.
-     *
-     * @return the NamespaceApi instance owned by this GitLabApi instance
-     */
-    public NamespaceApi getNamespaceApi() {
+    return (milestonesApi);
+  }
 
+  /**
+   * Gets the NamespaceApi instance owned by this GitLabApi instance. The NamespaceApi is used to
+   * perform all namespace related API calls.
+   *
+   * @return the NamespaceApi instance owned by this GitLabApi instance
+   */
+  public NamespaceApi getNamespaceApi() {
+
+    if (namespaceApi == null) {
+      synchronized (this) {
         if (namespaceApi == null) {
-            synchronized (this) {
-                if (namespaceApi == null) {
-                    namespaceApi = new NamespaceApi(this);
-                }
-            }
+          namespaceApi = new NamespaceApi(this);
         }
-
-        return (namespaceApi);
+      }
     }
 
-    /**
-     * Gets the NotesApi instance owned by this GitLabApi instance. The NotesApi is used
-     * to perform all notes related API calls.
-     *
-     * @return the NotesApi instance owned by this GitLabApi instance
-     */
-    public NotesApi getNotesApi() {
+    return (namespaceApi);
+  }
 
+  /**
+   * Gets the NotesApi instance owned by this GitLabApi instance. The NotesApi is used to perform
+   * all notes related API calls.
+   *
+   * @return the NotesApi instance owned by this GitLabApi instance
+   */
+  public NotesApi getNotesApi() {
+
+    if (notesApi == null) {
+      synchronized (this) {
         if (notesApi == null) {
-            synchronized (this) {
-                if (notesApi == null) {
-                    notesApi = new NotesApi(this);
-                }
-            }
+          notesApi = new NotesApi(this);
         }
-
-        return (notesApi);
+      }
     }
 
-    /**
-     * Gets the NotesApi instance owned by this GitLabApi instance. The NotesApi is used
-     * to perform all notes related API calls.
-     *
-     * @return the NotesApi instance owned by this GitLabApi instance
-     */
-    public NotificationSettingsApi getNotificationSettingsApi() {
+    return (notesApi);
+  }
 
+  /**
+   * Gets the NotesApi instance owned by this GitLabApi instance. The NotesApi is used to perform
+   * all notes related API calls.
+   *
+   * @return the NotesApi instance owned by this GitLabApi instance
+   */
+  public NotificationSettingsApi getNotificationSettingsApi() {
+
+    if (notificationSettingsApi == null) {
+      synchronized (this) {
         if (notificationSettingsApi == null) {
-            synchronized (this) {
-                if (notificationSettingsApi == null) {
-                    notificationSettingsApi = new NotificationSettingsApi(this);
-                }
-            }
+          notificationSettingsApi = new NotificationSettingsApi(this);
         }
-
-        return (notificationSettingsApi);
+      }
     }
 
-    /**
-     * Gets the PackagesApi instance owned by this GitLabApi instance. The PackagesApi is used
-     * to perform all Package related API calls.
-     *
-     * @return the PackagesApi instance owned by this GitLabApi instance
-     */
-    public PackagesApi getPackagesApi() {
+    return (notificationSettingsApi);
+  }
 
+  /**
+   * Gets the PackagesApi instance owned by this GitLabApi instance. The PackagesApi is used to
+   * perform all Package related API calls.
+   *
+   * @return the PackagesApi instance owned by this GitLabApi instance
+   */
+  public PackagesApi getPackagesApi() {
+
+    if (packagesApi == null) {
+      synchronized (this) {
         if (packagesApi == null) {
-            synchronized (this) {
-                if (packagesApi == null) {
-                    packagesApi = new PackagesApi(this);
-                }
-            }
+          packagesApi = new PackagesApi(this);
         }
-
-        return (packagesApi);
+      }
     }
 
-    /**
-     * Gets the PipelineApi instance owned by this GitLabApi instance. The PipelineApi is used
-     * to perform all pipeline related API calls.
-     *
-     * @return the PipelineApi instance owned by this GitLabApi instance
-     */
-    public PipelineApi getPipelineApi() {
+    return (packagesApi);
+  }
 
+  /**
+   * Gets the PipelineApi instance owned by this GitLabApi instance. The PipelineApi is used to
+   * perform all pipeline related API calls.
+   *
+   * @return the PipelineApi instance owned by this GitLabApi instance
+   */
+  public PipelineApi getPipelineApi() {
+
+    if (pipelineApi == null) {
+      synchronized (this) {
         if (pipelineApi == null) {
-            synchronized (this) {
-                if (pipelineApi == null) {
-                    pipelineApi = new PipelineApi(this);
-                }
-            }
+          pipelineApi = new PipelineApi(this);
         }
-
-        return (pipelineApi);
+      }
     }
 
-    /**
-     * Gets the ProjectApi instance owned by this GitLabApi instance. The ProjectApi is used
-     * to perform all project related API calls.
-     *
-     * @return the ProjectApi instance owned by this GitLabApi instance
-     */
-    public ProjectApi getProjectApi() {
+    return (pipelineApi);
+  }
 
+  /**
+   * Gets the ProjectApi instance owned by this GitLabApi instance. The ProjectApi is used to
+   * perform all project related API calls.
+   *
+   * @return the ProjectApi instance owned by this GitLabApi instance
+   */
+  public ProjectApi getProjectApi() {
+
+    if (projectApi == null) {
+      synchronized (this) {
         if (projectApi == null) {
-            synchronized (this) {
-                if (projectApi == null) {
-                    projectApi = new ProjectApi(this);
-                }
-            }
+          projectApi = new ProjectApi(this);
         }
-
-        return (projectApi);
+      }
     }
 
-    /**
-     * Gets the ProtectedBranchesApi instance owned by this GitLabApi instance. The ProtectedBranchesApi is used
-     * to perform all protection related actions on a branch of a project.
-     *
-     * @return the ProtectedBranchesApi instance owned by this GitLabApi instance
-     */
-    public ProtectedBranchesApi getProtectedBranchesApi() {
+    return (projectApi);
+  }
 
+  /**
+   * Gets the ProtectedBranchesApi instance owned by this GitLabApi instance. The
+   * ProtectedBranchesApi is used to perform all protection related actions on a branch of a
+   * project.
+   *
+   * @return the ProtectedBranchesApi instance owned by this GitLabApi instance
+   */
+  public ProtectedBranchesApi getProtectedBranchesApi() {
+
+    if (this.protectedBranchesApi == null) {
+      synchronized (this) {
         if (this.protectedBranchesApi == null) {
-            synchronized (this) {
-                if (this.protectedBranchesApi == null) {
-                    this.protectedBranchesApi = new ProtectedBranchesApi(this);
-                }
-            }
+          this.protectedBranchesApi = new ProtectedBranchesApi(this);
         }
-
-        return (this.protectedBranchesApi);
+      }
     }
 
-    /**
-     * Gets the ReleasesApi instance owned by this GitLabApi instance. The ReleasesApi is used
-     * to perform all release related API calls.
-     *
-     * @return the ReleasesApi instance owned by this GitLabApi instance
-     */
-    public ReleasesApi getReleasesApi() {
+    return (this.protectedBranchesApi);
+  }
 
+  /**
+   * Gets the ReleasesApi instance owned by this GitLabApi instance. The ReleasesApi is used to
+   * perform all release related API calls.
+   *
+   * @return the ReleasesApi instance owned by this GitLabApi instance
+   */
+  public ReleasesApi getReleasesApi() {
+
+    if (releasesApi == null) {
+      synchronized (this) {
         if (releasesApi == null) {
-            synchronized (this) {
-                if (releasesApi == null) {
-                    releasesApi = new ReleasesApi(this);
-                }
-            }
+          releasesApi = new ReleasesApi(this);
         }
-
-        return (releasesApi);
+      }
     }
 
-    /**
-     * Gets the RepositoryApi instance owned by this GitLabApi instance. The RepositoryApi is used
-     * to perform all repository related API calls.
-     *
-     * @return the RepositoryApi instance owned by this GitLabApi instance
-     */
-    public RepositoryApi getRepositoryApi() {
+    return (releasesApi);
+  }
 
+  /**
+   * Gets the RepositoryApi instance owned by this GitLabApi instance. The RepositoryApi is used to
+   * perform all repository related API calls.
+   *
+   * @return the RepositoryApi instance owned by this GitLabApi instance
+   */
+  public RepositoryApi getRepositoryApi() {
+
+    if (repositoryApi == null) {
+      synchronized (this) {
         if (repositoryApi == null) {
-            synchronized (this) {
-                if (repositoryApi == null) {
-                    repositoryApi = new RepositoryApi(this);
-                }
-            }
+          repositoryApi = new RepositoryApi(this);
         }
-
-        return (repositoryApi);
+      }
     }
 
-    /**
-     * Gets the RepositoryFileApi instance owned by this GitLabApi instance. The RepositoryFileApi is used
-     * to perform all repository files related API calls.
-     *
-     * @return the RepositoryFileApi instance owned by this GitLabApi instance
-     */
-    public RepositoryFileApi getRepositoryFileApi() {
+    return (repositoryApi);
+  }
 
+  /**
+   * Gets the RepositoryFileApi instance owned by this GitLabApi instance. The RepositoryFileApi is
+   * used to perform all repository files related API calls.
+   *
+   * @return the RepositoryFileApi instance owned by this GitLabApi instance
+   */
+  public RepositoryFileApi getRepositoryFileApi() {
+
+    if (repositoryFileApi == null) {
+      synchronized (this) {
         if (repositoryFileApi == null) {
-            synchronized (this) {
-                if (repositoryFileApi == null) {
-                    repositoryFileApi = new RepositoryFileApi(this);
-                }
-            }
+          repositoryFileApi = new RepositoryFileApi(this);
         }
-
-        return (repositoryFileApi);
+      }
     }
 
-    /**
-     * Gets the ResourceLabelEventsApi instance owned by this GitLabApi instance. The ResourceLabelEventsApi
-     * is used to perform all Resource Label Events related API calls.
-     *
-     * @return the ResourceLabelEventsApi instance owned by this GitLabApi instance
-     */
-    public ResourceLabelEventsApi getResourceLabelEventsApi() {
+    return (repositoryFileApi);
+  }
 
+  /**
+   * Gets the ResourceLabelEventsApi instance owned by this GitLabApi instance. The
+   * ResourceLabelEventsApi is used to perform all Resource Label Events related API calls.
+   *
+   * @return the ResourceLabelEventsApi instance owned by this GitLabApi instance
+   */
+  public ResourceLabelEventsApi getResourceLabelEventsApi() {
+
+    if (resourceLabelEventsApi == null) {
+      synchronized (this) {
         if (resourceLabelEventsApi == null) {
-            synchronized (this) {
-                if (resourceLabelEventsApi == null) {
-                    resourceLabelEventsApi = new ResourceLabelEventsApi(this);
-                }
-            }
+          resourceLabelEventsApi = new ResourceLabelEventsApi(this);
         }
-
-        return (resourceLabelEventsApi);
+      }
     }
 
-    /**
-     * Gets the ResourceStateEventsApi instance owned by this GitLabApi instance. The ResourceStateEventsApi
-     * is used to perform all Resource State Events related API calls.
-     *
-     * @return the ResourceStateEventsApi instance owned by this GitLabApi instance
-     */
-    public ResourceStateEventsApi getResourceStateEventsApi() {
+    return (resourceLabelEventsApi);
+  }
 
+  /**
+   * Gets the ResourceStateEventsApi instance owned by this GitLabApi instance. The
+   * ResourceStateEventsApi is used to perform all Resource State Events related API calls.
+   *
+   * @return the ResourceStateEventsApi instance owned by this GitLabApi instance
+   */
+  public ResourceStateEventsApi getResourceStateEventsApi() {
+
+    if (resourceStateEventsApi == null) {
+      synchronized (this) {
         if (resourceStateEventsApi == null) {
-            synchronized (this) {
-                if (resourceStateEventsApi == null) {
-                    resourceStateEventsApi = new ResourceStateEventsApi(this);
-                }
-            }
+          resourceStateEventsApi = new ResourceStateEventsApi(this);
         }
-
-        return (resourceStateEventsApi);
+      }
     }
 
-    /**
-     * Gets the RunnersApi instance owned by this GitLabApi instance. The RunnersApi is used
-     * to perform all Runner related API calls.
-     *
-     * @return the RunnerApi instance owned by this GitLabApi instance
-     */
-    public RunnersApi getRunnersApi() {
+    return (resourceStateEventsApi);
+  }
 
+  /**
+   * Gets the RunnersApi instance owned by this GitLabApi instance. The RunnersApi is used to
+   * perform all Runner related API calls.
+   *
+   * @return the RunnerApi instance owned by this GitLabApi instance
+   */
+  public RunnersApi getRunnersApi() {
+
+    if (runnersApi == null) {
+      synchronized (this) {
         if (runnersApi == null) {
-            synchronized (this) {
-                if (runnersApi == null) {
-                    runnersApi = new RunnersApi(this);
-                }
-            }
+          runnersApi = new RunnersApi(this);
         }
-
-        return (runnersApi);
+      }
     }
 
-    /**
-     * Gets the SearchApi instance owned by this GitLabApi instance. The SearchApi is used
-     * to perform search related API calls.
-     *
-     * @return the SearchApi instance owned by this GitLabApi instance
-     */
-    public SearchApi getSearchApi() {
+    return (runnersApi);
+  }
 
+  /**
+   * Gets the SearchApi instance owned by this GitLabApi instance. The SearchApi is used to perform
+   * search related API calls.
+   *
+   * @return the SearchApi instance owned by this GitLabApi instance
+   */
+  public SearchApi getSearchApi() {
+
+    if (searchApi == null) {
+      synchronized (this) {
         if (searchApi == null) {
-            synchronized (this) {
-                if (searchApi == null) {
-                    searchApi = new SearchApi(this);
-                }
-            }
+          searchApi = new SearchApi(this);
         }
-
-        return (searchApi);
+      }
     }
 
-    /**
-     * Gets the ServicesApi instance owned by this GitLabApi instance. The ServicesApi is used
-     * to perform all services related API calls.
-     *
-     * @return the ServicesApi instance owned by this GitLabApi instance
-     */
-    public ServicesApi getServicesApi() {
+    return (searchApi);
+  }
 
+  /**
+   * Gets the ServicesApi instance owned by this GitLabApi instance. The ServicesApi is used to
+   * perform all services related API calls.
+   *
+   * @return the ServicesApi instance owned by this GitLabApi instance
+   */
+  public ServicesApi getServicesApi() {
+
+    if (servicesApi == null) {
+      synchronized (this) {
         if (servicesApi == null) {
-            synchronized (this) {
-                if (servicesApi == null) {
-                    servicesApi = new ServicesApi(this);
-                }
-            }
+          servicesApi = new ServicesApi(this);
         }
-
-        return (servicesApi);
+      }
     }
 
-    /**
-     * Gets the SystemHooksApi instance owned by this GitLabApi instance. All methods
-     * require administrator authorization.
-     *
-     * @return the SystemHooksApi instance owned by this GitLabApi instance
-     */
-    public SystemHooksApi getSystemHooksApi() {
+    return (servicesApi);
+  }
 
+  /**
+   * Gets the SystemHooksApi instance owned by this GitLabApi instance. All methods require
+   * administrator authorization.
+   *
+   * @return the SystemHooksApi instance owned by this GitLabApi instance
+   */
+  public SystemHooksApi getSystemHooksApi() {
+
+    if (systemHooksApi == null) {
+      synchronized (this) {
         if (systemHooksApi == null) {
-            synchronized (this) {
-                if (systemHooksApi == null) {
-                    systemHooksApi = new SystemHooksApi(this);
-                }
-            }
+          systemHooksApi = new SystemHooksApi(this);
         }
-
-        return (systemHooksApi);
+      }
     }
 
-    /**
-     * Gets the TagsApi instance owned by this GitLabApi instance. The TagsApi is used
-     * to perform all tag and release related API calls.
-     *
-     * @return the TagsApi instance owned by this GitLabApi instance
-     */
-    public TagsApi getTagsApi() {
+    return (systemHooksApi);
+  }
 
+  /**
+   * Gets the TagsApi instance owned by this GitLabApi instance. The TagsApi is used to perform all
+   * tag and release related API calls.
+   *
+   * @return the TagsApi instance owned by this GitLabApi instance
+   */
+  public TagsApi getTagsApi() {
+
+    if (tagsApi == null) {
+      synchronized (this) {
         if (tagsApi == null) {
-            synchronized (this) {
-                if (tagsApi == null) {
-                    tagsApi = new TagsApi(this);
-                }
-            }
+          tagsApi = new TagsApi(this);
         }
-
-        return (tagsApi);
+      }
     }
 
-    /**
-     * Gets the SnippetsApi instance owned by this GitLabApi instance. The SnippetsApi is used
-     * to perform all snippet related API calls.
-     *
-     * @return the SnippetsApi instance owned by this GitLabApi instance
-     */
-    public SnippetsApi getSnippetApi() {
+    return (tagsApi);
+  }
+
+  /**
+   * Gets the SnippetsApi instance owned by this GitLabApi instance. The SnippetsApi is used to
+   * perform all snippet related API calls.
+   *
+   * @return the SnippetsApi instance owned by this GitLabApi instance
+   */
+  public SnippetsApi getSnippetApi() {
+    if (snippetsApi == null) {
+      synchronized (this) {
         if (snippetsApi == null) {
-            synchronized (this) {
-                if (snippetsApi == null) {
-                    snippetsApi = new SnippetsApi(this);
-                }
-            }
+          snippetsApi = new SnippetsApi(this);
         }
-
-        return snippetsApi;
+      }
     }
 
-    /**
-     * Gets the TodosApi instance owned by this GitLabApi instance. The TodosApi is used to perform all Todo related API calls.
-     *
-     * @return the TodosApi instance owned by this GitLabApi instance
-     */
-    public TodosApi getTodosApi() {
+    return snippetsApi;
+  }
+
+  /**
+   * Gets the TodosApi instance owned by this GitLabApi instance. The TodosApi is used to perform
+   * all Todo related API calls.
+   *
+   * @return the TodosApi instance owned by this GitLabApi instance
+   */
+  public TodosApi getTodosApi() {
+    if (todosApi == null) {
+      synchronized (this) {
         if (todosApi == null) {
-            synchronized (this) {
-                if (todosApi == null) {
-                    todosApi = new TodosApi(this);
-                }
-            }
+          todosApi = new TodosApi(this);
         }
-
-        return todosApi;
+      }
     }
 
-    /**
-     * Gets the UserApi instance owned by this GitLabApi instance. The UserApi is used
-     * to perform all user related API calls.
-     *
-     * @return the UserApi instance owned by this GitLabApi instance
-     */
-    public UserApi getUserApi() {
+    return todosApi;
+  }
 
+  /**
+   * Gets the UserApi instance owned by this GitLabApi instance. The UserApi is used to perform all
+   * user related API calls.
+   *
+   * @return the UserApi instance owned by this GitLabApi instance
+   */
+  public UserApi getUserApi() {
+
+    if (userApi == null) {
+      synchronized (this) {
         if (userApi == null) {
-            synchronized (this) {
-                if (userApi == null) {
-                    userApi = new UserApi(this);
-                }
-            }
+          userApi = new UserApi(this);
         }
-
-        return (userApi);
+      }
     }
 
-    /**
-     * Gets the WikisApi instance owned by this GitLabApi instance. The WikisApi is used to perform all wiki related API calls.
-     *
-     * @return the WikisApi instance owned by this GitLabApi instance
-     */
-    public WikisApi getWikisApi() {
+    return (userApi);
+  }
+
+  /**
+   * Gets the WikisApi instance owned by this GitLabApi instance. The WikisApi is used to perform
+   * all wiki related API calls.
+   *
+   * @return the WikisApi instance owned by this GitLabApi instance
+   */
+  public WikisApi getWikisApi() {
+    if (wikisApi == null) {
+      synchronized (this) {
         if (wikisApi == null) {
-            synchronized (this) {
-                if (wikisApi == null) {
-                    wikisApi = new WikisApi(this);
-                }
-            }
+          wikisApi = new WikisApi(this);
         }
-
-        return wikisApi;
+      }
     }
 
-    /**
-     * Gets the KeysApi instance owned by this GitLabApi instance. The KeysApi is used to look up users by their ssh key signatures
-     *
-     * @return the KeysApi instance owned by this GitLabApi instance
-     */
-    public KeysApi getKeysAPI() {
-        synchronized (this) {
-            if (keysApi == null) {
-                keysApi = new KeysApi(this);
-            }
-        }
-        return keysApi;
+    return wikisApi;
+  }
+
+  /**
+   * Gets the KeysApi instance owned by this GitLabApi instance. The KeysApi is used to look up
+   * users by their ssh key signatures
+   *
+   * @return the KeysApi instance owned by this GitLabApi instance
+   */
+  public KeysApi getKeysAPI() {
+    synchronized (this) {
+      if (keysApi == null) {
+        keysApi = new KeysApi(this);
+      }
+    }
+    return keysApi;
+  }
+
+  /**
+   * Create and return an Optional instance associated with a GitLabApiException.
+   *
+   * @param <T> the type of the Optional instance
+   * @param glae the GitLabApiException that was the result of a call to the GitLab API
+   * @return the created Optional instance
+   */
+  protected static final <T> Optional<T> createOptionalFromException(
+      final GitLabApiException glae) {
+    final Optional<T> optional = Optional.empty();
+    optionalExceptionMap.put(System.identityHashCode(optional), glae);
+    return (optional);
+  }
+
+  /**
+   * Get the exception associated with the provided Optional instance, or null if no exception is
+   * associated with the Optional instance.
+   *
+   * @param optional the Optional instance to get the exception for
+   * @return the exception associated with the provided Optional instance, or null if no exception
+   *     is associated with the Optional instance
+   */
+  public static final GitLabApiException getOptionalException(final Optional<?> optional) {
+    return (optionalExceptionMap.get(System.identityHashCode(optional)));
+  }
+
+  /**
+   * Return the Optional instances contained value, if present, otherwise throw the exception that
+   * is associated with the Optional instance.
+   *
+   * @param <T> the type for the Optional parameter
+   * @param optional the Optional instance to get the value for
+   * @return the value of the Optional instance if no exception is associated with it
+   * @throws GitLabApiException if there was an exception associated with the Optional instance
+   */
+  public static final <T> T orElseThrow(final Optional<T> optional) throws GitLabApiException {
+
+    final GitLabApiException glea = getOptionalException(optional);
+    if (glea != null) {
+      throw (glea);
     }
 
-
-    /**
-     * Create and return an Optional instance associated with a GitLabApiException.
-     *
-     * @param <T> the type of the Optional instance
-     * @param glae the GitLabApiException that was the result of a call to the GitLab API
-     * @return the created Optional instance
-     */
-    protected static final <T> Optional<T> createOptionalFromException(GitLabApiException glae) {
-        Optional<T> optional = Optional.empty();
-        optionalExceptionMap.put(System.identityHashCode(optional),  glae);
-        return (optional);
-    }
-
-    /**
-     * Get the exception associated with the provided Optional instance, or null if no exception is
-     * associated with the Optional instance.
-     *
-     * @param optional the Optional instance to get the exception for
-     * @return the exception associated with the provided Optional instance, or null if no exception is
-     * associated with the Optional instance
-     */
-    public static final GitLabApiException getOptionalException(Optional<?> optional) {
-        return (optionalExceptionMap.get(System.identityHashCode(optional)));
-    }
-
-    /**
-     * Return the Optional instances contained value, if present, otherwise throw the exception that is
-     * associated with the Optional instance.
-     *
-     * @param <T> the type for the Optional parameter
-     * @param optional the Optional instance to get the value for
-     * @return the value of the Optional instance if no exception is associated with it
-     * @throws GitLabApiException if there was an exception associated with the Optional instance
-     */
-    public static final <T> T orElseThrow(Optional<T> optional) throws GitLabApiException {
-
-        GitLabApiException glea = getOptionalException(optional);
-        if (glea != null) {
-            throw (glea);
-        }
-
-        return (optional.get());
-    }
+    return (optional.get());
+  }
 }

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -1,5 +1,15 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.client.Client;
+import jakarta.ws.rs.client.ClientBuilder;
+import jakarta.ws.rs.client.Entity;
+import jakarta.ws.rs.client.Invocation;
+import jakarta.ws.rs.client.WebTarget;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.StreamingOutput;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -20,16 +30,6 @@ import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 import javax.net.ssl.TrustManager;
 import javax.net.ssl.X509ExtendedTrustManager;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import org.gitlab4j.api.Constants.TokenType;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.utils.JacksonJson;
@@ -47,930 +47,1004 @@ import org.glassfish.jersey.media.multipart.MultiPartFeature;
 import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
 import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 
-
-/**
- * This class utilizes the Jersey client package to communicate with a GitLab API endpoint.
- */
+/** This class utilizes the Jersey client package to communicate with a GitLab API endpoint. */
 public class GitLabApiClient implements AutoCloseable {
 
-    protected static final String PRIVATE_TOKEN_HEADER  = "PRIVATE-TOKEN";
-    protected static final String SUDO_HEADER           = "Sudo";
-    protected static final String AUTHORIZATION_HEADER  = "Authorization";
-    protected static final String X_GITLAB_TOKEN_HEADER = "X-Gitlab-Token";
+  protected static final String PRIVATE_TOKEN_HEADER = "PRIVATE-TOKEN";
+  protected static final String SUDO_HEADER = "Sudo";
+  protected static final String AUTHORIZATION_HEADER = "Authorization";
+  protected static final String X_GITLAB_TOKEN_HEADER = "X-Gitlab-Token";
 
-    private ClientConfig clientConfig;
-    private Client apiClient;
-    private String baseUrl;
-    private String hostUrl;
-    private TokenType tokenType = TokenType.PRIVATE;
-    private Supplier<String> authToken;
-    private String secretToken;
-    private boolean ignoreCertificateErrors;
-    private SSLContext openSslContext;
-    private HostnameVerifier openHostnameVerifier;
-    private Long sudoAsId;
-    private Integer connectTimeout;
-    private Integer readTimeout;
+  private final ClientConfig clientConfig;
+  private Client apiClient;
+  private final String baseUrl;
+  private String hostUrl;
+  private TokenType tokenType = TokenType.PRIVATE;
+  private Supplier<String> authToken;
+  private final String secretToken;
+  private boolean ignoreCertificateErrors;
+  private SSLContext openSslContext;
+  private HostnameVerifier openHostnameVerifier;
+  private Long sudoAsId;
+  private Integer connectTimeout;
+  private Integer readTimeout;
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL, private token, and secret token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, String privateToken) {
-        this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, null);
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL, private token, and secret token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   */
+  public GitLabApiClient(final ApiVersion apiVersion, final String hostUrl, final String privateToken) {
+    this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL, auth token type, private or access token, and secret token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to authenticate with
+   */
+  public GitLabApiClient(
+      final ApiVersion apiVersion, final String hostUrl, final TokenType tokenType, final String authToken) {
+    this(apiVersion, hostUrl, tokenType, authToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and
+   * the specified server URL, private token, and secret token.
+   *
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   */
+  public GitLabApiClient(final String hostUrl, final String privateToken) {
+    this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, privateToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and
+   * the specified server URL, private token, and secret token.
+   *
+   * @param hostUrl the URL to the GitLab API server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to authenticate with
+   */
+  public GitLabApiClient(final String hostUrl, final TokenType tokenType, final String authToken) {
+    this(ApiVersion.V4, hostUrl, tokenType, authToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL, private token, and secret token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApiClient(
+      final ApiVersion apiVersion, final String hostUrl, final String privateToken, final String secretToken) {
+    this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, secretToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL, private token, and secret token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApiClient(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      final String secretToken) {
+    this(apiVersion, hostUrl, tokenType, authToken, secretToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and
+   * the specified server URL, private token, and secret token.
+   *
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApiClient(final String hostUrl, final String privateToken, final String secretToken) {
+    this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, privateToken, secretToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and
+   * the specified server URL, private token, and secret token.
+   *
+   * @param hostUrl the URL to the GitLab API server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   */
+  public GitLabApiClient(
+      final String hostUrl, final TokenType tokenType, final String authToken, final String secretToken) {
+    this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken, null);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and
+   * the specified server URL and private token.
+   *
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties the properties given to Jersey's clientconfig
+   */
+  public GitLabApiClient(
+      final String hostUrl,
+      final String privateToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(
+        ApiVersion.V4,
+        hostUrl,
+        TokenType.PRIVATE,
+        privateToken,
+        secretToken,
+        clientConfigProperties);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL and private token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param privateToken the private token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties the properties given to Jersey's clientconfig
+   */
+  public GitLabApiClient(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final String privateToken,
+      final String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+    this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, secretToken, clientConfigProperties);
+  }
+
+  /**
+   * Construct an instance to communicate with a GitLab API server using the specified GitLab API
+   * version, server URL and private token.
+   *
+   * @param apiVersion the ApiVersion specifying which version of the API to use
+   * @param hostUrl the URL to the GitLab API server
+   * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
+   * @param authToken the private token to authenticate with
+   * @param secretToken use this token to validate received payloads
+   * @param clientConfigProperties the properties given to Jersey's clientconfig
+   */
+  public GitLabApiClient(
+      final ApiVersion apiVersion,
+      final String hostUrl,
+      final TokenType tokenType,
+      final String authToken,
+      String secretToken,
+      final Map<String, Object> clientConfigProperties) {
+
+    // Remove the trailing "/" from the hostUrl if present
+    this.hostUrl = (hostUrl.endsWith("/") ? hostUrl.replaceAll("/$", "") : hostUrl);
+    this.baseUrl = this.hostUrl;
+    this.hostUrl += apiVersion.getApiNamespace();
+
+    this.tokenType = tokenType;
+    this.authToken = () -> authToken;
+
+    if (secretToken != null) {
+      secretToken = secretToken.trim();
+      secretToken = (secretToken.length() > 0 ? secretToken : null);
     }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL, auth token type, private or access token, and secret token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to authenticate with
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken) {
-        this(apiVersion, hostUrl, tokenType, authToken, null);
+    this.secretToken = secretToken;
+
+    clientConfig = new ClientConfig();
+    if (clientConfigProperties != null) {
+
+      if (clientConfigProperties.containsKey(ClientProperties.PROXY_URI)) {
+        clientConfig.connectorProvider(new ApacheConnectorProvider());
+      }
+
+      for (final Map.Entry<String, Object> propertyEntry : clientConfigProperties.entrySet()) {
+        clientConfig.property(propertyEntry.getKey(), propertyEntry.getValue());
+      }
     }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and the specified
-     * server URL, private token, and secret token.
-     *
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     */
-    public GitLabApiClient(String hostUrl, String privateToken) {
-        this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, privateToken, null);
+    // Disable auto-discovery of feature and services lookup, this will force Jersey
+    // to use the features and services explicitly configured by gitlab4j
+    clientConfig.property(ClientProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
+    clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
+
+    clientConfig.register(JacksonJson.class);
+    clientConfig.register(JacksonFeature.class);
+    clientConfig.register(MultiPartFeature.class);
+  }
+
+  /** Close the underlying {@link Client} and its associated resources. */
+  @Override
+  public void close() {
+    if (apiClient != null) {
+      apiClient.close();
     }
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and the specified
-     * server URL, private token, and secret token.
-     *
-     * @param hostUrl the URL to the GitLab API server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to authenticate with
-     */
-    public GitLabApiClient(String hostUrl, TokenType tokenType, String authToken) {
-        this(ApiVersion.V4, hostUrl, tokenType, authToken, null);
+  /**
+   * Enable the logging of the requests to and the responses from the GitLab server API.
+   *
+   * @param logger the Logger instance to log to
+   * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
+   * @param maxEntityLength maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is <= 0, entity
+   *     logging will be disabled
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  void enableRequestResponseLogging(
+      final Logger logger, final Level level, final int maxEntityLength, final List<String> maskedHeaderNames) {
+
+    final MaskingLoggingFilter loggingFilter =
+        new MaskingLoggingFilter(logger, level, maxEntityLength, maskedHeaderNames);
+    clientConfig.register(loggingFilter);
+
+    // Recreate the Client instance if already created.
+    if (apiClient != null) {
+      createApiClient();
     }
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL, private token, and secret token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, String privateToken, String secretToken) {
-        this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, secretToken, null);
+  /**
+   * Sets the per request connect and read timeout.
+   *
+   * @param connectTimeout the per request connect timeout in milliseconds, can be null to use
+   *     default
+   * @param readTimeout the per request read timeout in milliseconds, can be null to use default
+   */
+  void setRequestTimeout(final Integer connectTimeout, final Integer readTimeout) {
+    this.connectTimeout = connectTimeout;
+    this.readTimeout = readTimeout;
+  }
+
+  /**
+   * Get the auth token being used by this client.
+   *
+   * @return the auth token being used by this client
+   */
+  String getAuthToken() {
+    return (authToken.get());
+  }
+
+  /**
+   * Get the secret token.
+   *
+   * @return the secret token
+   */
+  String getSecretToken() {
+    return (secretToken);
+  }
+
+  /**
+   * Get the TokenType this client is using.
+   *
+   * @return the TokenType this client is using
+   */
+  TokenType getTokenType() {
+    return (tokenType);
+  }
+
+  /** Set the ID of the user to sudo as. */
+  Long getSudoAsId() {
+    return (sudoAsId);
+  }
+
+  /**
+   * Set the ID of the user to sudo as.
+   *
+   * @param sudoAsId the ID of the user to sudo as
+   */
+  void setSudoAsId(final Long sudoAsId) {
+    this.sudoAsId = sudoAsId;
+  }
+
+  /**
+   * Construct a REST URL with the specified path arguments.
+   *
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a REST URL with the specified path arguments
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected URL getApiUrl(final Object... pathArgs) throws IOException {
+    final String url = appendPathArgs(this.hostUrl, pathArgs);
+    return (new URL(url));
+  }
+
+  /**
+   * Construct a REST URL with the specified path arguments using Gitlab base url.
+   *
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a REST URL with the specified path arguments
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected URL getUrlWithBase(final Object... pathArgs) throws IOException {
+    final String url = appendPathArgs(this.baseUrl, pathArgs);
+    return (new URL(url));
+  }
+
+  private String appendPathArgs(final String url, final Object... pathArgs) {
+    final StringBuilder urlBuilder = new StringBuilder(url);
+    for (final Object pathArg : pathArgs) {
+      if (pathArg != null) {
+        urlBuilder.append("/");
+        urlBuilder.append(pathArg.toString());
+      }
     }
+    return urlBuilder.toString();
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL, private token, and secret token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken, String secretToken) {
-        this(apiVersion, hostUrl, tokenType, authToken, secretToken, null);
+  /**
+   * Validates the secret token (X-GitLab-Token) header against the expected secret token, returns
+   * true if valid, otherwise returns false.
+   *
+   * @param response the Response instance sent from the GitLab server
+   * @return true if the response's secret token is valid, otherwise returns false
+   */
+  protected boolean validateSecretToken(final Response response) {
+
+    if (this.secretToken == null) return (true);
+
+    final String secretToken = response.getHeaderString(X_GITLAB_TOKEN_HEADER);
+    if (secretToken == null) return (false);
+
+    return (this.secretToken.equals(secretToken));
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response get(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (get(queryParams, url));
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response get(final MultivaluedMap<String, String> queryParams, final URL url) {
+    return (invocation(url, queryParams).get());
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param accepts if non-empty will set the Accepts header to this value
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response getWithAccepts(
+      final MultivaluedMap<String, String> queryParams, final String accepts, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (getWithAccepts(queryParams, url, accepts));
+  }
+
+  /**
+   * Perform an HTTP GET call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @param accepts if non-empty will set the Accepts header to this value
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response getWithAccepts(
+      final MultivaluedMap<String, String> queryParams, final URL url, final String accepts) {
+    return (invocation(url, queryParams, accepts).get());
+  }
+
+  /**
+   * Perform an HTTP HEAD call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response head(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (head(queryParams, url));
+  }
+
+  /**
+   * Perform an HTTP HEAD call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response head(final MultivaluedMap<String, String> queryParams, final URL url) {
+    return (invocation(url, queryParams).head());
+  }
+
+  /**
+   * Perform an HTTP PATCH call with the specified query parameters and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response patch(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (patch(queryParams, url));
+  }
+
+  /**
+   * Perform an HTTP PATCH call with the specified query parameters and URL, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response patch(final MultivaluedMap<String, String> queryParams, final URL url) {
+    final Entity<?> empty = Entity.text("");
+    // use "X-HTTP-Method-Override" header on POST to override to unsupported PATCH
+    return (invocation(url, queryParams).header("X-HTTP-Method-Override", "PATCH").post(empty));
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response post(final Form formData, final Object... pathArgs) throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return post(formData, url);
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a Response instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response post(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return post(queryParams, url);
+  }
+
+  /**
+   * Perform an HTTP POST call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response post(final Form formData, final URL url) {
+    if (formData instanceof GitLabApiForm) {
+      return (invocation(url, null)
+          .post(Entity.entity(formData.asMap(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+    } else if (formData != null) {
+      return (invocation(url, null)
+          .post(Entity.entity(formData, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+    } else {
+      return (invocation(url, null)
+          .post(Entity.entity(new Form(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
     }
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and the specified
-     * server URL, private token, and secret token.
-     *
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApiClient(String hostUrl, String privateToken, String secretToken) {
-        this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, privateToken, secretToken, null);
-    }
+  /**
+   * Perform an HTTP POST call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parametersformData the Form containing the
+   *     name/value pairs
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response post(final MultivaluedMap<String, String> queryParams, final URL url) {
+    return (invocation(url, queryParams)
+        .post(Entity.entity(new Form(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and the specified
-     * server URL, private token, and secret token.
-     *
-     * @param hostUrl the URL to the GitLab API server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     */
-    public GitLabApiClient(String hostUrl, TokenType tokenType, String authToken, String secretToken) {
-        this(ApiVersion.V4, hostUrl, tokenType, authToken, secretToken, null);
-    }
+  /**
+   * Perform an HTTP POST call with the specified payload object and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param payload the object instance that will be serialized to JSON and used as the POST data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response post(final Object payload, final Object... pathArgs) throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    final Entity<?> entity = Entity.entity(payload, MediaType.APPLICATION_JSON);
+    return (invocation(url, null).post(entity));
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using GitLab API version 4, and the specified
-     * server URL and private token.
-     *
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties the properties given to Jersey's clientconfig
-     */
-    public GitLabApiClient(String hostUrl, String privateToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this(ApiVersion.V4, hostUrl, TokenType.PRIVATE, privateToken, secretToken, clientConfigProperties);
-    }
+  /**
+   * Perform an HTTP POST call with the specified StreamingOutput, MediaType, and path objects,
+   * returning a ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param stream the StreamingOutput instance that contains the POST data
+   * @param mediaType the content-type of the POST data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response post(final StreamingOutput stream, final String mediaType, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (invocation(url, null).post(Entity.entity(stream, mediaType)));
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL and private token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param privateToken the private token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties the properties given to Jersey's clientconfig
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, String privateToken, String secretToken, Map<String, Object> clientConfigProperties) {
-        this(apiVersion, hostUrl, TokenType.PRIVATE, privateToken, secretToken, clientConfigProperties);
-    }
+  /**
+   * Perform a file upload using the specified media type, returning a ClientResponse instance with
+   * the data returned from the endpoint.
+   *
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaTypeString unused; will be removed in the next major version
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response upload(
+      final String name, final File fileToUpload, final String mediaTypeString, final Object... pathArgs)
+      throws IOException {
+    return upload(name, fileToUpload, mediaTypeString, null, pathArgs);
+  }
 
-    /**
-     * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
-     * server URL and private token.
-     *
-     * @param apiVersion the ApiVersion specifying which version of the API to use
-     * @param hostUrl the URL to the GitLab API server
-     * @param tokenType the type of auth the token is for, PRIVATE or ACCESS
-     * @param authToken the private token to authenticate with
-     * @param secretToken use this token to validate received payloads
-     * @param clientConfigProperties the properties given to Jersey's clientconfig
-     */
-    public GitLabApiClient(ApiVersion apiVersion, String hostUrl, TokenType tokenType, String authToken, String secretToken, Map<String, Object> clientConfigProperties) {
+  /**
+   * Perform a file upload using the specified media type, returning a ClientResponse instance with
+   * the data returned from the endpoint.
+   *
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaTypeString unused; will be removed in the next major version
+   * @param formData the Form containing the name/value pairs
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response upload(
+      final String name, final File fileToUpload, final String mediaTypeString, final Form formData, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (upload(name, fileToUpload, mediaTypeString, formData, url));
+  }
 
-        // Remove the trailing "/" from the hostUrl if present
-        this.hostUrl = (hostUrl.endsWith("/") ? hostUrl.replaceAll("/$", "") : hostUrl);
-        this.baseUrl = this.hostUrl;
-        this.hostUrl += apiVersion.getApiNamespace();
+  /**
+   * Perform a file upload using multipart/form-data, returning a ClientResponse instance with the
+   * data returned from the endpoint.
+   *
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param mediaTypeString unused; will be removed in the next major version
+   * @param formData the Form containing the name/value pairs
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response upload(
+      final String name, final File fileToUpload, final String mediaTypeString, final Form formData, final URL url)
+      throws IOException {
+    final FileDataBodyPart filePart = new FileDataBodyPart(name, fileToUpload);
+    return upload(filePart, formData, url);
+  }
 
-        this.tokenType = tokenType;
-        this.authToken = () -> authToken;
+  protected Response upload(
+      final String name,
+      final InputStream inputStream,
+      final String filename,
+      final String mediaTypeString,
+      final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (upload(name, inputStream, filename, mediaTypeString, null, url));
+  }
 
-        if (secretToken != null) {
-            secretToken = secretToken.trim();
-            secretToken = (secretToken.length() > 0 ? secretToken : null);
-        }
+  protected Response upload(
+      final String name,
+      final InputStream inputStream,
+      final String filename,
+      final String mediaTypeString,
+      final Form formData,
+      final URL url)
+      throws IOException {
+    final StreamDataBodyPart streamDataBodyPart = new StreamDataBodyPart(name, inputStream, filename);
+    return upload(streamDataBodyPart, formData, url);
+  }
 
-        this.secretToken = secretToken;
-
-        clientConfig = new ClientConfig();
-        if (clientConfigProperties != null) {
-
-            if (clientConfigProperties.containsKey(ClientProperties.PROXY_URI)) {
-                clientConfig.connectorProvider(new ApacheConnectorProvider());
-            }
-
-            for (Map.Entry<String, Object> propertyEntry : clientConfigProperties.entrySet()) {
-                clientConfig.property(propertyEntry.getKey(), propertyEntry.getValue());
-            }
-        }
-
-        // Disable auto-discovery of feature and services lookup, this will force Jersey
-        // to use the features and services explicitly configured by gitlab4j
-        clientConfig.property(ClientProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
-        clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
-
-        clientConfig.register(JacksonJson.class);
-        clientConfig.register(JacksonFeature.class);
-        clientConfig.register(MultiPartFeature.class);
-    }
-
-    /**
-     * Close the underlying {@link Client} and its associated resources.
-     */
-    @Override
-    public void close() {
-        if (apiClient != null) {
-            apiClient.close();
-        }
-    }
-
-    /**
-     * Enable the logging of the requests to and the responses from the GitLab server API.
-     *
-     * @param logger the Logger instance to log to
-     * @param level the logging level (SEVERE, WARNING, INFO, CONFIG, FINE, FINER, FINEST)
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is <= 0, entity logging will be disabled
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    void enableRequestResponseLogging(Logger logger, Level level, int maxEntityLength, List<String> maskedHeaderNames) {
-
-        MaskingLoggingFilter loggingFilter = new MaskingLoggingFilter(logger, level, maxEntityLength, maskedHeaderNames);
-        clientConfig.register(loggingFilter);
-
-        // Recreate the Client instance if already created.
-        if (apiClient != null) {
-            createApiClient();
-        }
-    }
-
-    /**
-     * Sets the per request connect and read timeout.
-     *
-     * @param connectTimeout the per request connect timeout in milliseconds, can be null to use default
-     * @param readTimeout the per request read timeout in milliseconds, can be null to use default
-     */
-    void setRequestTimeout(Integer connectTimeout, Integer readTimeout) {
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
-    }
-
-    /**
-     * Get the auth token being used by this client.
-     *
-     * @return the auth token being used by this client
-     */
-    String getAuthToken() {
-        return (authToken.get());
-    }
-
-    /**
-     * Get the secret token.
-     *
-     * @return the secret token
-     */
-    String getSecretToken() {
-        return (secretToken);
-    }
-
-    /**
-     * Get the TokenType this client is using.
-     *
-     * @return the TokenType this client is using
-     */
-    TokenType getTokenType() {
-        return (tokenType);
-    }
-
-    /**
-     * Set the ID of the user to sudo as.
-     *
-     */
-    Long getSudoAsId() {
-        return (sudoAsId);
-    }
-
-    /**
-     * Set the ID of the user to sudo as.
-     *
-     * @param sudoAsId the ID of the user to sudo as
-     */
-    void setSudoAsId(Long sudoAsId) {
-        this.sudoAsId = sudoAsId;
-    }
-
-    /**
-     * Construct a REST URL with the specified path arguments.
-     *
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a REST URL with the specified path arguments
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected URL getApiUrl(Object... pathArgs) throws IOException {
-        String url = appendPathArgs(this.hostUrl, pathArgs);
-        return (new URL(url));
-    }
-
-    /**
-     * Construct a REST URL with the specified path arguments using
-     * Gitlab base url.
-     *
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a REST URL with the specified path arguments
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected URL getUrlWithBase(Object... pathArgs) throws IOException {
-        String url = appendPathArgs(this.baseUrl, pathArgs);
-        return (new URL(url));
-    }
-
-    private String appendPathArgs(String url, Object... pathArgs) {
-        StringBuilder urlBuilder = new StringBuilder(url);
-        for (Object pathArg : pathArgs) {
-            if (pathArg != null) {
-                urlBuilder.append("/");
-                urlBuilder.append(pathArg.toString());
-            }
-        }
-        return urlBuilder.toString();
-    }
-
-    /**
-     * Validates the secret token (X-GitLab-Token) header against the expected secret token, returns true if valid,
-     * otherwise returns false.
-     *
-     * @param response the Response instance sent from the GitLab server
-     * @return true if the response's secret token is valid, otherwise returns false
-     */
-    protected boolean validateSecretToken(Response response) {
-
-        if (this.secretToken == null)
-            return (true);
-
-        String secretToken = response.getHeaderString(X_GITLAB_TOKEN_HEADER);
-        if (secretToken == null)
-            return (false);
-
-        return (this.secretToken.equals(secretToken));
-    }
-
-    /**
-     * Perform an HTTP GET call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response get(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (get(queryParams, url));
-    }
-
-    /**
-     * Perform an HTTP GET call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response get(MultivaluedMap<String, String> queryParams, URL url) {
-        return (invocation(url, queryParams).get());
-    }
-
-    /**
-     * Perform an HTTP GET call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param accepts if non-empty will set the Accepts header to this value
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response getWithAccepts(MultivaluedMap<String, String> queryParams, String accepts, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (getWithAccepts(queryParams, url, accepts));
-    }
-
-    /**
-     * Perform an HTTP GET call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @param accepts if non-empty will set the Accepts header to this value
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response getWithAccepts(MultivaluedMap<String, String> queryParams, URL url, String accepts) {
-        return (invocation(url, queryParams, accepts).get());
-    }
-
-    /**
-     * Perform an HTTP HEAD call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response head(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (head(queryParams, url));
-    }
-
-    /**
-     * Perform an HTTP HEAD call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response head(MultivaluedMap<String, String> queryParams, URL url) {
-        return (invocation(url, queryParams).head());
-    }
-
-    /**
-     * Perform an HTTP PATCH call with the specified query parameters and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response patch(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (patch(queryParams, url));
-    }
-
-    /**
-     * Perform an HTTP PATCH call with the specified query parameters and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response patch(MultivaluedMap<String, String> queryParams, URL url) {
-        Entity<?> empty = Entity.text("");
-        // use "X-HTTP-Method-Override" header on POST to override to unsupported PATCH
-        return (invocation(url, queryParams)
-                .header("X-HTTP-Method-Override", "PATCH").post(empty));
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response post(Form formData, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return post(formData, url);
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a Response instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response post(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return post(queryParams, url);
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response post(Form formData, URL url) {
-        if (formData instanceof GitLabApiForm) {
-            return (invocation(url, null).post(Entity.entity(formData.asMap(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-        } else if (formData != null) {
-            return (invocation(url, null).post(Entity.entity(formData, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-        } else {
-            return (invocation(url, null).post(Entity.entity(new Form(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-        }
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parametersformData the Form containing the name/value pairs
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response post(MultivaluedMap<String, String> queryParams, URL url) {
-        return (invocation(url, queryParams).post(Entity.entity(new Form(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified payload object and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param payload the object instance that will be serialized to JSON and used as the POST data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response post(Object payload, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        Entity<?> entity = Entity.entity(payload, MediaType.APPLICATION_JSON);
-        return (invocation(url, null).post(entity));
-    }
-
-    /**
-     * Perform an HTTP POST call with the specified StreamingOutput, MediaType, and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param stream the StreamingOutput instance that contains the POST data
-     * @param mediaType the content-type of the POST data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response post(StreamingOutput stream, String mediaType, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (invocation(url, null).post(Entity.entity(stream, mediaType)));
-    }
-
-    /**
-     * Perform a file upload using the specified media type, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString unused; will be removed in the next major version
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response upload(String name, File fileToUpload, String mediaTypeString, Object... pathArgs) throws IOException {
-        return upload(name, fileToUpload, mediaTypeString, null, pathArgs);
-    }
-
-    /**
-     * Perform a file upload using the specified media type, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString unused; will be removed in the next major version
-     * @param formData the Form containing the name/value pairs
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response upload(String name, File fileToUpload, String mediaTypeString, Form formData, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (upload(name, fileToUpload, mediaTypeString, formData, url));
-    }
-
-    /**
-     * Perform a file upload using multipart/form-data, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param mediaTypeString unused; will be removed in the next major version
-     * @param formData the Form containing the name/value pairs
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response upload(String name, File fileToUpload, String mediaTypeString, Form formData, URL url) throws IOException {
-        FileDataBodyPart filePart = new FileDataBodyPart(name, fileToUpload);
-        return upload(filePart, formData, url);
-    }
-
-    protected Response upload(String name, InputStream inputStream, String filename, String mediaTypeString, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (upload(name, inputStream, filename, mediaTypeString, null, url));
-    }
-
-    protected Response upload(String name, InputStream inputStream, String filename, String mediaTypeString, Form formData, URL url) throws IOException {
-        StreamDataBodyPart streamDataBodyPart = new StreamDataBodyPart(name, inputStream, filename);
-        return upload(streamDataBodyPart, formData, url);
-    }
-
-    protected Response upload(BodyPart bodyPart, Form formData, URL url) throws IOException {
-        try (FormDataMultiPart multiPart = new FormDataMultiPart()) {
-            if (formData != null) {
-                formData.asMap().forEach((key, values) -> {
-                    if (values != null) {
-                        values.forEach(value -> multiPart.field(key, value));
-                    }
+  protected Response upload(final BodyPart bodyPart, final Form formData, final URL url) throws IOException {
+    try (final FormDataMultiPart multiPart = new FormDataMultiPart()) {
+      if (formData != null) {
+        formData
+            .asMap()
+            .forEach(
+                (key, values) -> {
+                  if (values != null) {
+                    values.forEach(value -> multiPart.field(key, value));
+                  }
                 });
-            }
+      }
 
-            multiPart.bodyPart(bodyPart);
-            final Entity<?> entity = Entity.entity(multiPart, Boundary.addBoundary(multiPart.getMediaType()));
-            return (invocation(url, null).post(entity));
-        }
+      multiPart.bodyPart(bodyPart);
+      final Entity<?> entity =
+          Entity.entity(multiPart, Boundary.addBoundary(multiPart.getMediaType()));
+      return (invocation(url, null).post(entity));
+    }
+  }
+
+  /**
+   * Perform a file upload using multipart/form-data using the HTTP PUT method, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response putUpload(final String name, final File fileToUpload, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (putUpload(name, fileToUpload, url));
+  }
+
+  /**
+   * Perform a file upload using multipart/form-data using the HTTP PUT method, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param name the name for the form field that contains the file name
+   * @param fileToUpload a File instance pointing to the file to upload
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response putUpload(final String name, final File fileToUpload, final URL url) throws IOException {
+
+    try (final MultiPart multiPart = new FormDataMultiPart()) {
+      multiPart.bodyPart(
+          new FileDataBodyPart(name, fileToUpload, MediaType.APPLICATION_OCTET_STREAM_TYPE));
+      final Entity<?> entity =
+          Entity.entity(multiPart, Boundary.addBoundary(multiPart.getMediaType()));
+      return (invocation(url, null).put(entity));
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response put(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return (put(queryParams, url));
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response put(final MultivaluedMap<String, String> queryParams, final URL url) {
+    if (queryParams == null || queryParams.isEmpty()) {
+      final Entity<?> empty = Entity.text("");
+      return (invocation(url, null).put(empty));
+    } else {
+      return (invocation(url, null)
+          .put(Entity.entity(queryParams, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+    }
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and path objects, returning a
+   * ClientResponse instance with the data returned from the endpoint.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response put(final Form formData, final Object... pathArgs) throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    return put(formData, url);
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified form data and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param formData the Form containing the name/value pairs
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a ClientResponse instance with the data returned from the endpoint
+   */
+  protected Response put(final Form formData, final URL url) {
+    if (formData instanceof GitLabApiForm)
+      return (invocation(url, null)
+          .put(Entity.entity(formData.asMap(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+    else
+      return (invocation(url, null)
+          .put(Entity.entity(formData, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+  }
+
+  /**
+   * Perform an HTTP PUT call with the specified payload object and URL, returning a ClientResponse
+   * instance with the data returned from the endpoint.
+   *
+   * @param payload the object instance that will be serialized to JSON and used as the PUT data
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a ClientResponse instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response put(final Object payload, final Object... pathArgs) throws IOException {
+    final URL url = getApiUrl(pathArgs);
+    final Entity<?> entity = Entity.entity(payload, MediaType.APPLICATION_JSON);
+    return (invocation(url, null).put(entity));
+  }
+
+  /**
+   * Perform an HTTP DELETE call with the specified form data and path objects, returning a Response
+   * instance with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param pathArgs variable list of arguments used to build the URI
+   * @return a Response instance with the data returned from the endpoint
+   * @throws IOException if an error occurs while constructing the URL
+   */
+  protected Response delete(final MultivaluedMap<String, String> queryParams, final Object... pathArgs)
+      throws IOException {
+    return (delete(queryParams, getApiUrl(pathArgs)));
+  }
+
+  /**
+   * Perform an HTTP DELETE call with the specified form data and URL, returning a Response instance
+   * with the data returned from the endpoint.
+   *
+   * @param queryParams multivalue map of request parameters
+   * @param url the fully formed path to the GitLab API endpoint
+   * @return a Response instance with the data returned from the endpoint
+   */
+  protected Response delete(final MultivaluedMap<String, String> queryParams, final URL url) {
+    return (invocation(url, queryParams).delete());
+  }
+
+  protected Invocation.Builder invocation(final URL url, final MultivaluedMap<String, String> queryParams) {
+    return (invocation(url, queryParams, MediaType.APPLICATION_JSON));
+  }
+
+  protected Client createApiClient() {
+
+    // Explicitly use an instance of the JerseyClientBuilder, this allows this
+    // library to work when both Jersey and Resteasy are present
+    final ClientBuilder clientBuilder = new JerseyClientBuilder().withConfig(clientConfig);
+
+    // Register JacksonJson as the ObjectMapper provider.
+    clientBuilder.register(JacksonJson.class);
+    clientBuilder.register(JacksonFeature.class);
+
+    if (ignoreCertificateErrors) {
+      clientBuilder.sslContext(openSslContext).hostnameVerifier(openHostnameVerifier);
     }
 
-    /**
-     * Perform a file upload using multipart/form-data using the HTTP PUT method, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response putUpload(String name, File fileToUpload, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (putUpload(name, fileToUpload, url));
+    apiClient = clientBuilder.build();
+    return (apiClient);
+  }
+
+  protected Invocation.Builder invocation(
+      final URL url, final MultivaluedMap<String, String> queryParams, final String accept) {
+
+    if (apiClient == null) {
+      createApiClient();
     }
 
-    /**
-     * Perform a file upload using multipart/form-data using the HTTP PUT method, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param name the name for the form field that contains the file name
-     * @param fileToUpload a File instance pointing to the file to upload
-
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response putUpload(String name, File fileToUpload, URL url) throws IOException {
-
-        try (MultiPart multiPart = new FormDataMultiPart()) {
-            multiPart.bodyPart(new FileDataBodyPart(name, fileToUpload, MediaType.APPLICATION_OCTET_STREAM_TYPE));
-            final Entity<?> entity = Entity.entity(multiPart, Boundary.addBoundary(multiPart.getMediaType()));
-            return (invocation(url, null).put(entity));
-        }
+    WebTarget target =
+        apiClient.target(url.toExternalForm()).property(ClientProperties.FOLLOW_REDIRECTS, true);
+    if (queryParams != null) {
+      for (final Map.Entry<String, List<String>> param : queryParams.entrySet()) {
+        target = target.queryParam(param.getKey(), param.getValue().toArray());
+      }
     }
 
-    /**
-     * Perform an HTTP PUT call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response put(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return (put(queryParams, url));
+    final String authHeader =
+        (tokenType == TokenType.OAUTH2_ACCESS ? AUTHORIZATION_HEADER : PRIVATE_TOKEN_HEADER);
+    final String authValue =
+        (tokenType == TokenType.OAUTH2_ACCESS ? "Bearer " + authToken.get() : authToken.get());
+    Invocation.Builder builder = target.request();
+    if (accept == null || accept.trim().length() == 0) {
+      builder = builder.header(authHeader, authValue);
+    } else {
+      builder = builder.header(authHeader, authValue).accept(accept);
     }
 
-    /**
-     * Perform an HTTP PUT call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response put(MultivaluedMap<String, String> queryParams, URL url) {
-        if (queryParams == null || queryParams.isEmpty()) {
-            Entity<?> empty = Entity.text("");
-            return (invocation(url, null).put(empty));
-        } else {
-            return (invocation(url, null).put(Entity.entity(queryParams, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-        }
+    // If sudo as ID is set add the Sudo header
+    if (sudoAsId != null && sudoAsId.intValue() > 0)
+      builder = builder.header(SUDO_HEADER, sudoAsId);
+
+    // Set the per request connect timeout
+    if (connectTimeout != null) {
+      builder.property(ClientProperties.CONNECT_TIMEOUT, connectTimeout);
     }
 
-    /**
-     * Perform an HTTP PUT call with the specified form data and path objects, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response put(Form formData, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        return put(formData, url);
+    // Set the per request read timeout
+    if (readTimeout != null) {
+      builder.property(ClientProperties.READ_TIMEOUT, readTimeout);
     }
 
-    /**
-     * Perform an HTTP PUT call with the specified form data and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param formData the Form containing the name/value pairs
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a ClientResponse instance with the data returned from the endpoint
-     */
-    protected Response put(Form formData, URL url) {
-        if (formData instanceof GitLabApiForm)
-            return (invocation(url, null).put(Entity.entity(formData.asMap(), MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
-        else
-            return (invocation(url, null).put(Entity.entity(formData, MediaType.APPLICATION_FORM_URLENCODED_TYPE)));
+    return (builder);
+  }
+
+  /** Used to set the host URL to be used by OAUTH2 login in GitLabApi. */
+  void setHostUrlToBaseUrl() {
+    this.hostUrl = this.baseUrl;
+  }
+
+  /**
+   * Returns true if the API is setup to ignore SSL certificate errors, otherwise returns false.
+   *
+   * @return true if the API is setup to ignore SSL certificate errors, otherwise returns false
+   */
+  public boolean getIgnoreCertificateErrors() {
+    return (ignoreCertificateErrors);
+  }
+
+  /**
+   * Sets up the Jersey system ignore SSL certificate errors or not.
+   *
+   * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate
+   *     errors
+   */
+  public void setIgnoreCertificateErrors(final boolean ignoreCertificateErrors) {
+
+    if (this.ignoreCertificateErrors == ignoreCertificateErrors) {
+      return;
     }
 
-    /**
-     * Perform an HTTP PUT call with the specified payload object and URL, returning
-     * a ClientResponse instance with the data returned from the endpoint.
-     *
-     * @param payload the object instance that will be serialized to JSON and used as the PUT data
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a ClientResponse instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response put(Object payload, Object... pathArgs) throws IOException {
-        URL url = getApiUrl(pathArgs);
-        Entity<?> entity = Entity.entity(payload, MediaType.APPLICATION_JSON);
-        return (invocation(url, null).put(entity));
+    if (!ignoreCertificateErrors) {
+
+      this.ignoreCertificateErrors = false;
+      openSslContext = null;
+      openHostnameVerifier = null;
+      apiClient = null;
+
+    } else {
+
+      if (setupIgnoreCertificateErrors()) {
+        this.ignoreCertificateErrors = true;
+        apiClient = null;
+      } else {
+        this.ignoreCertificateErrors = false;
+        apiClient = null;
+        throw new RuntimeException("Unable to ignore certificate errors.");
+      }
     }
+  }
 
-    /**
-     * Perform an HTTP DELETE call with the specified form data and path objects, returning
-     * a Response instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param pathArgs variable list of arguments used to build the URI
-     * @return a Response instance with the data returned from the endpoint
-     * @throws IOException if an error occurs while constructing the URL
-     */
-    protected Response delete(MultivaluedMap<String, String> queryParams, Object... pathArgs) throws IOException {
-        return (delete(queryParams, getApiUrl(pathArgs)));
-    }
+  /**
+   * Sets up Jersey client to ignore certificate errors.
+   *
+   * @return true if successful at setting up to ignore certificate errors, otherwise returns false.
+   */
+  private boolean setupIgnoreCertificateErrors() {
 
-    /**
-     * Perform an HTTP DELETE call with the specified form data and URL, returning
-     * a Response instance with the data returned from the endpoint.
-     *
-     * @param queryParams multivalue map of request parameters
-     * @param url the fully formed path to the GitLab API endpoint
-     * @return a Response instance with the data returned from the endpoint
-     */
-    protected Response delete(MultivaluedMap<String, String> queryParams, URL url) {
-        return (invocation(url, queryParams).delete());
-    }
-
-    protected Invocation.Builder invocation(URL url, MultivaluedMap<String, String> queryParams) {
-        return (invocation(url, queryParams, MediaType.APPLICATION_JSON));
-    }
-
-    protected Client createApiClient() {
-
-        // Explicitly use an instance of the JerseyClientBuilder, this allows this
-        // library to work when both Jersey and Resteasy are present
-        ClientBuilder clientBuilder = new JerseyClientBuilder().withConfig(clientConfig);
-
-        // Register JacksonJson as the ObjectMapper provider.
-        clientBuilder.register(JacksonJson.class);
-        clientBuilder.register(JacksonFeature.class);
-
-        if (ignoreCertificateErrors) {
-            clientBuilder.sslContext(openSslContext).hostnameVerifier(openHostnameVerifier);
-        }
-
-        apiClient = clientBuilder.build();
-        return (apiClient);
-    }
-
-    protected Invocation.Builder invocation(URL url, MultivaluedMap<String, String> queryParams, String accept) {
-
-        if (apiClient == null) {
-            createApiClient();
-        }
-
-        WebTarget target = apiClient.target(url.toExternalForm()).property(ClientProperties.FOLLOW_REDIRECTS, true);
-        if (queryParams != null) {
-            for (Map.Entry<String, List<String>> param : queryParams.entrySet()) {
-                target = target.queryParam(param.getKey(), param.getValue().toArray());
-            }
-        }
-
-        String authHeader = (tokenType == TokenType.OAUTH2_ACCESS ? AUTHORIZATION_HEADER : PRIVATE_TOKEN_HEADER);
-        String authValue = (tokenType == TokenType.OAUTH2_ACCESS ? "Bearer " + authToken.get() : authToken.get());
-        Invocation.Builder builder = target.request();
-        if (accept == null || accept.trim().length() == 0) {
-            builder = builder.header(authHeader, authValue);
-        } else {
-            builder = builder.header(authHeader, authValue).accept(accept);
-        }
-
-        // If sudo as ID is set add the Sudo header
-        if (sudoAsId != null && sudoAsId.intValue() > 0)
-            builder = builder.header(SUDO_HEADER,  sudoAsId);
-
-        // Set the per request connect timeout
-        if (connectTimeout != null) {
-            builder.property(ClientProperties.CONNECT_TIMEOUT, connectTimeout);
-        }
-
-        // Set the per request read timeout
-        if (readTimeout != null) {
-            builder.property(ClientProperties.READ_TIMEOUT, readTimeout);
-        }
-
-        return (builder);
-    }
-
-    /**
-     * Used to set the host URL to be used by OAUTH2 login in GitLabApi.
-     */
-    void setHostUrlToBaseUrl() {
-        this.hostUrl = this.baseUrl;
-    }
-
-    /**
-     * Returns true if the API is setup to ignore SSL certificate errors, otherwise returns false.
-     *
-     * @return true if the API is setup to ignore SSL certificate errors, otherwise returns false
-     */
-    public boolean getIgnoreCertificateErrors() {
-        return (ignoreCertificateErrors);
-    }
-
-    /**
-     * Sets up the Jersey system ignore SSL certificate errors or not.
-     *
-     * @param ignoreCertificateErrors if true will set up the Jersey system ignore SSL certificate errors
-     */
-    public void setIgnoreCertificateErrors(boolean ignoreCertificateErrors) {
-
-        if (this.ignoreCertificateErrors == ignoreCertificateErrors) {
-            return;
-        }
-
-        if (!ignoreCertificateErrors) {
-
-            this.ignoreCertificateErrors = false;
-            openSslContext = null;
-            openHostnameVerifier = null;
-            apiClient = null;
-
-        } else {
-
-            if (setupIgnoreCertificateErrors()) {
-                this.ignoreCertificateErrors = true;
-                apiClient = null;
-            } else {
-                this.ignoreCertificateErrors = false;
-                apiClient = null;
-                throw new RuntimeException("Unable to ignore certificate errors.");
-            }
-        }
-    }
-
-    /**
-     * Sets up Jersey client to ignore certificate errors.
-     *
-     * @return true if successful at setting up to ignore certificate errors, otherwise returns false.
-     */
-    private boolean setupIgnoreCertificateErrors() {
-
-        // Create a TrustManager that trusts all certificates
-        TrustManager[] trustAllCerts = new TrustManager[] { new X509ExtendedTrustManager() {
+    // Create a TrustManager that trusts all certificates
+    final TrustManager[] trustAllCerts =
+        new TrustManager[] {
+          new X509ExtendedTrustManager() {
             @Override
             public X509Certificate[] getAcceptedIssuers() {
-                return null;
+              return null;
             }
 
             @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-            }
+            public void checkServerTrusted(final X509Certificate[] chain, final String authType)
+                throws CertificateException {}
 
             @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType) throws CertificateException {
-            }
+            public void checkClientTrusted(final X509Certificate[] chain, final String authType)
+                throws CertificateException {}
 
             @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-            }
+            public void checkClientTrusted(final X509Certificate[] chain, final String authType, final Socket socket)
+                throws CertificateException {}
 
             @Override
-            public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
-            }
+            public void checkClientTrusted(
+                final X509Certificate[] chain, final String authType, final SSLEngine engine)
+                throws CertificateException {}
 
             @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, Socket socket) throws CertificateException {
-            }
+            public void checkServerTrusted(final X509Certificate[] chain, final String authType, final Socket socket)
+                throws CertificateException {}
 
             @Override
-            public void checkServerTrusted(X509Certificate[] chain, String authType, SSLEngine engine) throws CertificateException {
-            }
-        }};
-
-        // Ignore differences between given hostname and certificate hostname
-        HostnameVerifier hostnameVerifier = new HostnameVerifier() {
-            @Override
-            public boolean verify(String hostname, SSLSession session) {
-                return true;
-            }
+            public void checkServerTrusted(
+                final X509Certificate[] chain, final String authType, final SSLEngine engine)
+                throws CertificateException {}
+          }
         };
 
-        try {
-            SSLContext sslContext = SSLContext.getInstance("TLS");
-            sslContext.init(null, trustAllCerts, new SecureRandom());
-            openSslContext = sslContext;
-            openHostnameVerifier = hostnameVerifier;
-        } catch (GeneralSecurityException ex) {
-            openSslContext = null;
-            openHostnameVerifier = null;
-            return (false);
-        }
+    // Ignore differences between given hostname and certificate hostname
+    final HostnameVerifier hostnameVerifier =
+        new HostnameVerifier() {
+          @Override
+          public boolean verify(final String hostname, final SSLSession session) {
+            return true;
+          }
+        };
 
-        return (true);
+    try {
+      final SSLContext sslContext = SSLContext.getInstance("TLS");
+      sslContext.init(null, trustAllCerts, new SecureRandom());
+      openSslContext = sslContext;
+      openHostnameVerifier = hostnameVerifier;
+    } catch (final GeneralSecurityException ex) {
+      openSslContext = null;
+      openHostnameVerifier = null;
+      return (false);
     }
 
-    /**
-     * Set auth token supplier for gitlab api client.
-     * @param authTokenSupplier - supplier which provide actual auth token
-     */
-    public void setAuthTokenSupplier(Supplier<String> authTokenSupplier) {
-        this.authToken = authTokenSupplier;
-    }
+    return (true);
+  }
+
+  /**
+   * Set auth token supplier for gitlab api client.
+   *
+   * @param authTokenSupplier - supplier which provide actual auth token
+   */
+  public void setAuthTokenSupplier(final Supplier<String> authTokenSupplier) {
+    this.authToken = authTokenSupplier;
+  }
 }

--- a/src/main/java/org/gitlab4j/api/GitLabApiException.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiException.java
@@ -1,253 +1,249 @@
 package org.gitlab4j.api;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.StatusType;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.StatusType;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.databind.JsonNode;
-
 /**
- * This is the exception that will be thrown if any exception occurs while communicating
- * with a GitLab API endpoint.
+ * This is the exception that will be thrown if any exception occurs while communicating with a
+ * GitLab API endpoint.
  */
 public class GitLabApiException extends Exception {
 
-    private static final long serialVersionUID = 1L;
-    private StatusType statusInfo;
-    private int httpStatus;
-    private String message;
-    private Map<String, List<String>> validationErrors;
-    
-    /**
-     * Create a GitLabApiException instance with the specified message.
-     *
-     * @param message the message for the exception
-     */
-    public GitLabApiException(String message) {
-        super(message);
+  private static final long serialVersionUID = 1L;
+  private StatusType statusInfo;
+  private int httpStatus;
+  private String message;
+  private Map<String, List<String>> validationErrors;
+
+  /**
+   * Create a GitLabApiException instance with the specified message.
+   *
+   * @param message the message for the exception
+   */
+  public GitLabApiException(final String message) {
+    super(message);
+    this.message = message;
+  }
+
+  /**
+   * Create a GitLabApiException instance with the specified message and HTTP status code.
+   *
+   * @param message the message for the exception
+   * @param httpStatus the HTTP status code for the exception
+   */
+  public GitLabApiException(final String message, final int httpStatus) {
+    super(message);
+    this.message = message;
+    this.httpStatus = httpStatus;
+  }
+
+  /**
+   * Create a GitLabApiException instance based on the ClientResponse.
+   *
+   * @param response the JAX-RS response that caused the exception
+   */
+  public GitLabApiException(final Response response) {
+
+    super();
+    statusInfo = response.getStatusInfo();
+    httpStatus = response.getStatus();
+
+    if (response.hasEntity()) {
+
+      try {
+
+        final String message = response.readEntity(String.class);
         this.message = message;
-    }
 
-    /**
-     * Create a GitLabApiException instance with the specified message and HTTP status code.
-     *
-     * @param message the message for the exception
-     * @param httpStatus the HTTP status code for the exception
-     */
-    public GitLabApiException(String message, int httpStatus) {
-        super(message);
-        this.message = message;
-        this.httpStatus = httpStatus;
-    }
+        // Determine what is in the content of the response and process it accordingly
+        final MediaType mediaType = response.getMediaType();
+        if (mediaType != null && "json".equals(mediaType.getSubtype())) {
 
-    /**
-     * Create a GitLabApiException instance based on the ClientResponse.
-     *
-     * @param response the JAX-RS response that caused the exception
-     */
-    public GitLabApiException(Response response) {
+          final JsonNode json = JacksonJson.toJsonNode(message);
 
-        super();
-        statusInfo = response.getStatusInfo();
-        httpStatus = response.getStatus();
+          // First see if it is a "message", if so it is either a simple message,
+          // or a Map<String, List<String>> of validation errors
+          final JsonNode jsonMessage = json.get("message");
+          if (jsonMessage != null) {
 
-        if (response.hasEntity()) {
+            // If the node is an object, then it is validation errors
+            if (jsonMessage.isObject()) {
 
-            try {
+              final StringBuilder buf = new StringBuilder();
+              validationErrors = new HashMap<>();
+              final Iterator<Entry<String, JsonNode>> fields = jsonMessage.fields();
+              while (fields.hasNext()) {
 
-                String message = response.readEntity(String.class);
-                this.message = message;
-
-                // Determine what is in the content of the response and process it accordingly
-                MediaType mediaType = response.getMediaType();
-                if (mediaType != null && "json".equals(mediaType.getSubtype())) {
-
-                    JsonNode json = JacksonJson.toJsonNode(message);
-
-                    // First see if it is a "message", if so it is either a simple message,
-                    // or a Map<String, List<String>> of validation errors
-                    JsonNode jsonMessage = json.get("message");
-                    if (jsonMessage != null) {
-
-                        // If the node is an object, then it is validation errors
-                        if (jsonMessage.isObject()) {
-
-                            StringBuilder buf = new StringBuilder();
-                            validationErrors = new HashMap<>();
-                            Iterator<Entry<String, JsonNode>> fields = jsonMessage.fields();
-                            while(fields.hasNext()) {
-
-                                Entry<String, JsonNode> field = fields.next();
-                                String fieldName = field.getKey();                                
-                                List<String> values = new ArrayList<>();
-                                validationErrors.put(fieldName, values);
-                                for (JsonNode value : field.getValue()) {
-                                    values.add(value.asText());
-                                }
-
-                                if (values.size() > 0) {
-                                    buf.append((buf.length() > 0 ? ", " : "")).append(fieldName);
-                                }
-                            }
-
-                            if (buf.length() > 0) {
-                                this.message = "The following fields have validation errors: " + buf.toString();
-                            }
-
-                        } else if (jsonMessage.isArray()) {
-
-                           List<String> values = new ArrayList<>();
-                           for (JsonNode value : jsonMessage) {
-                                values.add(value.asText());
-                           }
-
-                           if (values.size() > 0) {
-                               this.message = String.join("\n", values);
-                           }
-
-                        } else if (jsonMessage.isTextual()) {
-                            this.message = jsonMessage.asText();
-                        } else {
-                            this.message = jsonMessage.toString();
-                        }
-
-                    } else {
-
-                        JsonNode jsonError = json.get("error");
-                        if (jsonError != null) {
-                            this.message = jsonError.asText();
-                        }
-                    }
+                final Entry<String, JsonNode> field = fields.next();
+                final String fieldName = field.getKey();
+                final List<String> values = new ArrayList<>();
+                validationErrors.put(fieldName, values);
+                for (final JsonNode value : field.getValue()) {
+                  values.add(value.asText());
                 }
 
-            } catch (Exception ignore) {
+                if (values.size() > 0) {
+                  buf.append((buf.length() > 0 ? ", " : "")).append(fieldName);
+                }
+              }
+
+              if (buf.length() > 0) {
+                this.message = "The following fields have validation errors: " + buf.toString();
+              }
+
+            } else if (jsonMessage.isArray()) {
+
+              final List<String> values = new ArrayList<>();
+              for (final JsonNode value : jsonMessage) {
+                values.add(value.asText());
+              }
+
+              if (values.size() > 0) {
+                this.message = String.join("\n", values);
+              }
+
+            } else if (jsonMessage.isTextual()) {
+              this.message = jsonMessage.asText();
+            } else {
+              this.message = jsonMessage.toString();
             }
-        }
-    }
 
-    /**
-     * Create a GitLabApiException instance based on the exception.
-     *
-     * @param e the Exception to wrap
-     */
-    public GitLabApiException(Exception e) {
-        super(e);
-        message = e.getMessage();
-    }
+          } else {
 
-    /**
-     * Get the message associated with the exception.
-     *
-     * @return the message associated with the exception
-     */
-    @Override
-    public final String getMessage() {
-        return (message != null ? message : getReason());
-    }
-
-    /**
-     * Returns the HTTP status reason message, returns null if the
-     * causing error was not an HTTP related exception.
-     *
-     * @return the HTTP status reason message
-     */
-    public final String getReason() {
-        return (statusInfo != null ? statusInfo.getReasonPhrase() : null);
-    }
-
-    /**
-     * Returns the HTTP status code that was the cause of the exception. returns 0 if the
-     * causing error was not an HTTP related exception
-     *
-     * @return the HTTP status code, returns 0 if the causing error was not an HTTP related exception
-     */
-    public final int getHttpStatus() {
-        return (httpStatus);
-    }
-
-    /**
-     * Returns true if this GitLabApiException was caused by validation errors on the GitLab server,
-     * otherwise returns false.
-     *
-     * @return true if this GitLabApiException was caused by validation errors on the GitLab server,
-     * otherwise returns false
-     */
-    public boolean hasValidationErrors() {
-        return (validationErrors != null);
-    }
-
-    /**
-     * Returns a Map&lt;String, List&lt;String&gt;&gt; instance containing validation errors if this GitLabApiException 
-     * was caused by validation errors on the GitLab server, otherwise returns null.
-     *
-     * @return a Map&lt;String, List&lt;String&gt;&gt; instance containing validation errors if this GitLabApiException 
-     * was caused by validation errors on the GitLab server, otherwise returns null
-     */
-    public Map<String, List<String>> getValidationErrors() {
-        return (validationErrors);
-    }
-
-    @Override
-    public int hashCode() {
-        final int prime = 31;
-        int result = 1;
-        result = prime * result + httpStatus;
-        result = prime * result + ((message == null) ? 0 : message.hashCode());
-        result = prime * result + ((statusInfo == null) ? 0 : statusInfo.hashCode());
-        result = prime * result + ((validationErrors == null) ? 0 : validationErrors.hashCode());
-        return result;
-    }
-
-    @Override
-    public boolean equals(Object obj) {
-
-        if (this == obj) {
-            return true;
+            final JsonNode jsonError = json.get("error");
+            if (jsonError != null) {
+              this.message = jsonError.asText();
+            }
+          }
         }
 
-        if (obj == null) {
-            return false;
-        }
-
-        if (getClass() != obj.getClass()) {
-            return false;
-        }
-
-        GitLabApiException other = (GitLabApiException) obj;
-        if (httpStatus != other.httpStatus) {
-            return false;
-        }
-
-        if (message == null) {
-            if (other.message != null)
-                return false;
-        } else if (!message.equals(other.message)) {
-            return false;
-        }
-
-        if (statusInfo == null) {
-            if (other.statusInfo != null)
-                return false;
-        } else if (!statusInfo.equals(other.statusInfo)) {
-            return false;
-        }
-
-        if (validationErrors == null) {
-            if (other.validationErrors != null)
-                return false;
-        } else if (!validationErrors.equals(other.validationErrors)) {
-            return false;
-        }
-
-        return true;
+      } catch (final Exception ignore) {
+      }
     }
+  }
+
+  /**
+   * Create a GitLabApiException instance based on the exception.
+   *
+   * @param e the Exception to wrap
+   */
+  public GitLabApiException(final Exception e) {
+    super(e);
+    message = e.getMessage();
+  }
+
+  /**
+   * Get the message associated with the exception.
+   *
+   * @return the message associated with the exception
+   */
+  @Override
+  public final String getMessage() {
+    return (message != null ? message : getReason());
+  }
+
+  /**
+   * Returns the HTTP status reason message, returns null if the causing error was not an HTTP
+   * related exception.
+   *
+   * @return the HTTP status reason message
+   */
+  public final String getReason() {
+    return (statusInfo != null ? statusInfo.getReasonPhrase() : null);
+  }
+
+  /**
+   * Returns the HTTP status code that was the cause of the exception. returns 0 if the causing
+   * error was not an HTTP related exception
+   *
+   * @return the HTTP status code, returns 0 if the causing error was not an HTTP related exception
+   */
+  public final int getHttpStatus() {
+    return (httpStatus);
+  }
+
+  /**
+   * Returns true if this GitLabApiException was caused by validation errors on the GitLab server,
+   * otherwise returns false.
+   *
+   * @return true if this GitLabApiException was caused by validation errors on the GitLab server,
+   *     otherwise returns false
+   */
+  public boolean hasValidationErrors() {
+    return (validationErrors != null);
+  }
+
+  /**
+   * Returns a Map&lt;String, List&lt;String&gt;&gt; instance containing validation errors if this
+   * GitLabApiException was caused by validation errors on the GitLab server, otherwise returns
+   * null.
+   *
+   * @return a Map&lt;String, List&lt;String&gt;&gt; instance containing validation errors if this
+   *     GitLabApiException was caused by validation errors on the GitLab server, otherwise returns
+   *     null
+   */
+  public Map<String, List<String>> getValidationErrors() {
+    return (validationErrors);
+  }
+
+  @Override
+  public int hashCode() {
+    final int prime = 31;
+    int result = 1;
+    result = prime * result + httpStatus;
+    result = prime * result + ((message == null) ? 0 : message.hashCode());
+    result = prime * result + ((statusInfo == null) ? 0 : statusInfo.hashCode());
+    result = prime * result + ((validationErrors == null) ? 0 : validationErrors.hashCode());
+    return result;
+  }
+
+  @Override
+  public boolean equals(final Object obj) {
+
+    if (this == obj) {
+      return true;
+    }
+
+    if (obj == null) {
+      return false;
+    }
+
+    if (getClass() != obj.getClass()) {
+      return false;
+    }
+
+    final GitLabApiException other = (GitLabApiException) obj;
+    if (httpStatus != other.httpStatus) {
+      return false;
+    }
+
+    if (message == null) {
+      if (other.message != null) return false;
+    } else if (!message.equals(other.message)) {
+      return false;
+    }
+
+    if (statusInfo == null) {
+      if (other.statusInfo != null) return false;
+    } else if (!statusInfo.equals(other.statusInfo)) {
+      return false;
+    }
+
+    if (validationErrors == null) {
+      if (other.validationErrors != null) return false;
+    } else if (!validationErrors.equals(other.validationErrors)) {
+      return false;
+    }
+
+    return true;
+  }
 }

--- a/src/main/java/org/gitlab4j/api/GitLabApiForm.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiForm.java
@@ -1,220 +1,224 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MultivaluedHashMap;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MultivaluedHashMap;
-
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Variable;
 import org.gitlab4j.api.utils.ISO8601;
 
-/**
- * This class extends the standard JAX-RS Form class to make it fluent.
- */
+/** This class extends the standard JAX-RS Form class to make it fluent. */
 public class GitLabApiForm extends Form {
 
-    public GitLabApiForm() {
-        super();
+  public GitLabApiForm() {
+    super();
+  }
+
+  public GitLabApiForm(final MultivaluedHashMap<String, String> map) {
+    super(map);
+  }
+
+  /**
+   * Create a GitLabApiForm instance with the "page", and "per_page" parameters preset.
+   *
+   * @param page the value for the "page" parameter
+   * @param perPage the value for the "per_page" parameter
+   */
+  public GitLabApiForm(final int page, final int perPage) {
+    super();
+    withParam(AbstractApi.PAGE_PARAM, page);
+    withParam(AbstractApi.PER_PAGE_PARAM, (Integer) perPage);
+  }
+
+  /**
+   * Fluent method for adding query and form parameters to a get() or post() call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param value the value of the field/attribute to add
+   * @return this GitLabAPiForm instance
+   */
+  public GitLabApiForm withParam(final String name, final Object value) throws IllegalArgumentException {
+    return (withParam(name, value, false));
+  }
+
+  /**
+   * Fluent method for adding Date query and form parameters to a get() or post() call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param date the value of the field/attribute to add
+   * @return this GitLabAPiForm instance
+   */
+  public GitLabApiForm withParam(final String name, final Date date) throws IllegalArgumentException {
+    return (withParam(name, date, false));
+  }
+
+  /**
+   * Fluent method for adding Date query and form parameters to a get() or post() call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param date the value of the field/attribute to add
+   * @param required the field is required flag
+   * @return this GitLabAPiForm instance
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  public GitLabApiForm withParam(final String name, final Date date, final boolean required)
+      throws IllegalArgumentException {
+    return (withParam(name, (date == null ? null : ISO8601.toString(date)), required));
+  }
+
+  /**
+   * Fluent method for adding AccessLevel query and form parameters to a get() or post() call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param level the value of the field/attribute to add
+   * @return this GitLabAPiForm instance
+   */
+  public GitLabApiForm withParam(final String name, final AccessLevel level) throws IllegalArgumentException {
+    return (withParam(name, level, false));
+  }
+
+  /**
+   * Fluent method for adding AccessLevel query and form parameters to a get() or post() call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param level the value of the field/attribute to add
+   * @param required the field is required flag
+   * @return this GitLabAPiForm instance
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  public GitLabApiForm withParam(final String name, final AccessLevel level, final boolean required)
+      throws IllegalArgumentException {
+    return (withParam(name, (level == null ? null : level.toValue()), required));
+  }
+
+  /**
+   * Fluent method for adding a List type query and form parameters to a get() or post() call.
+   *
+   * @param <T> the type contained by the List
+   * @param name the name of the field/attribute to add
+   * @param values a List containing the values of the field/attribute to add
+   * @return this GitLabAPiForm instance
+   */
+  public <T> GitLabApiForm withParam(final String name, final List<T> values) {
+    return (withParam(name, values, false));
+  }
+
+  /**
+   * Fluent method for adding a List type query and form parameters to a get() or post() call.
+   *
+   * @param <T> the type contained by the List
+   * @param name the name of the field/attribute to add
+   * @param values a List containing the values of the field/attribute to add
+   * @param required the field is required flag
+   * @return this GitLabAPiForm instance
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  public <T> GitLabApiForm withParam(final String name, final List<T> values, final boolean required)
+      throws IllegalArgumentException {
+
+    if (values == null || values.isEmpty()) {
+      if (required) {
+        throw new IllegalArgumentException(name + " cannot be empty or null");
+      }
+
+      return (this);
     }
 
-    public GitLabApiForm(MultivaluedHashMap<String, String> map) {
-        super(map);
+    for (final T value : values) {
+      if (value != null) {
+        this.param(name + "[]", value.toString());
+      }
     }
 
-    /**
-     * Create a GitLabApiForm instance with the "page", and "per_page" parameters preset.
-     *
-     * @param page the value for the "page" parameter
-     * @param perPage the value for the "per_page" parameter
-     */
-    public GitLabApiForm(int page, int perPage) {
-        super();
-        withParam(AbstractApi.PAGE_PARAM,  page);
-        withParam(AbstractApi.PER_PAGE_PARAM, (Integer)perPage);
+    return (this);
+  }
+
+  /**
+   * Fluent method for adding an array of hash type query and form parameters to a get() or post()
+   * call.
+   *
+   * @param name the name of the field/attribute to add
+   * @param variables a Map containing array of hashes
+   * @param required the field is required flag
+   * @return this GitLabAPiForm instance
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  public GitLabApiForm withParam(final String name, final Map<String, ?> variables, final boolean required)
+      throws IllegalArgumentException {
+
+    if (variables == null || variables.isEmpty()) {
+      if (required) {
+        throw new IllegalArgumentException(name + " cannot be empty or null");
+      }
+
+      return (this);
     }
 
-    /**
-     * Fluent method for adding query and form parameters to a get() or post() call.
-     * 
-     * @param name the name of the field/attribute to add
-     * @param value the value of the field/attribute to add
-     * @return this GitLabAPiForm instance
-     */
-    public GitLabApiForm withParam(String name, Object value) throws IllegalArgumentException {
-        return (withParam(name, value, false));
+    for (final Entry<String, ?> variable : variables.entrySet()) {
+      final Object value = variable.getValue();
+      if (value != null) {
+        this.param(name + "[][key]", variable.getKey());
+        this.param(name + "[][value]", value.toString());
+      }
     }
 
-    /**
-     * Fluent method for adding Date query and form parameters to a get() or post() call.
-     *
-     * @param name the name of the field/attribute to add
-     * @param date the value of the field/attribute to add
-     * @return this GitLabAPiForm instance
-     */
-    public GitLabApiForm withParam(String name, Date date) throws IllegalArgumentException {
-        return (withParam(name, date, false));
+    return (this);
+  }
+
+  /**
+   * Fluent method for adding query and form parameters to a get() or post() call. If required is
+   * true and value is null, will throw an IllegalArgumentException.
+   *
+   * @param name the name of the field/attribute to add
+   * @param value the value of the field/attribute to add
+   * @param required the field is required flag
+   * @return this GitLabAPiForm instance
+   * @throws IllegalArgumentException if a required parameter is null or empty
+   */
+  public GitLabApiForm withParam(final String name, final Object value, final boolean required)
+      throws IllegalArgumentException {
+
+    if (value == null) {
+      if (required) {
+        throw new IllegalArgumentException(name + " cannot be empty or null");
+      }
+
+      return (this);
     }
 
-    /**
-     * Fluent method for adding Date query and form parameters to a get() or post() call.
-     *
-     * @param name the name of the field/attribute to add
-     * @param date the value of the field/attribute to add
-     * @param required the field is required flag
-     * @return this GitLabAPiForm instance
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    public GitLabApiForm withParam(String name, Date date, boolean required) throws IllegalArgumentException {
-        return (withParam(name, (date == null ? null : ISO8601.toString(date)), required));
+    final String stringValue = value.toString();
+    if (required && stringValue.trim().length() == 0) {
+      throw new IllegalArgumentException(name + " cannot be empty or null");
     }
 
-    /**
-     * Fluent method for adding AccessLevel query and form parameters to a get() or post() call.
-     *
-     * @param name the name of the field/attribute to add
-     * @param level the value of the field/attribute to add
-     * @return this GitLabAPiForm instance
-     */
-    public GitLabApiForm withParam(String name, AccessLevel level) throws IllegalArgumentException {
-        return (withParam(name, level, false));
+    this.param(name.trim(), stringValue);
+    return (this);
+  }
+
+  /**
+   * Fluent method for adding a List&lt;Variable&gt; type query and form parameters to a get(),
+   * post(), or put() call.
+   *
+   * @param variables the List of Variable to add
+   * @return this GitLabAPiForm instance
+   */
+  public GitLabApiForm withParam(final List<Variable> variables) {
+
+    if (variables == null || variables.isEmpty()) {
+      return (this);
     }
 
-    /**
-     * Fluent method for adding AccessLevel query and form parameters to a get() or post() call.
-     *
-     * @param name the name of the field/attribute to add
-     * @param level the value of the field/attribute to add
-     * @param required the field is required flag
-     * @return this GitLabAPiForm instance
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    public GitLabApiForm withParam(String name, AccessLevel level, boolean required) throws IllegalArgumentException {
-        return (withParam(name, (level == null ? null : level.toValue()), required));
-    }
-
-    /**
-     * Fluent method for adding a List type query and form parameters to a get() or post() call.
-     *
-     * @param <T> the type contained by the List
-     * @param name the name of the field/attribute to add
-     * @param values a List containing the values of the field/attribute to add
-     * @return this GitLabAPiForm instance
-     */
-    public <T> GitLabApiForm withParam(String name, List<T> values) {
-        return (withParam(name, values, false));
-    }
-
-    /**
-     * Fluent method for adding a List type query and form parameters to a get() or post() call.
-     *
-     * @param <T> the type contained by the List
-     * @param name the name of the field/attribute to add
-     * @param values a List containing the values of the field/attribute to add
-     * @param required the field is required flag
-     * @return this GitLabAPiForm instance
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    public <T> GitLabApiForm withParam(String name, List<T> values, boolean required) throws IllegalArgumentException {
-
-        if (values == null || values.isEmpty()) {
-            if (required) {
-                throw new IllegalArgumentException(name + " cannot be empty or null");
-            }
-
-            return (this);
-        }
-
-        for (T value : values) {
-            if (value != null) {
-                this.param(name + "[]", value.toString());
-            }
-        }
-
-        return (this);
-    }
-
-    /**
-     * Fluent method for adding an array of hash type query and form parameters to a get() or post() call.
-     *
-     * @param name the name of the field/attribute to add
-     * @param variables a Map containing array of hashes
-     * @param required the field is required flag
-     * @return this GitLabAPiForm instance
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    public GitLabApiForm withParam(String name, Map<String, ?> variables, boolean required) throws IllegalArgumentException {
-
-        if (variables == null || variables.isEmpty()) {
-            if (required) {
-                throw new IllegalArgumentException(name + " cannot be empty or null");
-            }
-
-            return (this);
-        }
-
-        for (Entry<String, ?> variable : variables.entrySet()) {
-            Object value = variable.getValue();
-            if (value != null) {
-                this.param(name + "[][key]", variable.getKey());
-                this.param(name + "[][value]", value.toString());
-            }
-        }
-
-        return (this);
-    }
-
-    /**
-     * Fluent method for adding query and form parameters to a get() or post() call.
-     * If required is true and value is null, will throw an IllegalArgumentException.
-     *
-     * @param name the name of the field/attribute to add
-     * @param value the value of the field/attribute to add
-     * @param required the field is required flag
-     * @return this GitLabAPiForm instance
-     * @throws IllegalArgumentException if a required parameter is null or empty
-     */
-    public GitLabApiForm withParam(String name, Object value, boolean required) throws IllegalArgumentException {
-
-        if (value == null) {
-            if (required) {
-                throw new IllegalArgumentException(name + " cannot be empty or null");
-            }
-
-            return (this);
-        }
-
-        String stringValue = value.toString();
-        if (required && stringValue.trim().length() == 0) {
-            throw new IllegalArgumentException(name + " cannot be empty or null");
-        }
-
-        this.param(name.trim(), stringValue);
-        return (this);
-    }
-
-    /**
-     * Fluent method for adding a List&lt;Variable&gt; type query and form parameters to a get(), post(), or put() call.
-     *
-     * @param variables the List of Variable to add
-     * @return this GitLabAPiForm instance
-     */
-    public GitLabApiForm withParam(List<Variable> variables) {
-
-        if (variables == null || variables.isEmpty()) {
-            return (this);
-        }
-
-        variables.forEach(v -> {
-            String value = v.getValue();
-            if (value != null) {
-                this.param("variables[" + v.getKey() + "]", value);
-            }
+    variables.forEach(
+        v -> {
+          final String value = v.getValue();
+          if (value != null) {
+            this.param("variables[" + v.getKey() + "]", value);
+          }
         });
 
-        return (this);
-    }
+    return (this);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -5,13 +5,10 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AccessRequest;
@@ -30,1917 +27,2550 @@ import org.gitlab4j.api.utils.ISO8601;
 
 /**
  * This class implements the client side API for the GitLab groups calls.
+ *
  * @see <a href="https://docs.gitlab.com/ce/api/groups.html">Groups API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/members.html">Group and project members API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/access_requests.html">Group and project access requests API</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/members.html">Group and project members API at
+ *     GitLab</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/access_requests.html">Group and project access
+ *     requests API</a>
  * @see <a href="https://docs.gitlab.com/ce/api/group_badges.html">Group badges API</a>
- * @see <a href="https://docs.gitlab.com/ee/api/audit_events.html#retrieve-all-group-audit-events">Group audit events API</a>
+ * @see <a
+ *     href="https://docs.gitlab.com/ee/api/audit_events.html#retrieve-all-group-audit-events">Group
+ *     audit events API</a>
  */
 public class GroupApi extends AbstractApi {
 
-    public GroupApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
-
-    /**
-     * <p>Get a list of groups. (As user: my groups, as admin: all groups)</p>
-     *
-     * <strong>WARNING:</strong> Do not use this method to fetch groups from https://gitlab.com,
-     * gitlab.com has many 1,000's of public groups and it will a long time to fetch all of them.
-     * Instead use {@link #getGroups(int itemsPerPage)} which will return a Pager of Group instances.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @return the list of groups viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getGroups() throws GitLabApiException {
-
-        String url = this.gitLabApi.getGitLabServerUrl();
-        if (url.startsWith("https://gitlab.com")) {
-            GitLabApi.getLogger().warning("Fetching all groups from " + url +
-                    " may take many minutes to complete, use Pager<Group> getGroups(int) instead.");
-        }
-
-        return (getGroups(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of groups (As user: my groups, as admin: all groups) and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of Group instances per page
-     * @return the list of groups viewable by the authenticated userin the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getGroups(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups");
-        return (response.readEntity(new GenericType<List<Group>>() {}));
-    }
-
-    /**
-     * Get a Pager of groups. (As user: my groups, as admin: all groups)
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return the list of groups viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Group> getGroups(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Group>(this, Group.class, itemsPerPage, null, "groups"));
-    }
-
-    /**
-     * Get a Stream of groups. (As user: my groups, as admin: all groups)
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @return a Stream of groups viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Group> getGroupsStream() throws GitLabApiException {
-        return (getGroups(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get all groups that match your string in their name or path.
-     *
-     * @param search the group name or path search criteria
-     * @return a List containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getGroups(String search) throws GitLabApiException {
-        return (getGroups(search, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get all groups that match your string in their name or path.
-     *
-     * @param search the group name or path search criteria
-     * @param page the page to get
-     * @param perPage the number of Group instances per page
-     * @return a List containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getGroups(String search, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search).withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "groups");
-        return (response.readEntity(new GenericType<List<Group>>() {}));
-    }
-
-    /**
-     * Get all groups that match your string in their name or path.
-     *
-     * @param search the group name or path search criteria
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return a Pager containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Group> getGroups(String search, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search);
-        return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups"));
-    }
-
-    /**
-     * Get all groups that match your string in their name or path as a Stream.
-     *
-     * @param search the group name or path search criteria
-     * @return a Stream containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Group> getGroupsStream(String search) throws GitLabApiException {
-        return (getGroups(search, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of visible groups for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @param filter the GroupFilter to match against
-     * @return a List&lt;Group&gt; of the matching groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getGroups(GroupFilter filter) throws GitLabApiException {
-        return (getGroups(filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of visible groups for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @param filter the GroupFilter to match against
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return a Pager containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Group> getGroups(GroupFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups"));
-    }
-
-    /**
-     * Get a Stream of visible groups for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups</code></pre>
-     *
-     * @param filter the GroupFilter to match against
-     * @return a Stream&lt;Group&gt; of the matching groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Group> getGroupsStream(GroupFilter filter) throws GitLabApiException {
-        return (getGroups(filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @return a List&lt;Group&gt; containing the group's sub-groups
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public List<Group> getSubGroups(Object groupIdOrPath) throws GitLabApiException {
-        return (getSubGroups(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return a Pager containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public Pager<Group> getSubGroups(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Group>(this, Group.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "subgroups"));
-    }
-
-    /**
-     * Get a Stream of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @return a Stream&lt;Group&gt; containing the group's sub-groups
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public Stream<Group> getSubGroupsStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getSubGroups(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param skipGroups skip the group IDs passed
-     * @param allAvailable show all the groups you have access to (defaults to false for authenticated users)
-     * @param search return the list of authorized groups matching the search criteria
-     * @param orderBy order groups by NAME or PATH. Default is NAME
-     * @param sortOrder order groups in ASC or DESC order. Default is ASC
-     * @param statistics include group statistics (admins only)
-     * @param owned limit to groups owned by the current user
-     * @return a List&lt;Group&gt; of the matching subgroups
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public List<Group> getSubGroups(Object groupIdOrPath, List<Integer> skipGroups, Boolean allAvailable, String search,
-            GroupOrderBy orderBy, SortOrder sortOrder, Boolean statistics, Boolean owned) throws GitLabApiException {
-        return (getSubGroups(groupIdOrPath, skipGroups, allAvailable, search, orderBy, sortOrder, statistics, owned, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param skipGroups skip the group IDs passed
-     * @param allAvailable show all the groups you have access to (defaults to false for authenticated users)
-     * @param search return the list of authorized groups matching the search criteria
-     * @param orderBy order groups by NAME or PATH. Default is NAME
-     * @param sortOrder order groups in ASC or DESC order. Default is ASC
-     * @param statistics include group statistics (admins only)
-     * @param owned limit to groups owned by the current user
-     * @param page the page to get
-     * @param perPage the number of Group instances per page
-     * @return a List&lt;Group&gt; of the matching subgroups
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public List<Group> getSubGroups(Object groupIdOrPath, List<Integer> skipGroups, Boolean allAvailable, String search,
-            GroupOrderBy orderBy, SortOrder sortOrder, Boolean statistics, Boolean owned,  int page, int perPage)
-            throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("skip_groups", skipGroups)
-                .withParam("all_available", allAvailable)
-                .withParam("search", search)
-                .withParam("order_by", orderBy)
-                .withParam("sort_order", sortOrder)
-                .withParam("statistics", statistics)
-                .withParam("owned", owned)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "subgroups");
-        return (response.readEntity(new GenericType<List<Group>>() {}));
-    }
-
-    /**
-     * Get a Pager of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param skipGroups skip the group IDs passed
-     * @param allAvailable show all the groups you have access to (defaults to false for authenticated users)
-     * @param search return the list of authorized groups matching the search criteria
-     * @param orderBy order groups by NAME or PATH. Default is NAME
-     * @param sortOrder order groups in ASC or DESC order. Default is ASC
-     * @param statistics include group statistics (admins only)
-     * @param owned limit to groups owned by the current user
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return a Pager containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public Pager<Group> getSubGroups(Object groupIdOrPath, List<Integer> skipGroups, Boolean allAvailable, String search,
-            GroupOrderBy orderBy, SortOrder sortOrder, Boolean statistics, Boolean owned, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("skip_groups", skipGroups)
-                .withParam("all_available", allAvailable)
-                .withParam("search", search)
-                .withParam("order_by", orderBy)
-                .withParam("sort_order", sortOrder)
-                .withParam("statistics", statistics)
-                .withParam("owned", owned);
-        return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "subgroups"));
-    }
-
-    /**
-     * Get a Stream of visible direct subgroups in this group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param skipGroups skip the group IDs passed
-     * @param allAvailable show all the groups you have access to (defaults to false for authenticated users)
-     * @param search return the list of authorized groups matching the search criteria
-     * @param orderBy order groups by NAME or PATH. Default is NAME
-     * @param sortOrder order groups in ASC or DESC order. Default is ASC
-     * @param statistics include group statistics (admins only)
-     * @param owned limit to groups owned by the current user
-     * @return a Stream&lt;Group&gt; of the matching subgroups
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.3.0
-     */
-    public Stream<Group> getSubGroupsStream(Object groupIdOrPath, List<Integer> skipGroups, Boolean allAvailable, String search,
-            GroupOrderBy orderBy, SortOrder sortOrder, Boolean statistics, Boolean owned) throws GitLabApiException {
-        return (getSubGroups(groupIdOrPath, skipGroups, allAvailable, search, orderBy, sortOrder, statistics, owned, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of visible descendant groups of a given group for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param filter the GroupFilter to match against
-     * @return a List&lt;Group&gt; of the matching groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Group> getDescendantGroups(Object groupIdOrPath, GroupFilter filter) throws GitLabApiException {
-        return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of visible descendant groups of a given group for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param filter the GroupFilter to match against
-     * @param itemsPerPage the number of Group instances that will be fetched per page
-     * @return a Pager containing matching Group instances
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Group> getDescendantGroups(Object groupIdOrPath, GroupFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "descendant_groups"));
-    }
-
-    /**
-     * Get a Stream of visible descendant groups of a given group for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param filter the GroupFilter to match against
-     * @return a Stream&lt;Group&gt; of the matching groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Group> getDescendantGroupsStream(Object groupIdOrPath, GroupFilter filter) throws GitLabApiException {
-        return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of projects belonging to the specified group ID and filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param filter the GroupProjectsFilter instance holding the filter values for the query
-     * @return a List containing Project instances that belong to the group and match the provided filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(Object groupIdOrPath, GroupProjectsFilter filter) throws GitLabApiException {
-        return (getProjects(groupIdOrPath, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of projects belonging to the specified group ID and filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param filter the GroupProjectsFilter instance holding the filter values for the query
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager containing Project instances that belong to the group and match the provided filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(Object groupIdOrPath, GroupProjectsFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects belonging to the specified group ID and filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param filter the GroupProjectsFilter instance holding the filter values for the query
-     * @return a Stream containing Project instances that belong to the group and match the provided filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getProjectsStream(Object groupIdOrPath, GroupProjectsFilter filter) throws GitLabApiException {
-        return (getProjects(groupIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of projects belonging to the specified group ID.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a list of projects belonging to the specified group ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(Object groupIdOrPath) throws GitLabApiException {
-        return (getProjects(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of projects belonging to the specified group ID in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param page the page to get
-     * @param perPage the number of Project instances per page
-     * @return a list of projects belonging to the specified group ID in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups", getGroupIdOrPath(groupIdOrPath), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of projects belonging to the specified group ID.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of projects belonging to the specified group ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Project>(this, Project.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects belonging to the specified group ID.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of projects belonging to the specified group ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getProjectsStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getProjects(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get all details of a group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return the Group instance for the specified group path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group getGroup(Object groupIdOrPath) throws GitLabApiException {
-      Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath));
-      return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Get all details of a group as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return the Group for the specified group path as an Optional instance
-     */
-    public Optional<Group> getOptionalGroup(Object groupIdOrPath) {
-        try {
-            return (Optional.ofNullable(getGroup(groupIdOrPath)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups</code></pre>
-     *
-     * @param params a GroupParams instance holding the parameters for the group creation
-     * @return the created Group instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group createGroup(GroupParams params) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, params.getForm(true), "groups");
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Updates the project group. Only available to group owners and administrators.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param params the GroupParams instance holding the properties to update
-     * @return updated Group instance
-     * @throws GitLabApiException at any exception
-     */
-    public Group updateGroup(Object groupIdOrPath, GroupParams params) throws GitLabApiException {
-        Response response = putWithFormData(Response.Status.OK,
-                params.getForm(false), "groups",  getGroupIdOrPath(groupIdOrPath));
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Creates a new project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups</code></pre>
-     *
-     * @param name the name of the group to add
-     * @param path the path for the group
-     * @return the created Group instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group addGroup(String name, String path) throws GitLabApiException {
-
-        Form formData = new Form();
-        formData.param("name", name);
-        formData.param("path", path);
-        Response response = post(Response.Status.CREATED, formData, "groups");
-        return (response.readEntity(Group.class));
-    }
-
-    public Group addGroup(Group group) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("name", group.getName(), true)
-                .withParam("path", group.getPath(), true)
-                .withParam("description", group.getDescription())
-                .withParam("visibility", group.getVisibility())
-                .withParam("lfs_enabled", group.getLfsEnabled())
-                .withParam("request_access_enabled", group.getRequestAccessEnabled())
-                .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : group.getParentId());
-        Response response = post(Response.Status.CREATED, formData, "groups");
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Creates a new project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups</code></pre>
-     *
-     * @param name the name of the group to add
-     * @param path the path for the group
-     * @param description (optional) - The group's description
-     * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
-     * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this group
-     * @param requestAccessEnabled (optional) - Allow users to request member access
-     * @param parentId (optional) - The parent group id for creating nested group
-     * @return the created Group instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group addGroup(String name, String path, String description, Visibility visibility,
-            Boolean lfsEnabled, Boolean requestAccessEnabled, Long parentId) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("path", path, true)
-                .withParam("description", description)
-                .withParam("visibility", visibility)
-                .withParam("lfs_enabled", lfsEnabled)
-                .withParam("request_access_enabled", requestAccessEnabled)
-                .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : parentId);
-        Response response = post(Response.Status.CREATED, formData, "groups");
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Updates a project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
-     *
-     * @param group to update
-     * @return updated group instance
-     * @throws GitLabApiException at any exception
-     */
-    public Group updateGroup(Group group) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("name", group.getName())
-                .withParam("path", group.getPath())
-                .withParam("description", group.getDescription())
-                .withParam("visibility", group.getVisibility())
-                .withParam("lfs_enabled", group.getLfsEnabled())
-                .withParam("request_access_enabled", group.getRequestAccessEnabled())
-                .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : group.getParentId());
-        Response response = put(Response.Status.OK, formData.asMap(), "groups", group.getId());
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Updates a project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param name the name of the group to add
-     * @param path the path for the group
-     * @param description (optional) - The group's description
-     * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
-     * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this group
-     * @param requestAccessEnabled (optional) - Allow users to request member access
-     * @param parentId (optional) - The parent group id for creating nested group
-     * @return the updated Group instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group updateGroup(Object groupIdOrPath, String name, String path, String description, Visibility visibility,
-            Boolean lfsEnabled, Boolean requestAccessEnabled, Long parentId) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("name", name)
-                .withParam("path", path)
-                .withParam("description", description)
-                .withParam("visibility", visibility)
-                .withParam("lfs_enabled", lfsEnabled)
-                .withParam("request_access_enabled", requestAccessEnabled)
-                .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : parentId);
-        Response response = put(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath));
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Creates a new project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups</code></pre>
-     *
-     * @param name the name of the group to add
-     * @param path the path for the group
-     * @param description (optional) - The group's description
-     * @param membershipLock (optional, boolean) - Prevent adding new members to project membership within this group
-     * @param shareWithGroupLock (optional, boolean) - Prevent sharing a project with another group within this group
-     * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
-     * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this group
-     * @param requestAccessEnabled (optional) - Allow users to request member access.
-     * @param parentId (optional) - The parent group id for creating nested group.
-     * @param sharedRunnersMinutesLimit (optional) - (admin-only) Pipeline minutes quota for this group
-     * @return the created Group instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #addGroup(String, String, String, Visibility,
-     *      Boolean, Boolean, Long)}
-     */
-    @Deprecated
-	public Group addGroup(String name, String path, String description, Boolean membershipLock,
-            Boolean shareWithGroupLock, Visibility visibility, Boolean lfsEnabled, Boolean requestAccessEnabled,
-            Long parentId, Integer sharedRunnersMinutesLimit) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("name", name)
-                .withParam("path", path)
-                .withParam("description", description)
-                .withParam("membership_lock", membershipLock)
-                .withParam("share_with_group_lock", shareWithGroupLock)
-                .withParam("visibility", visibility)
-                .withParam("lfs_enabled", lfsEnabled)
-                .withParam("request_access_enabled", requestAccessEnabled)
-                .withParam("parent_id", parentId)
-                .withParam("shared_runners_minutes_limit", sharedRunnersMinutesLimit);
-        Response response = post(Response.Status.CREATED, formData, "groups");
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Updates a project group. Available only for users who can create groups.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param name the name of the group to add
-     * @param path the path for the group
-     * @param description (optional) - The group's description
-     * @param membershipLock (optional, boolean) - Prevent adding new members to project membership within this group
-     * @param shareWithGroupLock (optional, boolean) - Prevent sharing a project with another group within this group
-     * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
-     * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this group
-     * @param requestAccessEnabled (optional) - Allow users to request member access
-     * @param parentId (optional) - The parent group id for creating nested group
-     * @param sharedRunnersMinutesLimit (optional) - (admin-only) Pipeline minutes quota for this group
-     * @return the updated Group instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #updateGroup(Object, String, String, String,
-     *      Visibility, Boolean, Boolean, Long)}
-     */
-    @Deprecated
-	public Group updateGroup(Object groupIdOrPath, String name, String path, String description, Boolean membershipLock,
-            Boolean shareWithGroupLock, Visibility visibility, Boolean lfsEnabled, Boolean requestAccessEnabled,
-            Long parentId, Integer sharedRunnersMinutesLimit) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("name", name)
-                .withParam("path", path)
-                .withParam("description", description)
-                .withParam("membership_lock", membershipLock)
-                .withParam("share_with_group_lock", shareWithGroupLock)
-                .withParam("visibility", visibility)
-                .withParam("lfs_enabled", lfsEnabled)
-                .withParam("request_access_enabled", requestAccessEnabled)
-                .withParam("parent_id", parentId)
-                .withParam("shared_runners_minutes_limit", sharedRunnersMinutesLimit);
-        Response response = put(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath));
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Removes group with all projects inside.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteGroup(Object groupIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "groups", getGroupIdOrPath(groupIdOrPath));
-    }
-
-    /**
-     * Get a list of group members viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a list of group members viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getMembers(Object groupIdOrPath) throws GitLabApiException {
-        return (getMembers(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of group members viewable by the authenticated user in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
-     *
-     *@param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param page the page to get
-     * @param perPage the number of Member instances per page
-     * @return a list of group members viewable by the authenticated user in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getMembers(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups", getGroupIdOrPath(groupIdOrPath), "members");
-        return (response.readEntity(new GenericType<List<Member>>() {}));
-    }
-
-    /**
-     * Get a Pager of group members viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of Member instances that will be fetched per page
-     * @return a list of group members viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getMembers(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Member>(this, Member.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "members"));
-    }
-
-    /**
-     * Get a Stream of group members viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of group members viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getMembersStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getMembers(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a group member viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the member ID of the member to get
-     * @return a member viewable by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member getMember(Object groupIdOrPath, long userId) throws GitLabApiException {
-	    return (getMember(groupIdOrPath, userId, false));
-    }
-
-    /**
-     * Get a group member viewable by the authenticated user as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the member ID of the member to get
-     * @return a member viewable by the authenticated user as an Optional instance
-     */
-    public Optional<Member> getOptionalMember(Object groupIdOrPath, long userId) {
-        try {
-            return (Optional.ofNullable(getMember(groupIdOrPath, userId, false)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Gets a group team member, optionally including inherited member.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all/:user_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID of the member
-     * @param includeInherited if true will the member even if inherited thru an ancestor group
-     * @return the member specified by the project ID/user ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member getMember(Object groupIdOrPath, Long userId, Boolean includeInherited) throws GitLabApiException {
-        Response response;
-        if (includeInherited) {
-            response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "members", "all", userId);
-        } else {
-            response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "members", userId);
-        }
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Gets a group team member, optionally including inherited member.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all/:user_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID of the member
-     * @param includeInherited if true will the member even if inherited thru an ancestor group
-     * @return the member specified by the group ID/user ID pair as the value of an Optional
-     */
-    public Optional<Member> getOptionalMember(Object groupIdOrPath, Long userId, Boolean includeInherited)  {
-        try {
-            return (Optional.ofNullable(getMember(groupIdOrPath, userId, includeInherited)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Gets a list of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a list of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getAllMembers(Object groupIdOrPath) throws GitLabApiException {
-        return (getAllMembers(groupIdOrPath, null, null));
-    }
-
-    /**
-     * Gets a list of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param page the page to get
-     * @param perPage the number of Member instances per page
-     * @return a list of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0
-     */
-    @Deprecated
-    public List<Member> getAllMembers(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "groups", getGroupIdOrPath(groupIdOrPath), "members", "all");
-        return (response.readEntity(new GenericType<List<Member>>() {}));
-    }
-
-    /**
-     * Gets a Pager of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of Member instances that will be fetched per page
-     * @return a Pager of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getAllMembers(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getAllMembers(groupIdOrPath, null, null, itemsPerPage));
-    }
-
-    /**
-     * Gets a Stream of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getAllMembersStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getAllMembersStream(groupIdOrPath, null, null));
-    }
-
-
-    /**
-     * Gets a list of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @return the group members viewable by the authenticated user, including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getAllMembers(Object groupIdOrPath, String query, List<Long> userIds) throws GitLabApiException {
-        return (getAllMembers(groupIdOrPath, query, userIds, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a Pager of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the group members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getAllMembers(Object groupIdOrPath, String query, List<Long> userIds, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("query", query).withParam("user_ids", userIds);
-        return (new Pager<Member>(this, Member.class, itemsPerPage, form.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "members", "all"));
-    }
-
-    /**
-     * Gets a Stream of group members viewable by the authenticated user, including inherited members
-     * through ancestor groups. Returns multiple times the same user (with different member attributes)
-     * when the user is a member of the group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @return a Stream of the group members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getAllMembersStream(Object groupIdOrPath, String query, List<Long> userIds) throws GitLabApiException {
-        return (getAllMembers(groupIdOrPath, query, userIds, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Adds a user to the list of group members.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @return a Member instance for the added user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object groupIdOrPath, Long userId, Integer accessLevel) throws GitLabApiException {
-        return (addMember(groupIdOrPath, userId, accessLevel, null));
-    }
-
-    /**
-     * Adds a user to the list of group members.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @return a Member instance for the added user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object groupIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        return (addMember(groupIdOrPath, userId, accessLevel.toValue(), null));
-    }
-
-    /**
-     * Adds a user to the list of group members.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return a Member instance for the added user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object groupIdOrPath, Long userId, AccessLevel accessLevel, Date expiresAt) throws GitLabApiException {
-        return (addMember(groupIdOrPath, userId, accessLevel.toValue(), expiresAt));
-    }
-
-    /**
-     * Adds a user to the list of group members.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return a Member instance for the added user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object groupIdOrPath, Long userId, Integer accessLevel, Date expiresAt) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("user_id", userId, true)
-                .withParam("access_level", accessLevel, true)
-                .withParam("expires_at",  expiresAt, false);
-        Response response = post(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "members");
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Updates a member of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object groupIdOrPath, Long userId, Integer accessLevel) throws GitLabApiException {
-        return (updateMember(groupIdOrPath, userId, accessLevel, null));
-    }
-
-    /**
-     * Updates a member of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object groupIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        return (updateMember(groupIdOrPath, userId, accessLevel.toValue(), null));
-    }
-
-    /**
-     * Updates a member of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object groupIdOrPath, Long userId, AccessLevel accessLevel, Date expiresAt) throws GitLabApiException {
-        return (updateMember(groupIdOrPath, userId, accessLevel.toValue(), expiresAt));
-    }
-
-    /**
-     * Updates a member of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object groupIdOrPath, Long userId, Integer accessLevel, Date expiresAt) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("access_level", accessLevel, true)
-                .withParam("expires_at",  expiresAt, false);
-        Response response = put(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "members", userId);
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Removes member from the group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/members/:user_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param userId the user ID of the member to remove
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void removeMember(Object groupIdOrPath, Long userId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "groups", getGroupIdOrPath(groupIdOrPath), "members", userId);
-    }
-
-    /**
-     * Syncs the group with its linked LDAP group. Only available to group owners and administrators.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_sync</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void ldapSync(Object groupIdOrPath) throws GitLabApiException {
-        post(Response.Status.NO_CONTENT, (Form)null, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_sync");
-    }
-
-    /**
-     * Adds an LDAP group link.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_group_links</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param cn the CN of a LDAP group
-     * @param groupAccess the minimum access level for members of the LDAP group
-     * @param provider the LDAP provider for the LDAP group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void addLdapGroupLink(Object groupIdOrPath, String cn, AccessLevel groupAccess, String provider) throws GitLabApiException {
-
-        if (groupAccess == null) {
-            throw new RuntimeException("groupAccess cannot be null or empty");
-        }
-
-        addLdapGroupLink(groupIdOrPath, cn, groupAccess.toValue(), provider);
-    }
-
-    /**
-     * Adds an LDAP group link.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_group_links</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param cn the CN of a LDAP group
-     * @param groupAccess the minimum access level for members of the LDAP group
-     * @param provider the LDAP provider for the LDAP group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void addLdapGroupLink(Object groupIdOrPath, String cn, Integer groupAccess, String provider) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("cn",  cn, true)
-                .withParam("group_access", groupAccess, true)
-                .withParam("provider",  provider, true);
-        post(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_group_links");
-    }
-
-    /**
-     * Deletes an LDAP group link.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/ldap_group_links/:cn</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param cn the CN of the LDAP group link to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteLdapGroupLink(Object groupIdOrPath, String cn) throws GitLabApiException {
-
-        if (cn == null || cn.trim().isEmpty()) {
-            throw new RuntimeException("cn cannot be null or empty");
-        }
-
-        delete(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_group_links", cn);
-    }
-
-    /**
-     * Deletes an LDAP group link for a specific LDAP provider.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/ldap_group_links/:provider/:cn</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param cn the CN of the LDAP group link to delete
-     * @param provider the name of the LDAP provider
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteLdapGroupLink(Object groupIdOrPath, String cn, String provider) throws GitLabApiException {
-
-        if (cn == null || cn.trim().isEmpty()) {
-            throw new RuntimeException("cn cannot be null or empty");
-        }
-
-        if (provider == null || provider.trim().isEmpty()) {
-            throw new RuntimeException("LDAP provider cannot be null or empty");
-        }
-
-        delete(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_group_links", provider, cn);
-    }
-
-    /**
-     * Get list of a group’s variables.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a list of variables belonging to the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Variable> getVariables(Object groupIdOrPath) throws GitLabApiException {
-        return (getVariables(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of variables for the specified group in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param page the page to get
-     * @param perPage the number of Variable instances per page
-     * @return a list of variables belonging to the specified group in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Variable> getVariables(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups", getGroupIdOrPath(groupIdOrPath), "variables");
-        return (response.readEntity(new GenericType<List<Variable>>() {}));
-    }
-
-    /**
-     * Get a Pager of variables belonging to the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of Variable instances that will be fetched per page
-     * @return a Pager of variables belonging to the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Variable> getVariables(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Variable>(this, Variable.class, itemsPerPage, null, "groups", getGroupIdOrPath(groupIdOrPath), "variables"));
-    }
-
-    /**
-     * Get a Stream of variables belonging to the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of variables belonging to the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Variable> getVariablesStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getVariables(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the details of a group variable.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables/:key</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param key the key of an existing variable, required
-     * @return the Variable instance for the specified group variable
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Variable getVariable(Object groupIdOrPath, String key) throws GitLabApiException {
-      Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "variables", key);
-      return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Get the details of a group variable as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/variables/:key</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param key the key of an existing variable, required
-     * @return the Variable for the specified group variable as an Optional instance
-     */
-    public Optional<Variable> getOptionalVariable(Object groupIdOrPath, String key) {
-        try {
-            return (Optional.ofNullable(getVariable(groupIdOrPath, key)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create a new group variable.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object groupIdOrPath, String key, String value, Boolean isProtected) throws GitLabApiException {
-
-        return createVariable(groupIdOrPath, key, value, isProtected, false);
-    }
-
-    /**
-     * Create a new group variable.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/variables</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @param masked whether the variable is masked, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object groupIdOrPath, String key, String value, Boolean isProtected, Boolean masked) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("key", key, true)
-                .withParam("value", value, true)
-                .withParam("masked", masked)
-                .withParam("protected", isProtected);
-        Response response = post(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "variables");
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Update a group variable.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/variables/:key</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object groupIdOrPath, String key, String value, Boolean isProtected) throws GitLabApiException {
-
-        return updateVariable(groupIdOrPath, key, value, isProtected, false);
-    }
-
-    /**
-     * Update a group variable.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/variables/:key</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @param masked whether the variable is masked, optional
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object groupIdOrPath, String key, String value, Boolean isProtected, Boolean masked) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("value", value, true)
-                .withParam("masked", masked)
-                .withParam("protected", isProtected);
-        Response response = putWithFormData(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "variables", key);
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Deletes a group variable.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/variables/:key</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param key the key of an existing variable, required
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteVariable(Object groupIdOrPath, String key) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "groups", getGroupIdOrPath(groupIdOrPath), "variables", key);
-    }
-
-    /**
-     * Transfer a project to the Group namespace. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/projects/:project_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the transferred Project instance
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Project transferProject(Object groupIdOrPath, Object projectIdOrPath) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (Form)null, "groups",  getGroupIdOrPath(groupIdOrPath),
-                "projects", getProjectIdOrPath(projectIdOrPath));
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Get a List of the group audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /groups/:id/audit_events</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
-     * @return a List of group Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AuditEvent> getAuditEvents(Object groupIdOrPath, Date created_after, Date created_before) throws GitLabApiException {
-        return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the group audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /groups/:id/audit_events</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
-     * @param itemsPerPage the number of Audit Event instances that will be fetched per page
-     * @return a Pager of group Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<AuditEvent> getAuditEvents(Object groupIdOrPath, Date created_after, Date created_before, int itemsPerPage) throws GitLabApiException {
-        Form form = new GitLabApiForm()
-                .withParam("created_before", ISO8601.toString(created_after, false))
-                .withParam("created_after", ISO8601.toString(created_before, false));
-        return (new Pager<AuditEvent>(this, AuditEvent.class, itemsPerPage, form.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "audit_events"));
-    }
-
-    /**
-     * Get a Stream of the group audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /groups/:id/audit_events</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
-     * @return a Stream of group Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<AuditEvent> getAuditEventsStream(Object groupIdOrPath, Date created_after, Date created_before) throws GitLabApiException {
-        return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific audit event of a group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/audit_events/:id_audit_event</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param auditEventId the auditEventId, required
-     * @return the group Audit event
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AuditEvent getAuditEvent(Object groupIdOrPath, Long auditEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "audit_events", auditEventId);
-        return (response.readEntity(AuditEvent.class));
-    }
-
-    /**
-     * Get a List of the group access requests viewable by the authenticated user.
-     *
-     * <pre><code>GET /group/:id/access_requests</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a List of project AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AccessRequest> getAccessRequests(Object groupIdOrPath) throws GitLabApiException {
-        return (getAccessRequests(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the group access requests viewable by the authenticated user.
-     *
-     * <pre><code>GET /groups/:id/access_requests</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param itemsPerPage the number of AccessRequest instances that will be fetched per page
-     * @return a Pager of group AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<AccessRequest> getAccessRequests(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<AccessRequest>(this, AccessRequest.class, itemsPerPage, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "access_requests"));
-    }
-
-    /**
-     * Get a Stream of the group access requests viewable by the authenticated user.
-     *
-     * <pre><code>GET /groups/:id/access_requests</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a Stream of group AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<AccessRequest> getAccessRequestsStream(Object groupIdOrPath) throws GitLabApiException {
-       return (getAccessRequests(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Requests access for the authenticated user to the specified group.
-     *
-     * <pre><code>POST /groups/:id/access_requests</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return the created AccessRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AccessRequest requestAccess(Object groupIdOrPath) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (Form)null, "groups", getGroupIdOrPath(groupIdOrPath), "access_requests");
-        return (response.readEntity(AccessRequest.class));
-    }
-
-    /**
-     * Approve access for the specified user to the specified group.
-     *
-     * <pre><code>PUT /groups/:id/access_requests/:user_id/approve</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID to approve access for
-     * @param accessLevel the access level the user is approved for, if null will be developer (30)
-     * @return the approved AccessRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AccessRequest approveAccessRequest(Object groupIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("access_level", accessLevel);
-        Response response = this.putWithFormData(Response.Status.CREATED, formData,
-                "groups", getGroupIdOrPath(groupIdOrPath), "access_requests", userId, "approve");
-        return (response.readEntity(AccessRequest.class));
-    }
-
-    /**
-     * Deny access for the specified user to the specified group.
-     *
-     * <pre><code>DELETE /groups/:id/access_requests/:user_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param userId the user ID to deny access for
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void denyAccessRequest(Object groupIdOrPath, Long userId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "access_requests", userId);
-    }
-
-    /**
-     * Gets a list of a group’s badges and its group badges.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @return a List of Badge instances for the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Badge> getBadges(Object groupIdOrPath) throws GitLabApiException {
+  public GroupApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of groups. (As user: my groups, as admin: all groups) <strong>WARNING:</strong> Do
+   * not use this method to fetch groups from https://gitlab.com, gitlab.com has many 1,000's of
+   * public groups and it will a long time to fetch all of them. Instead use {@link #getGroups(int
+   * itemsPerPage)} which will return a Pager of Group instances.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @return the list of groups viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getGroups() throws GitLabApiException {
+
+    final String url = this.gitLabApi.getGitLabServerUrl();
+    if (url.startsWith("https://gitlab.com")) {
+      GitLabApi.getLogger()
+          .warning(
+              "Fetching all groups from "
+                  + url
+                  + " may take many minutes to complete, use Pager<Group> getGroups(int) instead.");
+    }
+
+    return (getGroups(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of groups (As user: my groups, as admin: all groups) and in the specified page
+   * range.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of Group instances per page
+   * @return the list of groups viewable by the authenticated userin the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getGroups(final int page, final int perPage) throws GitLabApiException {
+    final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "groups");
+    return (response.readEntity(new GenericType<List<Group>>() {}));
+  }
+
+  /**
+   * Get a Pager of groups. (As user: my groups, as admin: all groups)
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return the list of groups viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Group> getGroups(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<Group>(this, Group.class, itemsPerPage, null, "groups"));
+  }
+
+  /**
+   * Get a Stream of groups. (As user: my groups, as admin: all groups)
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @return a Stream of groups viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Group> getGroupsStream() throws GitLabApiException {
+    return (getGroups(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get all groups that match your string in their name or path.
+   *
+   * @param search the group name or path search criteria
+   * @return a List containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getGroups(final String search) throws GitLabApiException {
+    return (getGroups(search, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all groups that match your string in their name or path.
+   *
+   * @param search the group name or path search criteria
+   * @param page the page to get
+   * @param perPage the number of Group instances per page
+   * @return a List containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getGroups(final String search, final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("search", search)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "groups");
+    return (response.readEntity(new GenericType<List<Group>>() {}));
+  }
+
+  /**
+   * Get all groups that match your string in their name or path.
+   *
+   * @param search the group name or path search criteria
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return a Pager containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Group> getGroups(final String search, final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("search", search);
+    return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups"));
+  }
+
+  /**
+   * Get all groups that match your string in their name or path as a Stream.
+   *
+   * @param search the group name or path search criteria
+   * @return a Stream containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Group> getGroupsStream(final String search) throws GitLabApiException {
+    return (getGroups(search, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of visible groups for the authenticated user using the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @param filter the GroupFilter to match against
+   * @return a List&lt;Group&gt; of the matching groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getGroups(final GroupFilter filter) throws GitLabApiException {
+    return (getGroups(filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of visible groups for the authenticated user using the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @param filter the GroupFilter to match against
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return a Pager containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Group> getGroups(final GroupFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Group>(this, Group.class, itemsPerPage, formData.asMap(), "groups"));
+  }
+
+  /**
+   * Get a Stream of visible groups for the authenticated user using the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups</code></pre>
+   *
+   * @param filter the GroupFilter to match against
+   * @return a Stream&lt;Group&gt; of the matching groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Group> getGroupsStream(final GroupFilter filter) throws GitLabApiException {
+    return (getGroups(filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @return a List&lt;Group&gt; containing the group's sub-groups
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public List<Group> getSubGroups(final Object groupIdOrPath) throws GitLabApiException {
+    return (getSubGroups(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return a Pager containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public Pager<Group> getSubGroups(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Group>(
+        this,
+        Group.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "subgroups"));
+  }
+
+  /**
+   * Get a Stream of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @return a Stream&lt;Group&gt; containing the group's sub-groups
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public Stream<Group> getSubGroupsStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getSubGroups(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param skipGroups skip the group IDs passed
+   * @param allAvailable show all the groups you have access to (defaults to false for authenticated
+   *     users)
+   * @param search return the list of authorized groups matching the search criteria
+   * @param orderBy order groups by NAME or PATH. Default is NAME
+   * @param sortOrder order groups in ASC or DESC order. Default is ASC
+   * @param statistics include group statistics (admins only)
+   * @param owned limit to groups owned by the current user
+   * @return a List&lt;Group&gt; of the matching subgroups
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public List<Group> getSubGroups(
+      final Object groupIdOrPath,
+      final List<Integer> skipGroups,
+      final Boolean allAvailable,
+      final String search,
+      final GroupOrderBy orderBy,
+      final SortOrder sortOrder,
+      final Boolean statistics,
+      final Boolean owned)
+      throws GitLabApiException {
+    return (getSubGroups(
+            groupIdOrPath,
+            skipGroups,
+            allAvailable,
+            search,
+            orderBy,
+            sortOrder,
+            statistics,
+            owned,
+            getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param skipGroups skip the group IDs passed
+   * @param allAvailable show all the groups you have access to (defaults to false for authenticated
+   *     users)
+   * @param search return the list of authorized groups matching the search criteria
+   * @param orderBy order groups by NAME or PATH. Default is NAME
+   * @param sortOrder order groups in ASC or DESC order. Default is ASC
+   * @param statistics include group statistics (admins only)
+   * @param owned limit to groups owned by the current user
+   * @param page the page to get
+   * @param perPage the number of Group instances per page
+   * @return a List&lt;Group&gt; of the matching subgroups
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public List<Group> getSubGroups(
+      final Object groupIdOrPath,
+      final List<Integer> skipGroups,
+      final Boolean allAvailable,
+      final String search,
+      final GroupOrderBy orderBy,
+      final SortOrder sortOrder,
+      final Boolean statistics,
+      final Boolean owned,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("skip_groups", skipGroups)
+            .withParam("all_available", allAvailable)
+            .withParam("search", search)
+            .withParam("order_by", orderBy)
+            .withParam("sort_order", sortOrder)
+            .withParam("statistics", statistics)
+            .withParam("owned", owned)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "subgroups");
+    return (response.readEntity(new GenericType<List<Group>>() {}));
+  }
+
+  /**
+   * Get a Pager of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param skipGroups skip the group IDs passed
+   * @param allAvailable show all the groups you have access to (defaults to false for authenticated
+   *     users)
+   * @param search return the list of authorized groups matching the search criteria
+   * @param orderBy order groups by NAME or PATH. Default is NAME
+   * @param sortOrder order groups in ASC or DESC order. Default is ASC
+   * @param statistics include group statistics (admins only)
+   * @param owned limit to groups owned by the current user
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return a Pager containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public Pager<Group> getSubGroups(
+      final Object groupIdOrPath,
+      final List<Integer> skipGroups,
+      final Boolean allAvailable,
+      final String search,
+      final GroupOrderBy orderBy,
+      final SortOrder sortOrder,
+      final Boolean statistics,
+      final Boolean owned,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("skip_groups", skipGroups)
+            .withParam("all_available", allAvailable)
+            .withParam("search", search)
+            .withParam("order_by", orderBy)
+            .withParam("sort_order", sortOrder)
+            .withParam("statistics", statistics)
+            .withParam("owned", owned);
+    return (new Pager<Group>(
+        this,
+        Group.class,
+        itemsPerPage,
+        formData.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "subgroups"));
+  }
+
+  /**
+   * Get a Stream of visible direct subgroups in this group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/subgroups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param skipGroups skip the group IDs passed
+   * @param allAvailable show all the groups you have access to (defaults to false for authenticated
+   *     users)
+   * @param search return the list of authorized groups matching the search criteria
+   * @param orderBy order groups by NAME or PATH. Default is NAME
+   * @param sortOrder order groups in ASC or DESC order. Default is ASC
+   * @param statistics include group statistics (admins only)
+   * @param owned limit to groups owned by the current user
+   * @return a Stream&lt;Group&gt; of the matching subgroups
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.3.0
+   */
+  public Stream<Group> getSubGroupsStream(
+      final Object groupIdOrPath,
+      final List<Integer> skipGroups,
+      final Boolean allAvailable,
+      final String search,
+      final GroupOrderBy orderBy,
+      final SortOrder sortOrder,
+      final Boolean statistics,
+      final Boolean owned)
+      throws GitLabApiException {
+    return (getSubGroups(
+        groupIdOrPath,
+        skipGroups,
+        allAvailable,
+        search,
+        orderBy,
+        sortOrder,
+        statistics,
+        owned,
+        getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a list of visible descendant groups of a given group for the authenticated user using the
+   * provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param filter the GroupFilter to match against
+   * @return a List&lt;Group&gt; of the matching groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Group> getDescendantGroups(final Object groupIdOrPath, final GroupFilter filter)
+      throws GitLabApiException {
+    return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of visible descendant groups of a given group for the authenticated user using the
+   * provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param filter the GroupFilter to match against
+   * @param itemsPerPage the number of Group instances that will be fetched per page
+   * @return a Pager containing matching Group instances
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Group> getDescendantGroups(
+      final Object groupIdOrPath, final GroupFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Group>(
+        this,
+        Group.class,
+        itemsPerPage,
+        formData.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "descendant_groups"));
+  }
+
+  /**
+   * Get a Stream of visible descendant groups of a given group for the authenticated user using the
+   * provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/descendant_groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param filter the GroupFilter to match against
+   * @return a Stream&lt;Group&gt; of the matching groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Group> getDescendantGroupsStream(
+      final Object groupIdOrPath, final GroupFilter filter) throws GitLabApiException {
+    return (getDescendantGroups(groupIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects belonging to the specified group ID and filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param filter the GroupProjectsFilter instance holding the filter values for the query
+   * @return a List containing Project instances that belong to the group and match the provided
+   *     filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final Object groupIdOrPath, final GroupProjectsFilter filter)
+      throws GitLabApiException {
+    return (getProjects(groupIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of projects belonging to the specified group ID and filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param filter the GroupProjectsFilter instance holding the filter values for the query
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager containing Project instances that belong to the group and match the provided
+   *     filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(
+      final Object groupIdOrPath, final GroupProjectsFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Project>(
+        this,
+        Project.class,
+        itemsPerPage,
+        formData.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "projects"));
+  }
+
+  /**
+   * Get a Stream of projects belonging to the specified group ID and filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param filter the GroupProjectsFilter instance holding the filter values for the query
+   * @return a Stream containing Project instances that belong to the group and match the provided
+   *     filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getProjectsStream(
+      final Object groupIdOrPath, final GroupProjectsFilter filter) throws GitLabApiException {
+    return (getProjects(groupIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects belonging to the specified group ID.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a list of projects belonging to the specified group ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final Object groupIdOrPath) throws GitLabApiException {
+    return (getProjects(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects belonging to the specified group ID in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param page the page to get
+   * @param perPage the number of Project instances per page
+   * @return a list of projects belonging to the specified group ID in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final Object groupIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects belonging to the specified group ID.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of projects belonging to the specified group ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Project>(
+        this,
+        Project.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "projects"));
+  }
+
+  /**
+   * Get a Stream of projects belonging to the specified group ID.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/projects</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of projects belonging to the specified group ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getProjectsStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getProjects(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get all details of a group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return the Group instance for the specified group path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group getGroup(final Object groupIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath));
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Get all details of a group as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return the Group for the specified group path as an Optional instance
+   */
+  public Optional<Group> getOptionalGroup(final Object groupIdOrPath) {
+    try {
+      return (Optional.ofNullable(getGroup(groupIdOrPath)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a new project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups</code></pre>
+   *
+   * @param params a GroupParams instance holding the parameters for the group creation
+   * @return the created Group instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group createGroup(final GroupParams params) throws GitLabApiException {
+    final Response response = post(Response.Status.CREATED, params.getForm(true), "groups");
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Updates the project group. Only available to group owners and administrators.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param params the GroupParams instance holding the properties to update
+   * @return updated Group instance
+   * @throws GitLabApiException at any exception
+   */
+  public Group updateGroup(final Object groupIdOrPath, final GroupParams params)
+      throws GitLabApiException {
+    final Response response =
+        putWithFormData(
+            Response.Status.OK, params.getForm(false), "groups", getGroupIdOrPath(groupIdOrPath));
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Creates a new project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups</code></pre>
+   *
+   * @param name the name of the group to add
+   * @param path the path for the group
+   * @return the created Group instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group addGroup(final String name, final String path) throws GitLabApiException {
+
+    final Form formData = new Form();
+    formData.param("name", name);
+    formData.param("path", path);
+    final Response response = post(Response.Status.CREATED, formData, "groups");
+    return (response.readEntity(Group.class));
+  }
+
+  public Group addGroup(final Group group) throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", group.getName(), true)
+            .withParam("path", group.getPath(), true)
+            .withParam("description", group.getDescription())
+            .withParam("visibility", group.getVisibility())
+            .withParam("lfs_enabled", group.getLfsEnabled())
+            .withParam("request_access_enabled", group.getRequestAccessEnabled())
+            .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : group.getParentId());
+    final Response response = post(Response.Status.CREATED, formData, "groups");
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Creates a new project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups</code></pre>
+   *
+   * @param name the name of the group to add
+   * @param path the path for the group
+   * @param description (optional) - The group's description
+   * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
+   * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this
+   *     group
+   * @param requestAccessEnabled (optional) - Allow users to request member access
+   * @param parentId (optional) - The parent group id for creating nested group
+   * @return the created Group instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group addGroup(
+      final String name,
+      final String path,
+      final String description,
+      final Visibility visibility,
+      final Boolean lfsEnabled,
+      final Boolean requestAccessEnabled,
+      final Long parentId)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("path", path, true)
+            .withParam("description", description)
+            .withParam("visibility", visibility)
+            .withParam("lfs_enabled", lfsEnabled)
+            .withParam("request_access_enabled", requestAccessEnabled)
+            .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : parentId);
+    final Response response = post(Response.Status.CREATED, formData, "groups");
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Updates a project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
+   *
+   * @param group to update
+   * @return updated group instance
+   * @throws GitLabApiException at any exception
+   */
+  public Group updateGroup(final Group group) throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", group.getName())
+            .withParam("path", group.getPath())
+            .withParam("description", group.getDescription())
+            .withParam("visibility", group.getVisibility())
+            .withParam("lfs_enabled", group.getLfsEnabled())
+            .withParam("request_access_enabled", group.getRequestAccessEnabled())
+            .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : group.getParentId());
+    final Response response = put(Response.Status.OK, formData.asMap(), "groups", group.getId());
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Updates a project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param name the name of the group to add
+   * @param path the path for the group
+   * @param description (optional) - The group's description
+   * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
+   * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this
+   *     group
+   * @param requestAccessEnabled (optional) - Allow users to request member access
+   * @param parentId (optional) - The parent group id for creating nested group
+   * @return the updated Group instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group updateGroup(
+      final Object groupIdOrPath,
+      final String name,
+      final String path,
+      final String description,
+      final Visibility visibility,
+      final Boolean lfsEnabled,
+      final Boolean requestAccessEnabled,
+      final Long parentId)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name)
+            .withParam("path", path)
+            .withParam("description", description)
+            .withParam("visibility", visibility)
+            .withParam("lfs_enabled", lfsEnabled)
+            .withParam("request_access_enabled", requestAccessEnabled)
+            .withParam("parent_id", isApiVersion(ApiVersion.V3) ? null : parentId);
+    final Response response =
+        put(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath));
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Creates a new project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups</code></pre>
+   *
+   * @param name the name of the group to add
+   * @param path the path for the group
+   * @param description (optional) - The group's description
+   * @param membershipLock (optional, boolean) - Prevent adding new members to project membership
+   *     within this group
+   * @param shareWithGroupLock (optional, boolean) - Prevent sharing a project with another group
+   *     within this group
+   * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
+   * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this
+   *     group
+   * @param requestAccessEnabled (optional) - Allow users to request member access.
+   * @param parentId (optional) - The parent group id for creating nested group.
+   * @param sharedRunnersMinutesLimit (optional) - (admin-only) Pipeline minutes quota for this
+   *     group
+   * @return the created Group instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #addGroup(String, String,
+   *     String, Visibility, Boolean, Boolean, Long)}
+   */
+  @Deprecated
+  public Group addGroup(
+      final String name,
+      final String path,
+      final String description,
+      final Boolean membershipLock,
+      final Boolean shareWithGroupLock,
+      final Visibility visibility,
+      final Boolean lfsEnabled,
+      final Boolean requestAccessEnabled,
+      final Long parentId,
+      final Integer sharedRunnersMinutesLimit)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name)
+            .withParam("path", path)
+            .withParam("description", description)
+            .withParam("membership_lock", membershipLock)
+            .withParam("share_with_group_lock", shareWithGroupLock)
+            .withParam("visibility", visibility)
+            .withParam("lfs_enabled", lfsEnabled)
+            .withParam("request_access_enabled", requestAccessEnabled)
+            .withParam("parent_id", parentId)
+            .withParam("shared_runners_minutes_limit", sharedRunnersMinutesLimit);
+    final Response response = post(Response.Status.CREATED, formData, "groups");
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Updates a project group. Available only for users who can create groups.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param name the name of the group to add
+   * @param path the path for the group
+   * @param description (optional) - The group's description
+   * @param membershipLock (optional, boolean) - Prevent adding new members to project membership
+   *     within this group
+   * @param shareWithGroupLock (optional, boolean) - Prevent sharing a project with another group
+   *     within this group
+   * @param visibility (optional) - The group's visibility. Can be private, internal, or public.
+   * @param lfsEnabled (optional) - Enable/disable Large File Storage (LFS) for the projects in this
+   *     group
+   * @param requestAccessEnabled (optional) - Allow users to request member access
+   * @param parentId (optional) - The parent group id for creating nested group
+   * @param sharedRunnersMinutesLimit (optional) - (admin-only) Pipeline minutes quota for this
+   *     group
+   * @return the updated Group instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #updateGroup(Object, String,
+   *     String, String, Visibility, Boolean, Boolean, Long)}
+   */
+  @Deprecated
+  public Group updateGroup(
+      final Object groupIdOrPath,
+      final String name,
+      final String path,
+      final String description,
+      final Boolean membershipLock,
+      final Boolean shareWithGroupLock,
+      final Visibility visibility,
+      final Boolean lfsEnabled,
+      final Boolean requestAccessEnabled,
+      final Long parentId,
+      final Integer sharedRunnersMinutesLimit)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name)
+            .withParam("path", path)
+            .withParam("description", description)
+            .withParam("membership_lock", membershipLock)
+            .withParam("share_with_group_lock", shareWithGroupLock)
+            .withParam("visibility", visibility)
+            .withParam("lfs_enabled", lfsEnabled)
+            .withParam("request_access_enabled", requestAccessEnabled)
+            .withParam("parent_id", parentId)
+            .withParam("shared_runners_minutes_limit", sharedRunnersMinutesLimit);
+    final Response response =
+        put(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath));
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Removes group with all projects inside.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteGroup(final Object groupIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "groups", getGroupIdOrPath(groupIdOrPath));
+  }
+
+  /**
+   * Get a list of group members viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a list of group members viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getMembers(final Object groupIdOrPath) throws GitLabApiException {
+    return (getMembers(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of group members viewable by the authenticated user in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param page the page to get
+   * @param perPage the number of Member instances per page
+   * @return a list of group members viewable by the authenticated user in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getMembers(final Object groupIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "members");
+    return (response.readEntity(new GenericType<List<Member>>() {}));
+  }
+
+  /**
+   * Get a Pager of group members viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of Member instances that will be fetched per page
+   * @return a list of group members viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getMembers(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Member>(
+        this,
+        Member.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "members"));
+  }
+
+  /**
+   * Get a Stream of group members viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of group members viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getMembersStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getMembers(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a group member viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the member ID of the member to get
+   * @return a member viewable by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member getMember(final Object groupIdOrPath, final long userId) throws GitLabApiException {
+    return (getMember(groupIdOrPath, userId, false));
+  }
+
+  /**
+   * Get a group member viewable by the authenticated user as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the member ID of the member to get
+   * @return a member viewable by the authenticated user as an Optional instance
+   */
+  public Optional<Member> getOptionalMember(final Object groupIdOrPath, final long userId) {
+    try {
+      return (Optional.ofNullable(getMember(groupIdOrPath, userId, false)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Gets a group team member, optionally including inherited member.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all/:user_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID of the member
+   * @param includeInherited if true will the member even if inherited thru an ancestor group
+   * @return the member specified by the project ID/user ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member getMember(
+      final Object groupIdOrPath, final Long userId, final Boolean includeInherited)
+      throws GitLabApiException {
+    final Response response;
+    if (includeInherited) {
+      response =
+          get(
+              Response.Status.OK,
+              null,
+              "groups",
+              getGroupIdOrPath(groupIdOrPath),
+              "members",
+              "all",
+              userId);
+    } else {
+      response =
+          get(
+              Response.Status.OK,
+              null,
+              "groups",
+              getGroupIdOrPath(groupIdOrPath),
+              "members",
+              userId);
+    }
+    return (response.readEntity(Member.class));
+  }
+
+  /**
+   * Gets a group team member, optionally including inherited member.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all/:user_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID of the member
+   * @param includeInherited if true will the member even if inherited thru an ancestor group
+   * @return the member specified by the group ID/user ID pair as the value of an Optional
+   */
+  public Optional<Member> getOptionalMember(
+      final Object groupIdOrPath, final Long userId, final Boolean includeInherited) {
+    try {
+      return (Optional.ofNullable(getMember(groupIdOrPath, userId, includeInherited)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Gets a list of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a list of group members viewable by the authenticated user, including inherited members
+   *     through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getAllMembers(final Object groupIdOrPath) throws GitLabApiException {
+    return (getAllMembers(groupIdOrPath, null, null));
+  }
+
+  /**
+   * Gets a list of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param page the page to get
+   * @param perPage the number of Member instances per page
+   * @return a list of group members viewable by the authenticated user, including inherited members
+   *     through ancestor groups in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0
+   */
+  @Deprecated
+  public List<Member> getAllMembers(final Object groupIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "members",
+            "all");
+    return (response.readEntity(new GenericType<List<Member>>() {}));
+  }
+
+  /**
+   * Gets a Pager of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of Member instances that will be fetched per page
+   * @return a Pager of group members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getAllMembers(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getAllMembers(groupIdOrPath, null, null, itemsPerPage));
+  }
+
+  /**
+   * Gets a Stream of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of group members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getAllMembersStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getAllMembersStream(groupIdOrPath, null, null));
+  }
+
+  /**
+   * Gets a list of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @return the group members viewable by the authenticated user, including inherited members
+   *     through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getAllMembers(
+      final Object groupIdOrPath, final String query, final List<Long> userIds)
+      throws GitLabApiException {
+    return (getAllMembers(groupIdOrPath, query, userIds, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a Pager of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the group members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getAllMembers(
+      final Object groupIdOrPath,
+      final String query,
+      final List<Long> userIds,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm form =
+        new GitLabApiForm().withParam("query", query).withParam("user_ids", userIds);
+    return (new Pager<Member>(
+        this,
+        Member.class,
+        itemsPerPage,
+        form.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "members",
+        "all"));
+  }
+
+  /**
+   * Gets a Stream of group members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/members/all</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @return a Stream of the group members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getAllMembersStream(
+      final Object groupIdOrPath, final String query, final List<Long> userIds)
+      throws GitLabApiException {
+    return (getAllMembers(groupIdOrPath, query, userIds, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Adds a user to the list of group members.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @return a Member instance for the added user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(final Object groupIdOrPath, final Long userId, final Integer accessLevel)
+      throws GitLabApiException {
+    return (addMember(groupIdOrPath, userId, accessLevel, null));
+  }
+
+  /**
+   * Adds a user to the list of group members.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @return a Member instance for the added user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object groupIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    return (addMember(groupIdOrPath, userId, accessLevel.toValue(), null));
+  }
+
+  /**
+   * Adds a user to the list of group members.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return a Member instance for the added user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object groupIdOrPath,
+      final Long userId,
+      final AccessLevel accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    return (addMember(groupIdOrPath, userId, accessLevel.toValue(), expiresAt));
+  }
+
+  /**
+   * Adds a user to the list of group members.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/members</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return a Member instance for the added user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object groupIdOrPath,
+      final Long userId,
+      final Integer accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("user_id", userId, true)
+            .withParam("access_level", accessLevel, true)
+            .withParam("expires_at", expiresAt, false);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "members");
+    return (response.readEntity(Member.class));
+  }
+
+  /**
+   * Updates a member of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object groupIdOrPath, final Long userId, final Integer accessLevel)
+      throws GitLabApiException {
+    return (updateMember(groupIdOrPath, userId, accessLevel, null));
+  }
+
+  /**
+   * Updates a member of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object groupIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    return (updateMember(groupIdOrPath, userId, accessLevel.toValue(), null));
+  }
+
+  /**
+   * Updates a member of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object groupIdOrPath,
+      final Long userId,
+      final AccessLevel accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    return (updateMember(groupIdOrPath, userId, accessLevel.toValue(), expiresAt));
+  }
+
+  /**
+   * Updates a member of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:groupId/members/:userId</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object groupIdOrPath,
+      final Long userId,
+      final Integer accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("access_level", accessLevel, true)
+            .withParam("expires_at", expiresAt, false);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "members",
+            userId);
+    return (response.readEntity(Member.class));
+  }
+
+  /**
+   * Removes member from the group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/members/:user_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param userId the user ID of the member to remove
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void removeMember(final Object groupIdOrPath, final Long userId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "groups", getGroupIdOrPath(groupIdOrPath), "members", userId);
+  }
+
+  /**
+   * Syncs the group with its linked LDAP group. Only available to group owners and administrators.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_sync</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void ldapSync(final Object groupIdOrPath) throws GitLabApiException {
+    post(
+        Response.Status.NO_CONTENT,
+        (Form) null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "ldap_sync");
+  }
+
+  /**
+   * Adds an LDAP group link.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_group_links</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param cn the CN of a LDAP group
+   * @param groupAccess the minimum access level for members of the LDAP group
+   * @param provider the LDAP provider for the LDAP group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void addLdapGroupLink(
+      final Object groupIdOrPath,
+      final String cn,
+      final AccessLevel groupAccess,
+      final String provider)
+      throws GitLabApiException {
+
+    if (groupAccess == null) {
+      throw new RuntimeException("groupAccess cannot be null or empty");
+    }
+
+    addLdapGroupLink(groupIdOrPath, cn, groupAccess.toValue(), provider);
+  }
+
+  /**
+   * Adds an LDAP group link.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/ldap_group_links</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param cn the CN of a LDAP group
+   * @param groupAccess the minimum access level for members of the LDAP group
+   * @param provider the LDAP provider for the LDAP group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void addLdapGroupLink(
+      final Object groupIdOrPath, final String cn, final Integer groupAccess, final String provider)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("cn", cn, true)
+            .withParam("group_access", groupAccess, true)
+            .withParam("provider", provider, true);
+    post(
+        Response.Status.CREATED,
+        formData,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "ldap_group_links");
+  }
+
+  /**
+   * Deletes an LDAP group link.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/ldap_group_links/:cn</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param cn the CN of the LDAP group link to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteLdapGroupLink(final Object groupIdOrPath, final String cn)
+      throws GitLabApiException {
+
+    if (cn == null || cn.trim().isEmpty()) {
+      throw new RuntimeException("cn cannot be null or empty");
+    }
+
+    delete(
+        Response.Status.OK,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "ldap_group_links",
+        cn);
+  }
+
+  /**
+   * Deletes an LDAP group link for a specific LDAP provider.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/ldap_group_links/:provider/:cn</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param cn the CN of the LDAP group link to delete
+   * @param provider the name of the LDAP provider
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteLdapGroupLink(
+      final Object groupIdOrPath, final String cn, final String provider)
+      throws GitLabApiException {
+
+    if (cn == null || cn.trim().isEmpty()) {
+      throw new RuntimeException("cn cannot be null or empty");
+    }
+
+    if (provider == null || provider.trim().isEmpty()) {
+      throw new RuntimeException("LDAP provider cannot be null or empty");
+    }
+
+    delete(
+        Response.Status.OK,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "ldap_group_links",
+        provider,
+        cn);
+  }
+
+  /**
+   * Get list of a group’s variables.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a list of variables belonging to the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Variable> getVariables(final Object groupIdOrPath) throws GitLabApiException {
+    return (getVariables(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of variables for the specified group in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param page the page to get
+   * @param perPage the number of Variable instances per page
+   * @return a list of variables belonging to the specified group in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Variable> getVariables(final Object groupIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "variables");
+    return (response.readEntity(new GenericType<List<Variable>>() {}));
+  }
+
+  /**
+   * Get a Pager of variables belonging to the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of Variable instances that will be fetched per page
+   * @return a Pager of variables belonging to the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Variable> getVariables(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Variable>(
+        this,
+        Variable.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "variables"));
+  }
+
+  /**
+   * Get a Stream of variables belonging to the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of variables belonging to the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Variable> getVariablesStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getVariables(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the details of a group variable.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables/:key</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param key the key of an existing variable, required
+   * @return the Variable instance for the specified group variable
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Variable getVariable(final Object groupIdOrPath, final String key)
+      throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "variables", key);
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Get the details of a group variable as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/variables/:key</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param key the key of an existing variable, required
+   * @return the Variable for the specified group variable as an Optional instance
+   */
+  public Optional<Variable> getOptionalVariable(final Object groupIdOrPath, final String key) {
+    try {
+      return (Optional.ofNullable(getVariable(groupIdOrPath, key)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Create a new group variable.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object groupIdOrPath, final String key, final String value, final Boolean isProtected)
+      throws GitLabApiException {
+
+    return createVariable(groupIdOrPath, key, value, isProtected, false);
+  }
+
+  /**
+   * Create a new group variable.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/variables</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @param masked whether the variable is masked, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object groupIdOrPath,
+      final String key,
+      final String value,
+      final Boolean isProtected,
+      final Boolean masked)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("key", key, true)
+            .withParam("value", value, true)
+            .withParam("masked", masked)
+            .withParam("protected", isProtected);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "variables");
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Update a group variable.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/variables/:key</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object groupIdOrPath, final String key, final String value, final Boolean isProtected)
+      throws GitLabApiException {
+
+    return updateVariable(groupIdOrPath, key, value, isProtected, false);
+  }
+
+  /**
+   * Update a group variable.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/variables/:key</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @param masked whether the variable is masked, optional
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object groupIdOrPath,
+      final String key,
+      final String value,
+      final Boolean isProtected,
+      final Boolean masked)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("value", value, true)
+            .withParam("masked", masked)
+            .withParam("protected", isProtected);
+    final Response response =
+        putWithFormData(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "variables",
+            key);
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Deletes a group variable.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/variables/:key</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param key the key of an existing variable, required
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteVariable(final Object groupIdOrPath, final String key)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "variables",
+        key);
+  }
+
+  /**
+   * Transfer a project to the Group namespace. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/projects/:project_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the transferred Project instance
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Project transferProject(final Object groupIdOrPath, final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (Form) null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath));
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Get a List of the group audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /groups/:id/audit_events</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param created_after Group audit events created on or after the given time.
+   * @param created_before Group audit events created on or before the given time.
+   * @return a List of group Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AuditEvent> getAuditEvents(
+      final Object groupIdOrPath, final Date created_after, final Date created_before)
+      throws GitLabApiException {
+    return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a Pager of the group audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /groups/:id/audit_events</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param created_after Group audit events created on or after the given time.
+   * @param created_before Group audit events created on or before the given time.
+   * @param itemsPerPage the number of Audit Event instances that will be fetched per page
+   * @return a Pager of group Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<AuditEvent> getAuditEvents(
+      final Object groupIdOrPath,
+      final Date created_after,
+      final Date created_before,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form form =
+        new GitLabApiForm()
+            .withParam("created_before", ISO8601.toString(created_after, false))
+            .withParam("created_after", ISO8601.toString(created_before, false));
+    return (new Pager<AuditEvent>(
+        this,
+        AuditEvent.class,
+        itemsPerPage,
+        form.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "audit_events"));
+  }
+
+  /**
+   * Get a Stream of the group audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /groups/:id/audit_events</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param created_after Group audit events created on or after the given time.
+   * @param created_before Group audit events created on or before the given time.
+   * @return a Stream of group Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<AuditEvent> getAuditEventsStream(
+      final Object groupIdOrPath, final Date created_after, final Date created_before)
+      throws GitLabApiException {
+    return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a specific audit event of a group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/audit_events/:id_audit_event</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param auditEventId the auditEventId, required
+   * @return the group Audit event
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AuditEvent getAuditEvent(final Object groupIdOrPath, final Long auditEventId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "audit_events",
+            auditEventId);
+    return (response.readEntity(AuditEvent.class));
+  }
+
+  /**
+   * Get a List of the group access requests viewable by the authenticated user.
+   *
+   * <pre><code>GET /group/:id/access_requests</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a List of project AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AccessRequest> getAccessRequests(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getAccessRequests(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of the group access requests viewable by the authenticated user.
+   *
+   * <pre><code>GET /groups/:id/access_requests</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param itemsPerPage the number of AccessRequest instances that will be fetched per page
+   * @return a Pager of group AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<AccessRequest> getAccessRequests(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<AccessRequest>(
+        this,
+        AccessRequest.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "access_requests"));
+  }
+
+  /**
+   * Get a Stream of the group access requests viewable by the authenticated user.
+   *
+   * <pre><code>GET /groups/:id/access_requests</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a Stream of group AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<AccessRequest> getAccessRequestsStream(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getAccessRequests(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Requests access for the authenticated user to the specified group.
+   *
+   * <pre><code>POST /groups/:id/access_requests</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return the created AccessRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AccessRequest requestAccess(final Object groupIdOrPath) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (Form) null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "access_requests");
+    return (response.readEntity(AccessRequest.class));
+  }
+
+  /**
+   * Approve access for the specified user to the specified group.
+   *
+   * <pre><code>PUT /groups/:id/access_requests/:user_id/approve</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID to approve access for
+   * @param accessLevel the access level the user is approved for, if null will be developer (30)
+   * @return the approved AccessRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AccessRequest approveAccessRequest(
+      final Object groupIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("access_level", accessLevel);
+    final Response response =
+        this.putWithFormData(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "access_requests",
+            userId,
+            "approve");
+    return (response.readEntity(AccessRequest.class));
+  }
+
+  /**
+   * Deny access for the specified user to the specified group.
+   *
+   * <pre><code>DELETE /groups/:id/access_requests/:user_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param userId the user ID to deny access for
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void denyAccessRequest(final Object groupIdOrPath, final Long userId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "access_requests",
+        userId);
+  }
+
+  /**
+   * Gets a list of a group’s badges and its group badges.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/badges</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @return a List of Badge instances for the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Badge> getBadges(final Object groupIdOrPath) throws GitLabApiException {
     return getBadges(groupIdOrPath, null);
-    }
+  }
 
-    /**
-     * Gets a list of a group’s badges, case-sensitively filtered on bagdeName if non-null.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges?name=:name</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeName The name to filter on (case-sensitive), ignored if null.
-     * @return All badges of the GitLab item, case insensitively filtered on name.
-     * @throws GitLabApiException If any problem is encountered
-     */
-    public List<Badge> getBadges(Object groupIdOrPath, String badgeName) throws GitLabApiException {
-    Form queryParam = new GitLabApiForm().withParam("name", badgeName);
-    Response response = get(Response.Status.OK, queryParam.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "badges");
+  /**
+   * Gets a list of a group’s badges, case-sensitively filtered on bagdeName if non-null.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/badges?name=:name</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeName The name to filter on (case-sensitive), ignored if null.
+   * @return All badges of the GitLab item, case insensitively filtered on name.
+   * @throws GitLabApiException If any problem is encountered
+   */
+  public List<Badge> getBadges(final Object groupIdOrPath, final String badgeName)
+      throws GitLabApiException {
+    final Form queryParam = new GitLabApiForm().withParam("name", badgeName);
+    final Response response =
+        get(
+            Response.Status.OK,
+            queryParam.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "badges");
     return (response.readEntity(new GenericType<List<Badge>>() {}));
-    }
+  }
 
-    /**
-     * Gets a badge of a group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges/:badge_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeId the ID of the badge to get
-     * @return a Badge instance for the specified group/badge ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge getBadge(Object groupIdOrPath, Long badgeId) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
-	return (response.readEntity(Badge.class));
-    }
+  /**
+   * Gets a badge of a group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/badges/:badge_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeId the ID of the badge to get
+   * @return a Badge instance for the specified group/badge ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge getBadge(final Object groupIdOrPath, final Long badgeId) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
+    return (response.readEntity(Badge.class));
+  }
 
-    /**
-     * Get an Optional instance with the value for the specified badge.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges/:badge_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeId the ID of the badge to get
-     * @return an Optional instance with the specified badge as the value
-     */
-    public Optional<Badge> getOptionalBadge(Object groupIdOrPath, Long badgeId) {
-	try {
-	    return (Optional.ofNullable(getBadge(groupIdOrPath, badgeId)));
-	} catch (GitLabApiException glae) {
-	    return (GitLabApi.createOptionalFromException(glae));
-	}
+  /**
+   * Get an Optional instance with the value for the specified badge.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/badges/:badge_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeId the ID of the badge to get
+   * @return an Optional instance with the specified badge as the value
+   */
+  public Optional<Badge> getOptionalBadge(final Object groupIdOrPath, final Long badgeId) {
+    try {
+      return (Optional.ofNullable(getBadge(groupIdOrPath, badgeId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Add a badge to a group.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/badges</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the added badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge addBadge(Object groupIdOrPath, String linkUrl, String imageUrl) throws GitLabApiException {
+  /**
+   * Add a badge to a group.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/badges</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the added badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge addBadge(final Object groupIdOrPath, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
     return addBadge(groupIdOrPath, null, linkUrl, imageUrl);
-    }
+  }
 
-    /**
-     * Add a badge to a group.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/badges</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param name The name to give the badge (may be null)
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return A Badge instance for the added badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge addBadge(Object groupIdOrPath, String name, String linkUrl, String imageUrl) throws GitLabApiException {
-    GitLabApiForm formData = new GitLabApiForm()
-        .withParam("name", name, false)
-        .withParam("link_url", linkUrl, true)
-        .withParam("image_url", imageUrl, true);
-    Response response = post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges");
+  /**
+   * Add a badge to a group.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/badges</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param name The name to give the badge (may be null)
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return A Badge instance for the added badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge addBadge(
+      final Object groupIdOrPath, final String name, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, false)
+            .withParam("link_url", linkUrl, true)
+            .withParam("image_url", imageUrl, true);
+    final Response response =
+        post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges");
     return (response.readEntity(Badge.class));
-    }
+  }
 
-    /**
-     * Edit a badge of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/badges</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeId the ID of the badge to get
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the editted badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge editBadge(Object groupIdOrPath, Long badgeId, String linkUrl, String imageUrl) throws GitLabApiException {
+  /**
+   * Edit a badge of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/badges</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeId the ID of the badge to get
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the editted badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge editBadge(
+      final Object groupIdOrPath, final Long badgeId, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
     return (editBadge(groupIdOrPath, badgeId, null, linkUrl, imageUrl));
-    }
+  }
 
-    /**
-     * Edit a badge of a group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/badges</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeId the ID of the badge to edit
-     * @param name The name of the badge to edit (may be null)
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the edited badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge editBadge(Object groupIdOrPath, Long badgeId, String name, String linkUrl, String imageUrl) throws GitLabApiException {
-    GitLabApiForm formData = new GitLabApiForm()
-        .withParam("name", name, false)
-        .withParam("link_url", linkUrl, false)
-        .withParam("image_url", imageUrl, false);
-    Response response = putWithFormData(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
+  /**
+   * Edit a badge of a group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/badges</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeId the ID of the badge to edit
+   * @param name The name of the badge to edit (may be null)
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the edited badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge editBadge(
+      final Object groupIdOrPath,
+      final Long badgeId,
+      final String name,
+      final String linkUrl,
+      final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, false)
+            .withParam("link_url", linkUrl, false)
+            .withParam("image_url", imageUrl, false);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "badges",
+            badgeId);
     return (response.readEntity(Badge.class));
+  }
+
+  /**
+   * Remove a badge from a group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/badges/:badge_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param badgeId the ID of the badge to remove
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void removeBadge(final Object groupIdOrPath, final Long badgeId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "badges",
+        badgeId);
+  }
+
+  /**
+   * Returns how the link_url and image_url final URLs would be after resolving the placeholder
+   * interpolation.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/badges/render</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the rendered badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge previewBadge(final Object groupIdOrPath, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("link_url", linkUrl, true)
+            .withParam("image_url", imageUrl, true);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "badges",
+            "render");
+    return (response.readEntity(Badge.class));
+  }
+
+  /**
+   * Uploads and sets the project avatar for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param avatarFile the File instance of the avatar file to upload
+   * @return the updated Group instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group setGroupAvatar(final Object groupIdOrPath, final File avatarFile)
+      throws GitLabApiException {
+    final Response response =
+        putUpload(
+            Response.Status.OK, "avatar", avatarFile, "groups", getGroupIdOrPath(groupIdOrPath));
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Share group with another group. Returns 200 and the group details on success.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/share</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param shareWithGroupId the ID of the group to share with, required
+   * @param groupAccess the access level to grant the group, required
+   * @param expiresAt expiration date of the share, optional
+   * @return a Group instance holding the details of the shared group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Group shareGroup(
+      final Object groupIdOrPath,
+      final Long shareWithGroupId,
+      final AccessLevel groupAccess,
+      final Date expiresAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("group_id", shareWithGroupId, true)
+            .withParam("group_access", groupAccess, true)
+            .withParam("expires_at", expiresAt);
+    final Response response =
+        post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "share");
+    return (response.readEntity(Group.class));
+  }
+
+  /**
+   * Unshare the group from another group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/share/:group_id</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path
+   * @param sharedWithGroupId the ID of the group to unshare with, required
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void unshareGroup(final Object groupIdOrPath, final Long sharedWithGroupId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "share",
+        sharedWithGroupId);
+  }
+
+  /**
+   * Get all custom attributes for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a list of group's CustomAttributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<CustomAttribute> getCustomAttributes(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getCustomAttributes(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of custom attributes for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param itemsPerPage the number of items per page
+   * @return a Pager of group's custom attributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<CustomAttribute> getCustomAttributes(
+      final Object groupIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<CustomAttribute>(
+        this,
+        CustomAttribute.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "custom_attributes"));
+  }
+
+  /**
+   * Get a Stream of all custom attributes for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a Stream of group's custom attributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<CustomAttribute> getCustomAttributesStream(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getCustomAttributes(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single custom attribute for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes/:key</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param key the key for the custom attribute
+   * @return a CustomAttribute instance for the specified key
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomAttribute getCustomAttribute(final Object groupIdOrPath, final String key)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "custom_attributes",
+            key);
+    return (response.readEntity(CustomAttribute.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for a single custom attribute for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes/:key</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance,
+   *     required
+   * @param key the key for the custom attribute, required
+   * @return an Optional instance with the value for a single custom attribute for the specified
+   *     group
+   */
+  public Optional<CustomAttribute> geOptionalCustomAttribute(
+      final Object groupIdOrPath, final String key) {
+    try {
+      return (Optional.ofNullable(getCustomAttribute(groupIdOrPath, key)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Set a custom attribute for the specified group. The attribute will be updated if it already
+   * exists, or newly created otherwise.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/custom_attributes/:key</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param key the key for the custom attribute
+   * @param value the value for the customAttribute
+   * @return a CustomAttribute instance for the updated or created custom attribute
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomAttribute setCustomAttribute(
+      final Object groupIdOrPath, final String key, final String value) throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key cannot be null or empty");
+    }
+    if (Objects.isNull(value) || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("Value cannot be null or empty");
     }
 
-    /**
-     * Remove a badge from a group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/badges/:badge_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param badgeId the ID of the badge to remove
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void removeBadge(Object groupIdOrPath, Long badgeId) throws GitLabApiException {
-	delete(Response.Status.NO_CONTENT, null, "groups", getGroupIdOrPath(groupIdOrPath), "badges", badgeId);
+    final GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "custom_attributes",
+            key);
+    return (response.readEntity(CustomAttribute.class));
+  }
+
+  /**
+   * Delete a custom attribute for the specified group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /groups/:id/custom_attributes/:key</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param key the key of the custom attribute to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteCustomAttribute(final Object groupIdOrPath, final String key)
+      throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key can't be null or empty");
     }
 
-    /**
-     * Returns how the link_url and image_url final URLs would be after resolving the placeholder interpolation.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/badges/render</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the rendered badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge previewBadge(Object groupIdOrPath,  String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, true)
-		.withParam("image_url", imageUrl, true);
-	Response response = get(Response.Status.OK, formData.asMap(), "groups", getGroupIdOrPath(groupIdOrPath), "badges", "render");
-	return (response.readEntity(Badge.class));
-    }
-
-    /**
-     * Uploads and sets the project avatar for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param avatarFile the File instance of the avatar file to upload
-     * @return the updated Group instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group setGroupAvatar(Object groupIdOrPath, File avatarFile) throws GitLabApiException {
-        Response response = putUpload(Response.Status.OK,
-                "avatar", avatarFile, "groups", getGroupIdOrPath(groupIdOrPath));
-        return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Share group with another group. Returns 200 and the group details on success.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/share</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param shareWithGroupId the ID of the group to share with, required
-     * @param groupAccess the access level to grant the group, required
-     * @param expiresAt expiration date of the share, optional
-     * @return a Group instance holding the details of the shared group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Group shareGroup(Object groupIdOrPath, Long shareWithGroupId, AccessLevel groupAccess, Date expiresAt) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("group_id", shareWithGroupId, true)
-		.withParam("group_access", groupAccess, true)
-		.withParam("expires_at", expiresAt);
-	Response response = post(Response.Status.OK, formData, "groups", getGroupIdOrPath(groupIdOrPath), "share");
-	return (response.readEntity(Group.class));
-    }
-
-    /**
-     * Unshare the group from another group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/share/:group_id</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param sharedWithGroupId the ID of the group to unshare with, required
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void unshareGroup(Object groupIdOrPath, Long sharedWithGroupId) throws GitLabApiException {
-	delete(Response.Status.NO_CONTENT, null,
-	        "groups", getGroupIdOrPath(groupIdOrPath), "share", sharedWithGroupId);
-    }
-
-    /**
-     * Get all custom attributes for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a list of group's CustomAttributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<CustomAttribute> getCustomAttributes(final Object groupIdOrPath) throws GitLabApiException {
-        return (getCustomAttributes(groupIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of custom attributes for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param itemsPerPage the number of items per page
-     * @return a Pager of group's custom attributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<CustomAttribute> getCustomAttributes(final Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<CustomAttribute>(this, CustomAttribute.class, itemsPerPage, null,
-            "groups", getGroupIdOrPath(groupIdOrPath), "custom_attributes"));
-    }
-
-    /**
-     * Get a Stream of all custom attributes for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a Stream of group's custom attributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<CustomAttribute> getCustomAttributesStream(final Object groupIdOrPath) throws GitLabApiException {
-        return (getCustomAttributes(groupIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single custom attribute for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes/:key</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param key the key for the custom attribute
-     * @return a CustomAttribute instance for the specified key
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomAttribute getCustomAttribute(final Object groupIdOrPath, final String key) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-            "groups", getGroupIdOrPath(groupIdOrPath), "custom_attributes", key);
-        return (response.readEntity(CustomAttribute.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for a single custom attribute for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/custom_attributes/:key</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance, required
-     * @param key the key for the custom attribute, required
-     * @return an Optional instance with the value for a single custom attribute for the specified group
-     */
-    public Optional<CustomAttribute> geOptionalCustomAttribute(final Object groupIdOrPath, final String key) {
-        try {
-            return (Optional.ofNullable(getCustomAttribute(groupIdOrPath, key)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Set a custom attribute for the specified group. The attribute will be updated if it already exists,
-     * or newly created otherwise.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/custom_attributes/:key</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param key the key for the custom attribute
-     * @param value the value for the customAttribute
-     * @return a CustomAttribute instance for the updated or created custom attribute
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomAttribute setCustomAttribute(final Object groupIdOrPath, final String key, final String value) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key cannot be null or empty");
-        }
-        if (Objects.isNull(value) || value.trim().isEmpty()) {
-            throw new IllegalArgumentException("Value cannot be null or empty");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
-        Response response = putWithFormData(Response.Status.OK, formData,
-            "groups", getGroupIdOrPath(groupIdOrPath), "custom_attributes", key);
-        return (response.readEntity(CustomAttribute.class));
-    }
-
-    /**
-     * Delete a custom attribute for the specified group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /groups/:id/custom_attributes/:key</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param key the key of the custom attribute to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteCustomAttribute(final Object groupIdOrPath, final String key) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key can't be null or empty");
-        }
-
-        delete(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "custom_attributes", key);
-    }
+    delete(
+        Response.Status.OK,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "custom_attributes",
+        key);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/HealthCheckApi.java
+++ b/src/main/java/org/gitlab4j/api/HealthCheckApi.java
@@ -1,14 +1,13 @@
 package org.gitlab4j.api;
 
-import org.gitlab4j.api.models.HealthCheckInfo;
-
-import javax.ws.rs.core.Response;
 import java.io.IOException;
 import java.net.URL;
+import jakarta.ws.rs.core.Response;
+import org.gitlab4j.api.models.HealthCheckInfo;
 
 public class HealthCheckApi extends AbstractApi {
 
-    public HealthCheckApi(GitLabApi gitLabApi) {
+    public HealthCheckApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -37,13 +36,13 @@ public class HealthCheckApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      * @deprecated
      */
-    public HealthCheckInfo getLiveness(String token) throws GitLabApiException {
+    public HealthCheckInfo getLiveness(final String token) throws GitLabApiException {
         try {
-            URL livenessUrl = getApiClient().getUrlWithBase("-", "liveness");
-            GitLabApiForm formData = new GitLabApiForm().withParam("token", token, false);
-            Response response = get(Response.Status.OK, formData.asMap(), livenessUrl);
+            final URL livenessUrl = getApiClient().getUrlWithBase("-", "liveness");
+            final GitLabApiForm formData = new GitLabApiForm().withParam("token", token, false);
+            final Response response = get(Response.Status.OK, formData.asMap(), livenessUrl);
             return (response.readEntity(HealthCheckInfo.class));
-        } catch (IOException ioe) {
+        } catch (final IOException ioe) {
             throw (new GitLabApiException(ioe));
         }
     }
@@ -73,13 +72,13 @@ public class HealthCheckApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      * @deprecated
      */
-    public HealthCheckInfo getReadiness(String token) throws GitLabApiException {
+    public HealthCheckInfo getReadiness(final String token) throws GitLabApiException {
         try {
-            URL readinessUrl = getApiClient().getUrlWithBase("-", "readiness");
-            GitLabApiForm formData = new GitLabApiForm().withParam("token", token, false);
-            Response response = get(Response.Status.OK, formData.asMap(), readinessUrl);
+            final URL readinessUrl = getApiClient().getUrlWithBase("-", "readiness");
+            final GitLabApiForm formData = new GitLabApiForm().withParam("token", token, false);
+            final Response response = get(Response.Status.OK, formData.asMap(), readinessUrl);
             return (response.readEntity(HealthCheckInfo.class));
-        } catch (IOException ioe) {
+        } catch (final IOException ioe) {
             throw (new GitLabApiException(ioe));
         }
     }

--- a/src/main/java/org/gitlab4j/api/HookManager.java
+++ b/src/main/java/org/gitlab4j/api/HookManager.java
@@ -1,66 +1,70 @@
-
 package org.gitlab4j.api;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 /**
- * This interface provides a base class handler for processing GitLab Web Hook and System Hook callouts.
+ * This interface provides a base class handler for processing GitLab Web Hook and System Hook
+ * callouts.
  */
 public interface HookManager {
 
-    /**
-     * Get the secret token that received hook events should be validated against.
-     *
-     * @return the secret token that received hook events should be validated against
-     */
-    String getSecretToken();
+  /**
+   * Get the secret token that received hook events should be validated against.
+   *
+   * @return the secret token that received hook events should be validated against
+   */
+  String getSecretToken();
 
-    /**
-     * Set the secret token that received hook events should be validated against.
-     *
-     * @param secretToken the secret token to verify against
-     */
-    void setSecretToken(String secretToken);
+  /**
+   * Set the secret token that received hook events should be validated against.
+   *
+   * @param secretToken the secret token to verify against
+   */
+  void setSecretToken(String secretToken);
 
-    /**
-     * Validate the provided secret token against the reference secret token. Returns true if
-     * the secret token is valid or there is no reference secret token to validate against,
-     * otherwise returns false.
-     * 
-     * @param secretToken the token to validate
-     * @return true if the secret token is valid or there is no reference secret token to validate against
-     */
-    default public boolean isValidSecretToken(String secretToken) {
-        String ourSecretToken = getSecretToken();
-        return (ourSecretToken == null ||
-                ourSecretToken.trim().isEmpty() ||
-                ourSecretToken.equals(secretToken) ? true : false);
+  /**
+   * Validate the provided secret token against the reference secret token. Returns true if the
+   * secret token is valid or there is no reference secret token to validate against, otherwise
+   * returns false.
+   *
+   * @param secretToken the token to validate
+   * @return true if the secret token is valid or there is no reference secret token to validate
+   *     against
+   */
+  public default boolean isValidSecretToken(final String secretToken) {
+    final String ourSecretToken = getSecretToken();
+    return (ourSecretToken == null
+            || ourSecretToken.trim().isEmpty()
+            || ourSecretToken.equals(secretToken)
+        ? true
+        : false);
+  }
+
+  /**
+   * Validate the provided secret token found in the HTTP header against the reference secret token.
+   * Returns true if the secret token is valid or there is no reference secret token to validate
+   * against, otherwise returns false.
+   *
+   * @param request the HTTP request to verify the secret token
+   * @return true if the secret token is valid or there is no reference secret token to validate
+   *     against
+   */
+  public default boolean isValidSecretToken(final HttpServletRequest request) {
+
+    if (getSecretToken() != null) {
+      final String secretToken = request.getHeader("X-Gitlab-Token");
+      return (isValidSecretToken(secretToken));
     }
 
-    /**
-     * Validate the provided secret token found in the HTTP header against the reference secret token.
-     * Returns true if the secret token is valid or there is no reference secret token to validate
-     * against, otherwise returns false.
-     * 
-     * @param request the HTTP request to verify the secret token
-     * @return true if the secret token is valid or there is no reference secret token to validate against
-     */
-    default public boolean isValidSecretToken(HttpServletRequest request) {
+    return (true);
+  }
 
-        if (getSecretToken() != null) {
-            String secretToken = request.getHeader("X-Gitlab-Token");
-            return (isValidSecretToken(secretToken));
-        }
-
-        return (true);
-    }
-
-    /**
-     * Parses and verifies an Event instance from the HTTP request and
-     * fires it off to the registered listeners.
-     * 
-     * @param request the HttpServletRequest to read the Event instance from
-     * @throws GitLabApiException if the parsed event is not supported
-     */
-    public void handleEvent(HttpServletRequest request) throws GitLabApiException;
+  /**
+   * Parses and verifies an Event instance from the HTTP request and fires it off to the registered
+   * listeners.
+   *
+   * @param request the HttpServletRequest to read the Event instance from
+   * @throws GitLabApiException if the parsed event is not supported
+   */
+  public void handleEvent(HttpServletRequest request) throws GitLabApiException;
 }

--- a/src/main/java/org/gitlab4j/api/ImportExportApi.java
+++ b/src/main/java/org/gitlab4j/api/ImportExportApi.java
@@ -8,255 +8,315 @@ import java.nio.file.Files;
 import java.nio.file.StandardCopyOption;
 import java.util.Date;
 import java.util.Map;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.ExportStatus;
 import org.gitlab4j.api.models.ImportStatus;
 import org.gitlab4j.api.models.Project;
 
 /**
  * This class provides an entry point to all the GitLab API project import/export calls.
- * @see <a href="https://docs.gitlab.com/ee/api/project_import_export.html">Project import/export API at GitLab</a>
+ *
+ * @see <a href="https://docs.gitlab.com/ee/api/project_import_export.html">Project import/export
+ *     API at GitLab</a>
  */
 public class ImportExportApi extends AbstractApi {
 
-    public ImportExportApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ImportExportApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Schedule an export.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void scheduleExport(final Object projectIdOrPath) throws GitLabApiException {
+    scheduleExport(projectIdOrPath, null, null, null, null);
+  }
+
+  /**
+   * Schedule an export.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param description overrides the project description, optional
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void scheduleExport(final Object projectIdOrPath, final String description)
+      throws GitLabApiException {
+    scheduleExport(projectIdOrPath, description, null, null, null);
+  }
+
+  /**
+   * Schedule an export.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param description overrides the project description, optional
+   * @param upload Mao that contains the information to upload the exported project to a web server
+   * @param uploadUrl the URL to upload the project
+   * @param uploadHttpMethod the HTTP method to upload the exported project. Only PUT and POST
+   *     methods allowed. Default is PUT
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void scheduleExport(
+      final Object projectIdOrPath,
+      final String description,
+      final Map<String, String> upload,
+      final String uploadUrl,
+      final String uploadHttpMethod)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("description", description)
+            .withParam("upload", upload)
+            .withParam("upload[url]", uploadUrl)
+            .withParam("upload[http_method]", uploadHttpMethod);
+    post(
+        Response.Status.ACCEPTED,
+        formData,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "export");
+  }
+
+  /**
+   * Get the status of export.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/export</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return an ExportStatus instance holding information on the export status
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExportStatus getExportStatus(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "export");
+    return (response.readEntity(ExportStatus.class));
+  }
+
+  /**
+   * Download the finished export.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/export/download</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param directory the File instance of the directory to save the export file to, if null will
+   *     use "java.io.tmpdir"
+   * @return a File instance pointing to the download of the project export file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadExport(final Object projectIdOrPath, final File directory)
+      throws GitLabApiException {
+    return downloadExport(projectIdOrPath, directory, null);
+  }
+
+  /**
+   * Download the finished export.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/export/download</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param directory the File instance of the directory to save the export file to, if null will
+   *     use "java.io.tmpdir"
+   * @param filename Name to give to the downloaded file. If null then we try to get from
+   *     Content-Disposition header or to compute one from parameters
+   * @return a File instance pointing to the download of the project export file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadExport(final Object projectIdOrPath, File directory, String filename)
+      throws GitLabApiException {
+
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            null,
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "export",
+            "download");
+
+    if (directory == null) {
+      directory = new File(System.getProperty("java.io.tmpdir"));
     }
 
-    /**
-     * Schedule an export.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void scheduleExport(Object projectIdOrPath) throws GitLabApiException {
-        scheduleExport(projectIdOrPath, null, null, null, null);
-    }
+    if (filename == null) {
 
-    /**
-     * Schedule an export.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param description overrides the project description, optional
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void scheduleExport(Object projectIdOrPath, String description) throws GitLabApiException {
-        scheduleExport(projectIdOrPath, description, null, null, null);
-    }
+      // No filename provided
+      final String disposition = response.getHeaderString("Content-Disposition");
+      if (disposition == null) {
 
-    /**
-     * Schedule an export.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/export</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param description overrides the project description, optional
-     * @param upload Mao that contains the information to upload the exported project to a web server
-     * @param uploadUrl the URL to upload the project
-     * @param uploadHttpMethod the HTTP method to upload the exported project.
-     *                          Only PUT and POST methods allowed. Default is PUT
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void scheduleExport(Object projectIdOrPath, String description,
-            Map<String, String> upload, String uploadUrl, String uploadHttpMethod) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("description", description)
-                .withParam("upload", upload)
-                .withParam("upload[url]", uploadUrl)
-                .withParam("upload[http_method]", uploadHttpMethod);
-        post(Response.Status.ACCEPTED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "export");
-    }
-
-    /**
-     * Get the status of export.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/export</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return an ExportStatus instance holding information on the export status
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExportStatus getExportStatus(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "export");
-        return (response.readEntity(ExportStatus.class));
-    }
-
-    /**
-     * Download the finished export.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/export/download</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param directory the File instance of the directory to save the export file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the project export file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadExport(Object projectIdOrPath, File directory) throws GitLabApiException {
-        return downloadExport(projectIdOrPath, directory, null);
-    }
-
-    /**
-     * Download the finished export.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/export/download</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param directory the File instance of the directory to save the export file to, if null will use "java.io.tmpdir"
-     * @param filename Name to give to the downloaded file. If null then we try to get from Content-Disposition header
-     *                 or to compute one from parameters
-     * @return a File instance pointing to the download of the project export file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadExport(Object projectIdOrPath, File directory, String filename) throws GitLabApiException {
-
-        Response response = getWithAccepts(Response.Status.OK, null, MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "export", "download");
-
-        if (directory == null) {
-            directory = new File(System.getProperty("java.io.tmpdir"));
+        // On GitLab.com the Content-Disposition returned is null
+        String name = null;
+        if (projectIdOrPath instanceof Project) {
+          name = ((Project) projectIdOrPath).getPathWithNamespace().replace('/', '_');
+        } else if (projectIdOrPath instanceof String) {
+          name = (String) projectIdOrPath;
+        } else if (projectIdOrPath instanceof Integer) {
+          name = "projectid-" + projectIdOrPath;
         }
 
-        if (filename == null) {
+        // template = "YYYY-MM-DD_HH-MM-SS_{name}_export.tar.gz"
+        final String template = "%1$tY-%1$tm-%1$td_%1$tH-%1$tM-%1$tS_%2$s_export.tar.gz";
+        filename = String.format(template, new Date(), name);
 
-            // No filename provided
-            String disposition = response.getHeaderString("Content-Disposition");
-            if (disposition == null) {
-
-                // On GitLab.com the Content-Disposition returned is null
-                String name = null;
-                if (projectIdOrPath instanceof Project) {
-                    name = ((Project) projectIdOrPath).getPathWithNamespace().replace('/', '_');
-                } else if(projectIdOrPath instanceof String) {
-                    name = (String)projectIdOrPath;
-                } else if(projectIdOrPath instanceof Integer) {
-                    name = "projectid-" + projectIdOrPath;
-                }
-
-                // template = "YYYY-MM-DD_HH-MM-SS_{name}_export.tar.gz"
-                final String template = "%1$tY-%1$tm-%1$td_%1$tH-%1$tM-%1$tS_%2$s_export.tar.gz";
-                filename = String.format(template,  new Date(), name);
-
-            } else {
-                filename = disposition.replaceFirst("(?i)^.*filename=\"?([^\"]+)\"?.*$", "$1");
-            }
-        }
-
-        try {
-
-            File file = new File(directory, filename);
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
+      } else {
+        filename = disposition.replaceFirst("(?i)^.*filename=\"?([^\"]+)\"?.*$", "$1");
+      }
     }
 
-    /**
-     * <p>Import an exported project.  The following properties on the Project instance
-     * are utilized in the creation of the new project:</p>
-     *<ul>
-     * <li>defaultBranch (optional) - master by default</li>
-     * <li>description (optional) - short project description</li>
-     * <li>visibility (optional) - Limit by visibility public, internal, or private</li>
-     * <li>visibilityLevel (optional)</li>
-     * <li>issuesEnabled (optional) - Enable issues for this project</li>
-     * <li>mergeMethod (optional) - Set the merge method used</li>
-     * <li>mergeRequestsEnabled (optional) - Enable merge requests for this project</li>
-     * <li>wikiEnabled (optional) - Enable wiki for this project</li>
-     * <li>snippetsEnabled (optional) - Enable snippets for this project</li>
-     * <li>jobsEnabled (optional) - Enable jobs for this project</li>
-     * <li>containerRegistryEnabled (optional) - Enable container registry for this project</li>
-     * <li>sharedRunnersEnabled (optional) - Enable shared runners for this project</li>
-     * <li>publicJobs (optional) - If true, jobs can be viewed by non-project-members</li>
-     * <li>onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be merged with successful jobs</li>
-     * <li>onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge requests can only be merged when all the discussions are resolved</li>
-     * <li>lfsEnabled (optional) - Enable LFS</li>
-     * <li>requestAccessEnabled (optional) - Allow users to request member access</li>
-     * <li>repositoryStorage (optional) - Which storage shard the repository is on. Available only to admins</li>
-     * <li>approvalsBeforeMerge (optional) - How many approvers should approve merge request by default</li>
-     * <li>printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line</li>
-     * <li>resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push</li>
-     * <li>initialize_with_readme (optional) - Initialize project with README file</li>
-     * <li>packagesEnabled (optional) - Enable or disable mvn packages repository feature</li>
-     *</ul>
-     * <pre><code>GitLab Endpoint: POST /projects/import</code></pre>
-     *
-     * @param namespaceIdOrPath the ID or path of the namespace that the project will be imported to. Defaults to the current user’s namespace
-     * @param exportFile the project export file to be imported
-     * @param path the name and path for the new project
-     * @param overwrite if there is a project with the same path the import will overwrite it. Defaults to false
-     * @param overrideParams overriding project params, supports all fields defined by the ProjectApi, optional
-     * @return an Importstatus instance with info for the project being imported to
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ImportStatus startImport(Object namespaceIdOrPath, File exportFile, String path, Boolean overwrite, Project overrideParams) throws GitLabApiException {
+    try {
 
-        URL url;
-        try {
-            url = getApiClient().getApiUrl("projects", "import");
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
+      final File file = new File(directory, filename);
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("path", path, true)
-                .withParam("namespace", namespaceIdOrPath)
-                .withParam("overwrite", overwrite);
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
+    }
+  }
 
-        if (overrideParams != null) {
-            formData.withParam("default_branch", overrideParams.getDefaultBranch())
-                .withParam("description", overrideParams.getDescription())
-                .withParam("issues_enabled", overrideParams.getIssuesEnabled())
-                .withParam("merge_method",  overrideParams.getMergeMethod())
-                .withParam("merge_requests_enabled", overrideParams.getMergeRequestsEnabled())
-                .withParam("jobs_enabled", overrideParams.getJobsEnabled())
-                .withParam("wiki_enabled", overrideParams.getWikiEnabled())
-                .withParam("container_registry_enabled", overrideParams.getContainerRegistryEnabled())
-                .withParam("snippets_enabled", overrideParams.getSnippetsEnabled())
-                .withParam("shared_runners_enabled", overrideParams.getSharedRunnersEnabled())
-                .withParam("public_jobs", overrideParams.getPublicJobs())
-                .withParam("visibility_level", overrideParams.getVisibilityLevel())
-                .withParam("only_allow_merge_if_pipeline_succeeds", overrideParams.getOnlyAllowMergeIfPipelineSucceeds())
-                .withParam("only_allow_merge_if_all_discussions_are_resolved", overrideParams.getOnlyAllowMergeIfAllDiscussionsAreResolved())
-                .withParam("lfs_enabled", overrideParams.getLfsEnabled())
-                .withParam("request_access_enabled", overrideParams.getRequestAccessEnabled())
-                .withParam("repository_storage", overrideParams.getRepositoryStorage())
-                .withParam("approvals_before_merge", overrideParams.getApprovalsBeforeMerge())
-                .withParam("printing_merge_request_link_enabled", overrideParams.getPrintingMergeRequestLinkEnabled())
-                .withParam("resolve_outdated_diff_discussions", overrideParams.getResolveOutdatedDiffDiscussions())
-                .withParam("initialize_with_readme", overrideParams.getInitializeWithReadme())
-                .withParam("packages_enabled", overrideParams.getPackagesEnabled())
-                .withParam("build_git_strategy", overrideParams.getBuildGitStrategy())
-                .withParam("build_coverage_regex", overrideParams.getBuildCoverageRegex())
-                .withParam("squash_option", overrideParams.getSquashOption());
-        }
+  /**
+   * Import an exported project. The following properties on the Project instance are utilized in
+   * the creation of the new project:
+   *
+   * <ul>
+   *   <li>defaultBranch (optional) - master by default
+   *   <li>description (optional) - short project description
+   *   <li>visibility (optional) - Limit by visibility public, internal, or private
+   *   <li>visibilityLevel (optional)
+   *   <li>issuesEnabled (optional) - Enable issues for this project
+   *   <li>mergeMethod (optional) - Set the merge method used
+   *   <li>mergeRequestsEnabled (optional) - Enable merge requests for this project
+   *   <li>wikiEnabled (optional) - Enable wiki for this project
+   *   <li>snippetsEnabled (optional) - Enable snippets for this project
+   *   <li>jobsEnabled (optional) - Enable jobs for this project
+   *   <li>containerRegistryEnabled (optional) - Enable container registry for this project
+   *   <li>sharedRunnersEnabled (optional) - Enable shared runners for this project
+   *   <li>publicJobs (optional) - If true, jobs can be viewed by non-project-members
+   *   <li>onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be
+   *       merged with successful jobs
+   *   <li>onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge requests can
+   *       only be merged when all the discussions are resolved
+   *   <li>lfsEnabled (optional) - Enable LFS
+   *   <li>requestAccessEnabled (optional) - Allow users to request member access
+   *   <li>repositoryStorage (optional) - Which storage shard the repository is on. Available only
+   *       to admins
+   *   <li>approvalsBeforeMerge (optional) - How many approvers should approve merge request by
+   *       default
+   *   <li>printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when
+   *       pushing from the command line
+   *   <li>resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs
+   *       discussions on lines changed with a push
+   *   <li>initialize_with_readme (optional) - Initialize project with README file
+   *   <li>packagesEnabled (optional) - Enable or disable mvn packages repository feature
+   * </ul>
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/import</code></pre>
+   *
+   * @param namespaceIdOrPath the ID or path of the namespace that the project will be imported to.
+   *     Defaults to the current user’s namespace
+   * @param exportFile the project export file to be imported
+   * @param path the name and path for the new project
+   * @param overwrite if there is a project with the same path the import will overwrite it.
+   *     Defaults to false
+   * @param overrideParams overriding project params, supports all fields defined by the ProjectApi,
+   *     optional
+   * @return an Importstatus instance with info for the project being imported to
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ImportStatus startImport(
+      final Object namespaceIdOrPath,
+      final File exportFile,
+      final String path,
+      final Boolean overwrite,
+      final Project overrideParams)
+      throws GitLabApiException {
 
-        Response response = upload(Response.Status.CREATED, "file", exportFile, null, formData, url);
-        return (response.readEntity(ImportStatus.class));
+    final URL url;
+    try {
+      url = getApiClient().getApiUrl("projects", "import");
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
 
-    /**
-     * Get the status of an import.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/import</code></pre>
-     *
-     * @param projectIdOrPath the new (imported) project identifier in the form of an Long(ID), String(path), or Project instance 
-     * @return an ImportStatus instance holding information on the import status
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ImportStatus getImportStatus(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "import");
-        return (response.readEntity(ImportStatus.class));
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("path", path, true)
+            .withParam("namespace", namespaceIdOrPath)
+            .withParam("overwrite", overwrite);
+
+    if (overrideParams != null) {
+      formData
+          .withParam("default_branch", overrideParams.getDefaultBranch())
+          .withParam("description", overrideParams.getDescription())
+          .withParam("issues_enabled", overrideParams.getIssuesEnabled())
+          .withParam("merge_method", overrideParams.getMergeMethod())
+          .withParam("merge_requests_enabled", overrideParams.getMergeRequestsEnabled())
+          .withParam("jobs_enabled", overrideParams.getJobsEnabled())
+          .withParam("wiki_enabled", overrideParams.getWikiEnabled())
+          .withParam("container_registry_enabled", overrideParams.getContainerRegistryEnabled())
+          .withParam("snippets_enabled", overrideParams.getSnippetsEnabled())
+          .withParam("shared_runners_enabled", overrideParams.getSharedRunnersEnabled())
+          .withParam("public_jobs", overrideParams.getPublicJobs())
+          .withParam("visibility_level", overrideParams.getVisibilityLevel())
+          .withParam(
+              "only_allow_merge_if_pipeline_succeeds",
+              overrideParams.getOnlyAllowMergeIfPipelineSucceeds())
+          .withParam(
+              "only_allow_merge_if_all_discussions_are_resolved",
+              overrideParams.getOnlyAllowMergeIfAllDiscussionsAreResolved())
+          .withParam("lfs_enabled", overrideParams.getLfsEnabled())
+          .withParam("request_access_enabled", overrideParams.getRequestAccessEnabled())
+          .withParam("repository_storage", overrideParams.getRepositoryStorage())
+          .withParam("approvals_before_merge", overrideParams.getApprovalsBeforeMerge())
+          .withParam(
+              "printing_merge_request_link_enabled",
+              overrideParams.getPrintingMergeRequestLinkEnabled())
+          .withParam(
+              "resolve_outdated_diff_discussions",
+              overrideParams.getResolveOutdatedDiffDiscussions())
+          .withParam("initialize_with_readme", overrideParams.getInitializeWithReadme())
+          .withParam("packages_enabled", overrideParams.getPackagesEnabled())
+          .withParam("build_git_strategy", overrideParams.getBuildGitStrategy())
+          .withParam("build_coverage_regex", overrideParams.getBuildCoverageRegex())
+          .withParam("squash_option", overrideParams.getSquashOption());
     }
+
+    final Response response =
+        upload(Response.Status.CREATED, "file", exportFile, null, formData, url);
+    return (response.readEntity(ImportStatus.class));
+  }
+
+  /**
+   * Get the status of an import.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/import</code></pre>
+   *
+   * @param projectIdOrPath the new (imported) project identifier in the form of an Long(ID),
+   *     String(path), or Project instance
+   * @return an ImportStatus instance holding information on the import status
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ImportStatus getImportStatus(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "import");
+    return (response.readEntity(ImportStatus.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/IssuesApi.java
+++ b/src/main/java/org/gitlab4j/api/IssuesApi.java
@@ -5,10 +5,8 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Duration;
 import org.gitlab4j.api.models.Issue;
@@ -23,434 +21,554 @@ import org.gitlab4j.api.utils.DurationUtils;
 
 /**
  * This class provides an entry point to all the GitLab API Issue calls.
+ *
  * @see <a href="https://docs.gitlab.com/ce/api/issues.html">Issues API at GitLab</a>
  * @see <a href="https://docs.gitlab.com/ce/api/issue_links.html">Issue Links API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/issues_statistics.html">Issues Statistics API at GitLab</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/issues_statistics.html">Issues Statistics API at
+ *     GitLab</a>
  */
 public class IssuesApi extends AbstractApi implements Constants {
 
-    public IssuesApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public IssuesApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get all issues the authenticated user has access to. Only returns issues created by the current
+   * user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @return a list of user's issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues() throws GitLabApiException {
+    return (getIssues(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all issues the authenticated user has access to using the specified page and per page
+   * setting. Only returns issues created by the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return the list of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final int page, final int perPage) throws GitLabApiException {
+    final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
+
+  /**
+   * Get a Pager of all issues the authenticated user has access to. Only returns issues created by
+   * the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * r
+   *
+   * @param itemsPerPage the number of issues per page
+   * @return the Pager of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssues(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<Issue>(this, Issue.class, itemsPerPage, null, "issues"));
+  }
+
+  /**
+   * Get all issues the authenticated user has access to as a Stream. Only returns issues created by
+   * the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @return a Stream of user's issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssuesStream() throws GitLabApiException {
+    return (getIssues(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final Object projectIdOrPath) throws GitLabApiException {
+    return (getIssues(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project's issues using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return the list of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
+
+  /**
+   * Get a Pager of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of issues per page
+   * @return the Pager of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssues(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of project's issues. Only returns the first page
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssuesStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getIssues(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
+   * @return the list of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final Object projectIdOrPath, final IssueFilter filter)
+      throws GitLabApiException {
+    return (getIssues(projectIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @param page the page to get.
+   * @param perPage the number of projects per page.
+   * @return the list of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(
+      final Object projectIdOrPath, final IssueFilter filter, final int page, final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams(page, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
+
+  /**
+   * Get a list of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @param itemsPerPage the number of Project instances that will be fetched per page.
+   * @return the Pager of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssues(
+      final Object projectIdOrPath, final IssueFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
+   * @return a Stream of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssuesStream(final Object projectIdOrPath, final IssueFilter filter)
+      throws GitLabApiException {
+    return (getIssues(projectIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get all issues the authenticated user has access to. By default it returns only issues created
+   * by the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
+   * @return the list of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final IssueFilter filter) throws GitLabApiException {
+    return (getIssues(filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all issues the authenticated user has access to. By default it returns only issues created
+   * by the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @param page the page to get.
+   * @param perPage the number of projects per page.
+   * @return the list of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final IssueFilter filter, final int page, final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams(page, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
+
+  /**
+   * Get all issues the authenticated user has access to. By default it returns only issues created
+   * by the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @param itemsPerPage the number of Project instances that will be fetched per page.
+   * @return the Pager of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssues(final IssueFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Issue>(this, Issue.class, itemsPerPage, formData.asMap(), "issues"));
+  }
+
+  /**
+   * Get all issues the authenticated user has access to. By default it returns only issues created
+   * by the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues</code></pre>
+   *
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
+   * @return the Stream of issues in the specified range.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssuesStream(final IssueFilter filter) throws GitLabApiException {
+    return (getIssues(filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of a group’s issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a List of issues for the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getGroupIssues(final Object groupIdOrPath) throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, null, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of groups's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param itemsPerPage the number of Issue instances that will be fetched per page.
+   * @return the Pager of issues for the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getGroupIssues(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, null, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of a group’s issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a Stream of issues for the specified group and filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getGroupIssuesStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, null, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of a group’s issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @return a List of issues for the specified group and filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getGroupIssues(final Object groupIdOrPath, final IssueFilter filter)
+      throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of groups's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @param itemsPerPage the number of Issue instances that will be fetched per page.
+   * @return the Pager of issues for the specified group and filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getGroupIssues(
+      final Object groupIdOrPath, final IssueFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        formData.asMap(),
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of a group’s issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
+   * @return a Stream of issues for the specified group and filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getGroupIssuesStream(final Object groupIdOrPath, final IssueFilter filter)
+      throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single project issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return the specified Issue instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue getIssue(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid);
+    return (response.readEntity(Issue.class));
+  }
+
+  /**
+   * Get a single project issue as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return the specified Issue as an Optional instance
+   */
+  public Optional<Issue> getOptionalIssue(final Object projectIdOrPath, final Long issueIid) {
+    try {
+      return (Optional.ofNullable(getIssue(projectIdOrPath, issueIid)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get all issues the authenticated user has access to. Only returns issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @return a list of user's issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues() throws GitLabApiException {
-        return (getIssues(getDefaultPerPage()).all());
-    }
+  /**
+   * Create an issue for the project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param title the title of an issue, required
+   * @param description the description of an issue, optional
+   * @return an instance of Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue createIssue(
+      final Object projectIdOrPath, final String title, final String description)
+      throws GitLabApiException {
+    return (createIssue(
+        projectIdOrPath, title, description, null, null, null, null, null, null, null, null));
+  }
 
-    /**
-     * Get all issues the authenticated user has access to using the specified page and per page setting. Only returns issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return the list of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "issues");
-        return (response.readEntity(new GenericType<List<Issue>>() {}));
-    }
+  /**
+   * Create an issue for the project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param title the issue title of an issue, required
+   * @param description the description of an issue, optional
+   * @param confidential set the issue to be confidential, default is false, optional
+   * @param assigneeIds the IDs of the users to assign issue, optional
+   * @param milestoneId the ID of a milestone to assign issue, optional
+   * @param labels comma-separated label names for an issue, optional
+   * @param createdAt the date the issue was created at, optional
+   * @param dueDate the due date, optional
+   * @param mergeRequestToResolveId the IID of a merge request in which to resolve all issues. This
+   *     will fill the issue with a default description and mark all discussions as resolved. When
+   *     passing a description or title, these values will take precedence over the default values.
+   *     Optional
+   * @param discussionToResolveId the ID of a discussion to resolve. This will fill in the issue
+   *     with a default description and mark the discussion as resolved. Use in combination with
+   *     merge_request_to_resolve_discussions_of. Optional
+   * @return an instance of Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue createIssue(
+      final Object projectIdOrPath,
+      final String title,
+      final String description,
+      final Boolean confidential,
+      final List<Long> assigneeIds,
+      final Long milestoneId,
+      final String labels,
+      final Date createdAt,
+      final Date dueDate,
+      final Long mergeRequestToResolveId,
+      final Long discussionToResolveId)
+      throws GitLabApiException {
 
-    /**
-     * Get a Pager of all issues the authenticated user has access to. Only returns issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *r
-     * @param itemsPerPage the number of issues per page
-     * @return the Pager of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssues(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null, "issues"));
-    }
+    return (createIssue(
+        projectIdOrPath,
+        title,
+        description,
+        confidential,
+        assigneeIds,
+        milestoneId,
+        labels,
+        createdAt,
+        dueDate,
+        mergeRequestToResolveId,
+        discussionToResolveId,
+        null));
+  }
 
-    /**
-     * Get all issues the authenticated user has access to as a Stream. Only returns issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @return a Stream of user's issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssuesStream() throws GitLabApiException {
-        return (getIssues(getDefaultPerPage()).stream());
-    }
+  /**
+   * Create an issue for the project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param title the issue title of an issue, required
+   * @param description the description of an issue, optional
+   * @param confidential set the issue to be confidential, default is false, optional
+   * @param assigneeIds the IDs of the users to assign issue, optional
+   * @param milestoneId the ID of a milestone to assign issue, optional
+   * @param labels comma-separated label names for an issue, optional
+   * @param createdAt the date the issue was created at, optional
+   * @param dueDate the due date, optional
+   * @param mergeRequestToResolveId the IID of a merge request in which to resolve all issues. This
+   *     will fill the issue with a default description and mark all discussions as resolved. When
+   *     passing a description or title, these values will take precedence over the default values.
+   *     Optional
+   * @param discussionToResolveId the ID of a discussion to resolve. This will fill in the issue
+   *     with a default description and mark the discussion as resolved. Use in combination with
+   *     merge_request_to_resolve_discussions_of. Optional
+   * @param iterationTitle the iteration title of an issue, optional
+   * @return an instance of Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue createIssue(
+      final Object projectIdOrPath,
+      final String title,
+      final String description,
+      final Boolean confidential,
+      final List<Long> assigneeIds,
+      final Long milestoneId,
+      final String labels,
+      final Date createdAt,
+      final Date dueDate,
+      final Long mergeRequestToResolveId,
+      final Long discussionToResolveId,
+      final String iterationTitle)
+      throws GitLabApiException {
 
-    /**
-     * Get a list of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(Object projectIdOrPath) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of project's issues using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return the list of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "issues");
-        return (response.readEntity(new GenericType<List<Issue>>() {}));
-    }
-
-    /**
-     * Get a Pager of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of issues per page
-     * @return the Pager of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssues(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "issues"));
-    }
-
-    /**
-     * Get a Stream of project's issues. Only returns the first page
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssuesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
-     * @return the list of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(Object projectIdOrPath, IssueFilter filter) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @param page the page to get.
-     * @param perPage the number of projects per page.
-     * @return the list of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(Object projectIdOrPath, IssueFilter filter, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams(page, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "issues");
-        return (response.readEntity(new GenericType<List<Issue>>() {}));
-    }
-
-    /**
-     * Get a list of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @param itemsPerPage the number of Project instances that will be fetched per page.
-     * @return the Pager of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssues(Object projectIdOrPath, IssueFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "issues"));
-    }
-
-    /**
-     * Get a Stream of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
-     * @return a Stream of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssuesStream(Object projectIdOrPath, IssueFilter filter) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get all issues the authenticated user has access to.
-     * By default it returns only issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
-     * @return the list of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(IssueFilter filter) throws GitLabApiException {
-        return (getIssues(filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get all issues the authenticated user has access to.
-     * By default it returns only issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @param page the page to get.
-     * @param perPage the number of projects per page.
-     * @return the list of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(IssueFilter filter, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams(page, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "issues");
-        return (response.readEntity(new GenericType<List<Issue>>() {}));
-    }
-
-    /**
-     * Get all issues the authenticated user has access to.
-     * By default it returns only issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @param itemsPerPage the number of Project instances that will be fetched per page.
-     * @return the Pager of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssues(IssueFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, formData.asMap(),  "issues"));
-    }
-
-    /**
-     * Get all issues the authenticated user has access to.
-     * By default it returns only issues created by the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues</code></pre>
-     *
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings
-     * @return the Stream of issues in the specified range.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssuesStream(IssueFilter filter) throws GitLabApiException {
-        return (getIssues(filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of a group’s issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a List of issues for the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getGroupIssues(Object groupIdOrPath) throws GitLabApiException {
-	return (getGroupIssues(groupIdOrPath, null, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of groups's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param itemsPerPage the number of Issue instances that will be fetched per page.
-     * @return the Pager of issues for the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getGroupIssues(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getGroupIssues(groupIdOrPath, null, itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of a group’s issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a Stream of issues for the specified group and filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getGroupIssuesStream(Object groupIdOrPath) throws GitLabApiException {
-	return (getGroupIssues(groupIdOrPath, null, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of a group’s issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @return a List of issues for the specified group and filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getGroupIssues(Object groupIdOrPath, IssueFilter filter) throws GitLabApiException {
-	return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of groups's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @param itemsPerPage the number of Issue instances that will be fetched per page.
-     * @return the Pager of issues for the specified group and filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getGroupIssues(Object groupIdOrPath, IssueFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "issues"));
-    }
-
-    /**
-     * Get a Stream of a group’s issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param filter {@link IssueFilter} a IssueFilter instance with the filter settings.
-     * @return a Stream of issues for the specified group and filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getGroupIssuesStream(Object groupIdOrPath, IssueFilter filter) throws GitLabApiException {
-	return (getGroupIssues(groupIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single project issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return the specified Issue instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue getIssue(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid);
-        return (response.readEntity(Issue.class));
-    }
-
-    /**
-     * Get a single project issue as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return the specified Issue as an Optional instance
-     */
-    public Optional<Issue> getOptionalIssue(Object projectIdOrPath, Long issueIid) {
-        try {
-            return (Optional.ofNullable(getIssue(projectIdOrPath, issueIid)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create an issue for the project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param title the title of an issue, required
-     * @param description the description of an issue, optional
-     * @return an instance of Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue createIssue(Object projectIdOrPath, String title, String description) throws GitLabApiException {
-        return (createIssue(projectIdOrPath, title, description, null, null, null, null, null, null, null, null));
-    }
-
-    /**
-     * Create an issue for the project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param title the issue title of an issue, required
-     * @param description the description of an issue, optional
-     * @param confidential set the issue to be confidential, default is false, optional
-     * @param assigneeIds the IDs of the users to assign issue, optional
-     * @param milestoneId the ID of a milestone to assign issue, optional
-     * @param labels comma-separated label names for an issue, optional
-     * @param createdAt the date the issue was created at, optional
-     * @param dueDate the due date, optional
-     * @param mergeRequestToResolveId the IID of a merge request in which to resolve all issues. This will fill the issue with a default
-     *        description and mark all discussions as resolved. When passing a description or title, these values will take precedence over the default values. Optional
-     * @param discussionToResolveId the ID of a discussion to resolve. This will fill in the issue with a default description and mark the discussion as resolved.
-     *        Use in combination with merge_request_to_resolve_discussions_of. Optional
-     * @return an instance of Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue createIssue(Object projectIdOrPath, String title, String description, Boolean confidential, List<Long> assigneeIds, Long milestoneId, String labels,
-            Date createdAt, Date dueDate, Long mergeRequestToResolveId, Long discussionToResolveId) throws GitLabApiException {
-
-        return (createIssue(projectIdOrPath, title, description, confidential, assigneeIds, milestoneId, labels, createdAt, dueDate, mergeRequestToResolveId, discussionToResolveId, null));
-    }
-
-    /**
-     * Create an issue for the project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param title the issue title of an issue, required
-     * @param description the description of an issue, optional
-     * @param confidential set the issue to be confidential, default is false, optional
-     * @param assigneeIds the IDs of the users to assign issue, optional
-     * @param milestoneId the ID of a milestone to assign issue, optional
-     * @param labels comma-separated label names for an issue, optional
-     * @param createdAt the date the issue was created at, optional
-     * @param dueDate the due date, optional
-     * @param mergeRequestToResolveId the IID of a merge request in which to resolve all issues. This will fill the issue with a default
-     *        description and mark all discussions as resolved. When passing a description or title, these values will take precedence over the default values. Optional
-     * @param discussionToResolveId the ID of a discussion to resolve. This will fill in the issue with a default description and mark the discussion as resolved.
-     *        Use in combination with merge_request_to_resolve_discussions_of. Optional
-     * @param iterationTitle the iteration title of an issue, optional
-     * @return an instance of Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue createIssue(Object projectIdOrPath, String title, String description, Boolean confidential, List<Long> assigneeIds, Long milestoneId, String labels,
-        Date createdAt, Date dueDate, Long mergeRequestToResolveId, Long discussionToResolveId, String iterationTitle) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("title", title, true)
             .withParam("description", description)
             .withParam("confidential", confidential)
@@ -462,592 +580,838 @@ public class IssuesApi extends AbstractApi implements Constants {
             .withParam("merge_request_to_resolve_discussions_of", mergeRequestToResolveId)
             .withParam("discussion_to_resolve", discussionToResolveId)
             .withParam("iteration_title", iterationTitle);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "issues");
-        return (response.readEntity(Issue.class));
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues");
+    return (response.readEntity(Issue.class));
+  }
+
+  /**
+   * Closes an existing project issue.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the issue IID to update, required
+   * @return an instance of the updated Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue closeIssue(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Closes an existing project issue.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the issue IID to update, required
-     * @return an instance of the updated Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue closeIssue(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("state_event", StateEvent.CLOSE);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid);
+    return (response.readEntity(Issue.class));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Updates an existing project issue. This call can also be used to mark an issue as closed.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the issue IID to update, required
+   * @param title the title of an issue, optional
+   * @param description the description of an issue, optional
+   * @param confidential set the issue to be confidential, default is false, optional
+   * @param assigneeIds the IDs of the users to assign issue, optional
+   * @param milestoneId the ID of a milestone to assign issue, optional
+   * @param labels comma-separated label names for an issue, optional
+   * @param stateEvent the state event of an issue. Set close to close the issue and reopen to
+   *     reopen it, optional
+   * @param updatedAt sets the updated date, requires admin or project owner rights, optional
+   * @param dueDate the due date, optional
+   * @return an instance of the updated Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue updateIssue(
+      final Object projectIdOrPath,
+      final Long issueIid,
+      final String title,
+      final String description,
+      final Boolean confidential,
+      final List<Long> assigneeIds,
+      final Long milestoneId,
+      final String labels,
+      final StateEvent stateEvent,
+      final Date updatedAt,
+      final Date dueDate)
+      throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm().withParam("state_event", StateEvent.CLOSE);
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid);
-        return (response.readEntity(Issue.class));
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Updates an existing project issue. This call can also be used to mark an issue as closed.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the issue IID to update, required
-     * @param title the title of an issue, optional
-     * @param description the description of an issue, optional
-     * @param confidential set the issue to be confidential, default is false, optional
-     * @param assigneeIds the IDs of the users to assign issue, optional
-     * @param milestoneId the ID of a milestone to assign issue, optional
-     * @param labels comma-separated label names for an issue, optional
-     * @param stateEvent the state event of an issue. Set close to close the issue and reopen to reopen it, optional
-     * @param updatedAt sets the updated date, requires admin or project owner rights, optional
-     * @param dueDate the due date, optional
-     * @return an instance of the updated Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue updateIssue(Object projectIdOrPath, Long issueIid, String title, String description, Boolean confidential, List<Long> assigneeIds,
-            Long milestoneId, String labels, StateEvent stateEvent, Date updatedAt, Date dueDate) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title)
+            .withParam("description", description)
+            .withParam("confidential", confidential)
+            .withParam("assignee_ids", assigneeIds)
+            .withParam("milestone_id", milestoneId)
+            .withParam("labels", labels)
+            .withParam("state_event", stateEvent)
+            .withParam("updated_at", updatedAt)
+            .withParam("due_date", dueDate);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid);
+    return (response.readEntity(Issue.class));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Updates an existing project issue. This call can also be used to mark an issue as closed.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the issue IID to update, required
+   * @param assigneeId the ID of the user to assign issue to, required
+   * @return an instance of the updated Issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue assignIssue(final Object projectIdOrPath, final Long issueIid, final Long assigneeId)
+      throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title)
-                .withParam("description", description)
-                .withParam("confidential", confidential)
-                .withParam("assignee_ids", assigneeIds)
-                .withParam("milestone_id", milestoneId)
-                .withParam("labels", labels)
-                .withParam("state_event", stateEvent)
-                .withParam("updated_at", updatedAt)
-                .withParam("due_date", dueDate);
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid);
-        return (response.readEntity(Issue.class));
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Updates an existing project issue. This call can also be used to mark an issue as closed.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the issue IID to update, required
-     * @param assigneeId the ID of the user to assign issue to, required
-     * @return an instance of the updated Issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue assignIssue(Object projectIdOrPath, Long issueIid, Long assigneeId) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("assignee_ids", Collections.singletonList(assigneeId));
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid);
+    return (response.readEntity(Issue.class));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Delete an issue.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the internal ID of a project's issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteIssue(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm().withParam("assignee_ids", Collections.singletonList(assigneeId));
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid);
-        return (response.readEntity(Issue.class));
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Delete an issue.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the internal ID of a project's issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteIssue(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        getDefaultPerPageParam(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid);
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Sets an estimated time of work in this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the internal ID of a project's issue
+   * @param duration estimated time in seconds
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats estimateTime(
+      final Object projectIdOrPath, final Long issueIid, final int duration)
+      throws GitLabApiException {
+    return (estimateTime(projectIdOrPath, issueIid, new Duration(duration)));
+  }
 
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, getDefaultPerPageParam(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid);
+  /**
+   * Sets an estimated time of work in this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the internal ID of a project's issue
+   * @param duration Human readable format, e.g. 3h30m
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats estimateTime(
+      final Object projectIdOrPath, final Long issueIid, final String duration)
+      throws GitLabApiException {
+    return (estimateTime(projectIdOrPath, issueIid, new Duration(duration)));
+  }
+
+  /**
+   * Sets an estimated time of work in this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param duration set the estimate of time to this duration
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats estimateTime(
+      final Object projectIdOrPath, final Long issueIid, final Duration duration)
+      throws GitLabApiException {
+
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Sets an estimated time of work in this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the internal ID of a project's issue
-     * @param duration estimated time in seconds
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats estimateTime(Object projectIdOrPath, Long issueIid, int duration) throws GitLabApiException {
-        return (estimateTime(projectIdOrPath, issueIid, new Duration(duration)));
+    final String durationString =
+        (duration != null ? DurationUtils.toString(duration.getSeconds(), false) : null);
+    final GitLabApiForm formData = new GitLabApiForm().withParam("duration", durationString, true);
+
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "time_estimate");
+    return (response.readEntity(TimeStats.class));
+  }
+
+  /**
+   * Resets the estimated time for this issue to 0 seconds.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/reset_time_estimate</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats resetEstimatedTime(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Sets an estimated time of work in this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the internal ID of a project's issue
-     * @param duration Human readable format, e.g. 3h30m
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats estimateTime(Object projectIdOrPath, Long issueIid, String duration) throws GitLabApiException {
-        return (estimateTime(projectIdOrPath, issueIid, new Duration(duration)));
+    final Response response =
+        post(
+            Response.Status.OK,
+            new GitLabApiForm().asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "reset_time_estimate");
+    return (response.readEntity(TimeStats.class));
+  }
+
+  /**
+   * Adds spent time for this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param duration the duration in seconds
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats addSpentTime(
+      final Object projectIdOrPath, final Long issueIid, final int duration)
+      throws GitLabApiException {
+    return (addSpentTime(projectIdOrPath, issueIid, new Duration(duration)));
+  }
+
+  /**
+   * Adds spent time for this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param duration Human readable format, e.g. 3h30m
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats addSpentTime(
+      final Object projectIdOrPath, final Long issueIid, final String duration)
+      throws GitLabApiException {
+    return (addSpentTime(projectIdOrPath, issueIid, new Duration(duration)));
+  }
+
+  /**
+   * Adds spent time for this issue
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param duration the duration of time spent
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats addSpentTime(
+      final Object projectIdOrPath, final Long issueIid, final Duration duration)
+      throws GitLabApiException {
+
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Sets an estimated time of work in this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/time_estimate</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param duration set the estimate of time to this duration
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats estimateTime(Object projectIdOrPath, Long issueIid, Duration duration) throws GitLabApiException {
+    final String durationString =
+        (duration != null ? DurationUtils.toString(duration.getSeconds(), false) : null);
+    final GitLabApiForm formData = new GitLabApiForm().withParam("duration", durationString, true);
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "add_spent_time");
+    return (response.readEntity(TimeStats.class));
+  }
 
-        String durationString = (duration != null ? DurationUtils.toString(duration.getSeconds(), false) : null);
-        GitLabApiForm formData = new GitLabApiForm().withParam("duration", durationString, true);
+  /**
+   * Resets the total spent time for this issue to 0 seconds.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/reset_spent_time</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a TimeSTats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats resetSpentTime(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
 
-        Response response = post(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "time_estimate");
-        return (response.readEntity(TimeStats.class));
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Resets the estimated time for this issue to 0 seconds.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/reset_time_estimate</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats resetEstimatedTime(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.OK,
+            new GitLabApiForm().asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "reset_spent_time");
+    return (response.readEntity(TimeStats.class));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Get time tracking stats.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/time_stats</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a TimeStats instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public TimeStats getTimeTrackingStats(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
 
-        Response response = post(Response.Status.OK, new GitLabApiForm().asMap(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "reset_time_estimate");
-        return (response.readEntity(TimeStats.class));
+    if (issueIid == null) {
+      throw new RuntimeException("issue IID cannot be null");
     }
 
-    /**
-     * Adds spent time for this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param duration the duration in seconds
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats addSpentTime(Object projectIdOrPath, Long issueIid, int duration) throws GitLabApiException {
-        return (addSpentTime(projectIdOrPath, issueIid, new Duration(duration)));
+    final Response response =
+        get(
+            Response.Status.OK,
+            new GitLabApiForm().asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "time_stats");
+    return (response.readEntity(TimeStats.class));
+  }
+
+  /**
+   * Get time tracking stats as an Optional instance
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/time_stats</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a TimeStats as an Optional instance
+   */
+  public Optional<TimeStats> getOptionalTimeTrackingStats(
+      final Object projectIdOrPath, final Long issueIid) {
+    try {
+      return (Optional.ofNullable(getTimeTrackingStats(projectIdOrPath, issueIid)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Adds spent time for this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param duration Human readable format, e.g. 3h30m
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats addSpentTime(Object projectIdOrPath, Long issueIid, String duration) throws GitLabApiException {
-        return (addSpentTime(projectIdOrPath, issueIid, new Duration(duration)));
-    }
+  /**
+   * Get list containing all the merge requests that will close issue when merged.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the internal ID of a project's issue
+   * @return a List containing all the merge requests what will close the issue when merged.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getClosedByMergeRequests(
+      final Object projectIdOrPath, final Long issueIid) throws GitLabApiException {
+    return (getClosedByMergeRequests(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Adds spent time for this issue
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/add_spent_time</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param duration the duration of time spent
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats addSpentTime(Object projectIdOrPath, Long issueIid, Duration duration) throws GitLabApiException {
+  /**
+   * Get list containing all the merge requests that will close issue when merged.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the internal ID of a project's issue
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return a List containing all the merge requests what will close the issue when merged.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getClosedByMergeRequests(
+      final Object projectIdOrPath, final Long issueIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "closed_by");
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Get a Pager containing all the merge requests that will close issue when merged.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the internal ID of a project's issue
+   * @param itemsPerPage the number of Issue instances that will be fetched per page
+   * @return a Pager containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<MergeRequest> getClosedByMergeRequests(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<MergeRequest>(
+        this,
+        MergeRequest.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "closed_by");
+  }
 
-        String durationString = (duration != null ? DurationUtils.toString(duration.getSeconds(), false) : null);
-        GitLabApiForm formData = new GitLabApiForm().withParam("duration", durationString, true);
+  /**
+   * Get list containing all the merge requests that will close issue when merged.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the internal ID of a project's issue
+   * @return a List containing all the merge requests what will close the issue when merged.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<MergeRequest> getClosedByMergeRequestsStream(
+      final Object projectIdOrPath, final Long issueIid) throws GitLabApiException {
+    return (getClosedByMergeRequests(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
+  }
 
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "add_spent_time");
-        return (response.readEntity(TimeStats.class));
-    }
+  /**
+   * Get a list of related issues of a given issue, sorted by the relationship creation datetime
+   * (ascending). Issues will be filtered according to the user authorizations.
+   *
+   * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a list of related issues of a given issue, sorted by the relationship creation datetime
+   *     (ascending)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssueLinks(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Resets the total spent time for this issue to 0 seconds.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/reset_spent_time</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a TimeSTats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats resetSpentTime(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+  /**
+   * Get a Pager of related issues of a given issue, sorted by the relationship creation datetime
+   * (ascending). Issues will be filtered according to the user authorizations.
+   *
+   * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param itemsPerPage the number of issues per page
+   * @return a Pager of related issues of a given issue, sorted by the relationship creation
+   *     datetime (ascending)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssueLinks(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "links"));
+  }
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+  /**
+   * Get a Stream of related issues of a given issue, sorted by the relationship creation datetime
+   * (ascending). Issues will be filtered according to the user authorizations.
+   *
+   * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @return a Stream of related issues of a given issue, sorted by the relationship creation
+   *     datetime (ascending)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssueLinksStream(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
+  }
 
-        Response response = post(Response.Status.OK, new GitLabApiForm().asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "reset_spent_time");
-        return (response.readEntity(TimeStats.class));
-    }
+  /**
+   * Creates a two-way relation between two issues. User must be allowed to update both issues in
+   * order to succeed.
+   *
+   * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/links</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue
+   * @param targetProjectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance of the target project
+   * @param targetIssueIid the internal ID of a target project’s issue
+   * @return an instance of IssueLink holding the link relationship
+   * @throws GitLabApiException if any exception occurs
+   */
+  public IssueLink createIssueLink(
+      final Object projectIdOrPath,
+      final Long issueIid,
+      final Object targetProjectIdOrPath,
+      final Long targetIssueIid)
+      throws GitLabApiException {
 
-    /**
-     * Get time tracking stats.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/time_stats</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a TimeStats instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public TimeStats getTimeTrackingStats(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("target_project_id", getProjectIdOrPath(targetProjectIdOrPath), true)
+            .withParam("target_issue_iid", targetIssueIid, true);
 
-        if (issueIid == null) {
-            throw new RuntimeException("issue IID cannot be null");
-        }
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "links");
+    return (response.readEntity(IssueLink.class));
+  }
 
-        Response response = get(Response.Status.OK, new GitLabApiForm().asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "time_stats");
-        return (response.readEntity(TimeStats.class));
-    }
+  /**
+   * Deletes an issue link, thus removes the two-way relationship.
+   *
+   * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/links/:issue_link_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the internal ID of a project's issue, required
+   * @param issueLinkId the ID of an issue relationship, required
+   * @return an instance of IssueLink holding the deleted link relationship
+   * @throws GitLabApiException if any exception occurs
+   */
+  public IssueLink deleteIssueLink(
+      final Object projectIdOrPath, final Long issueIid, final Long issueLinkId)
+      throws GitLabApiException {
+    final Response response =
+        delete(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "links",
+            issueLinkId);
+    return (response.readEntity(IssueLink.class));
+  }
 
-    /**
-     * Get time tracking stats as an Optional instance
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/time_stats</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a TimeStats as an Optional instance
-     */
-    public Optional<TimeStats> getOptionalTimeTrackingStats(Object projectIdOrPath, Long issueIid) {
-        try {
-            return (Optional.ofNullable(getTimeTrackingStats(projectIdOrPath, issueIid)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
+  /**
+   * Get list of participants for an issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the IID of the issue to get the participants for
+   * @return a List containing all participants for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Participant> getParticipants(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getParticipants(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get list containing all the merge requests that will close issue when merged.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the internal ID of a project's issue
-     * @return a List containing all the merge requests what will close the issue when merged.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getClosedByMergeRequests(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getClosedByMergeRequests(projectIdOrPath, issueIid, getDefaultPerPage()).all());
-    }
+  /**
+   * Get list of participants for an issue and in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the IID of the issue to get the participants for
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a List containing all participants for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Participant> getParticipants(
+      final Object projectIdOrPath, final Long issueIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "participants");
+    return (response.readEntity(new GenericType<List<Participant>>() {}));
+  }
 
-    /**
-     * Get list containing all the merge requests that will close issue when merged.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the internal ID of a project's issue
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return a List containing all the merge requests what will close the issue when merged.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getClosedByMergeRequests(Object projectIdOrPath, Long issueIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "closed_by");
-        return (response.readEntity(new GenericType<List<MergeRequest>>() { }));
-    }
+  /**
+   * Get a Pager of the participants for an issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the IID of the issue to get the participants for
+   * @param itemsPerPage the number of Participant instances that will be fetched per page
+   * @return a Pager containing all participants for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Participant> getParticipants(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Participant>(
+        this,
+        Participant.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "participants");
+  }
 
-    /**
-     * Get a Pager containing all the merge requests that will close issue when merged.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the internal ID of a project's issue
-     * @param itemsPerPage the number of Issue instances that will be fetched per page
-     * @return a Pager containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<MergeRequest> getClosedByMergeRequests(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "closed_by");
-    }
+  /**
+   * Get Stream of participants for an issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the IID of the issue to get the participants for
+   * @return a Stream containing all participants for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Participant> getParticipantsStream(
+      final Object projectIdOrPath, final Long issueIid) throws GitLabApiException {
+    return (getParticipants(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get list containing all the merge requests that will close issue when merged.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/closed_by</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the internal ID of a project's issue
-     * @return a List containing all the merge requests what will close the issue when merged.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<MergeRequest> getClosedByMergeRequestsStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getClosedByMergeRequests(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
-    }
+  /**
+   * Gets issues count statistics on all issues the authenticated user has access to. By default it
+   * returns only issues created by the current user. To get all issues, use parameter scope=all.
+   *
+   * <pre><code>GitLab Endpoint: GET /issues_statistics</code></pre>
+   *
+   * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter
+   *     settings.
+   * @return an IssuesStatistics instance with the statistics for the matched issues.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public IssuesStatistics getIssuesStatistics(final IssuesStatisticsFilter filter)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    final Response response = get(Response.Status.OK, formData.asMap(), "issues_statistics");
+    return (response.readEntity(IssuesStatistics.class));
+  }
 
-    /**
-     * Get a list of related issues of a given issue, sorted by the relationship creation datetime (ascending).
-     * Issues will be filtered according to the user authorizations.
-     *
-     * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a list of related issues of a given issue, sorted by the relationship creation datetime (ascending)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssueLinks(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).all());
-    }
+  /**
+   * Gets issues count statistics for given group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:groupId/issues_statistics</code></pre>
+   *
+   * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID
+   *     or path, required
+   * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter
+   *     settings
+   * @return an IssuesStatistics instance with the statistics for the matched issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public IssuesStatistics getGroupIssuesStatistics(
+      final Object groupIdOrPath, final IssuesStatisticsFilter filter) throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            this.getGroupIdOrPath(groupIdOrPath),
+            "issues_statistics");
+    return (response.readEntity(IssuesStatistics.class));
+  }
 
-    /**
-     * Get a Pager of related issues of a given issue, sorted by the relationship creation datetime (ascending).
-     * Issues will be filtered according to the user authorizations.
-     *
-     * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param itemsPerPage the number of issues per page
-     * @return a Pager of related issues of a given issue, sorted by the relationship creation datetime (ascending)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssueLinks(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "links"));
-    }
+  /**
+   * Gets issues count statistics for given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:projectId/issues_statistics</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter
+   *     settings.
+   * @return an IssuesStatistics instance with the statistics for the matched issues
+   * @throws GitLabApiException if any exception occurs
+   */
+  public IssuesStatistics geProjectIssuesStatistics(
+      final Object projectIdOrPath, final IssuesStatisticsFilter filter) throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "issues_statistics");
+    return (response.readEntity(IssuesStatistics.class));
+  }
 
-    /**
-     * Get a Stream of related issues of a given issue, sorted by the relationship creation datetime (ascending).
-     * Issues will be filtered according to the user authorizations.
-     *
-     * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/links</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @return a Stream of related issues of a given issue, sorted by the relationship creation datetime (ascending)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssueLinksStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Creates a two-way relation between two issues. User must be allowed to update both issues in order to succeed.
-     *
-     * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/links</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue
-     * @param targetProjectIdOrPath the project in the form of an Long(ID), String(path), or Project instance of the target project
-     * @param targetIssueIid the internal ID of a target project’s issue
-     * @return an instance of IssueLink holding the link relationship
-     * @throws GitLabApiException if any exception occurs
-     */
-    public IssueLink createIssueLink(Object projectIdOrPath, Long issueIid,
-            Object targetProjectIdOrPath, Long targetIssueIid) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("target_project_id", getProjectIdOrPath(targetProjectIdOrPath), true)
-                .withParam("target_issue_iid", targetIssueIid, true);
-
-        Response response = post(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "links");
-        return (response.readEntity(IssueLink.class));
-    }
-
-    /**
-     * Deletes an issue link, thus removes the two-way relationship.
-     *
-     * <p>NOTE: Only available in GitLab Starter, GitLab Bronze, and higher tiers.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/links/:issue_link_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the internal ID of a project's issue, required
-     * @param issueLinkId the ID of an issue relationship, required
-     * @return an instance of IssueLink holding the deleted link relationship
-     * @throws GitLabApiException if any exception occurs
-     */
-    public IssueLink deleteIssueLink(Object projectIdOrPath, Long issueIid, Long issueLinkId) throws GitLabApiException {
-        Response response = delete(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "links", issueLinkId);
-        return (response.readEntity(IssueLink.class));
-    }
-
-    /**
-     * Get list of participants for an issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the IID of the issue to get the participants for
-     * @return a List containing all participants for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Participant> getParticipants(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getParticipants(projectIdOrPath, issueIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list of participants for an issue and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the IID of the issue to get the participants for
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a List containing all participants for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Participant> getParticipants(Object projectIdOrPath, Long issueIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                    "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "participants");
-        return (response.readEntity(new GenericType<List<Participant>>() { }));
-    }
-
-    /**
-     * Get a Pager of the participants for an issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the IID of the issue to get the participants for
-     * @param itemsPerPage the number of Participant instances that will be fetched per page
-     * @return a Pager containing all participants for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Participant> getParticipants(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Participant>(this, Participant.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "participants");
-    }
-
-    /**
-     * Get Stream of participants for an issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the IID of the issue to get the participants for
-     * @return a Stream containing all participants for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Participant> getParticipantsStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getParticipants(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Gets issues count statistics on all issues the authenticated user has access to. By default it returns
-     * only issues created by the current user. To get all issues, use parameter scope=all.
-     *
-     * <pre><code>GitLab Endpoint: GET /issues_statistics</code></pre>
-     *
-     * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter settings.
-     * @return an IssuesStatistics instance with the statistics for the matched issues.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public IssuesStatistics getIssuesStatistics(IssuesStatisticsFilter filter) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        Response response = get(Response.Status.OK, formData.asMap(), "issues_statistics");
-        return (response.readEntity(IssuesStatistics.class));
-    }
-
-    /**
-     * Gets issues count statistics for given group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:groupId/issues_statistics</code></pre>
-     *
-     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path, required
-     * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter settings
-     * @return an IssuesStatistics instance with the statistics for the matched issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public IssuesStatistics getGroupIssuesStatistics(Object groupIdOrPath, IssuesStatisticsFilter filter) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        Response response = get(Response.Status.OK, formData.asMap(), "groups", this.getGroupIdOrPath(groupIdOrPath), "issues_statistics");
-        return (response.readEntity(IssuesStatistics.class));
-    }
-
-    /**
-     * Gets issues count statistics for given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:projectId/issues_statistics</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param filter {@link IssuesStatisticsFilter} a IssuesStatisticsFilter instance with the filter settings.
-     * @return an IssuesStatistics instance with the statistics for the matched issues
-     * @throws GitLabApiException if any exception occurs
-     */
-    public IssuesStatistics geProjectIssuesStatistics(Object projectIdOrPath, IssuesStatisticsFilter filter) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", this.getProjectIdOrPath(projectIdOrPath), "issues_statistics");
-        return (response.readEntity(IssuesStatistics.class));
-    }
-
-    /**
-     * <p>Moves an issue to a different project. If the target project equals the source project or
-     * the user has insufficient permissions to move an issue, error 400 together with an
-     * explaining error message is returned.</p>
-     *
-     * <p>If a given label and/or milestone with the same name also exists in the target project,
-     * it will then be assigned to the issue that is being moved.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:projectId/issues/:issue_iid/move</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueIid the IID of the issue to move
-     * @param toProjectId the ID of the project to move the issue to
-     * @return an Issue instance for the moved issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Issue moveIssue(Object projectIdOrPath, Long issueIid, Object toProjectId) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm().withParam("to_project_id", toProjectId, true);
-        Response response = post(Response.Status.OK, formData,
-        	"projects", this.getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "move");
-        return (response.readEntity(Issue.class));
-    }
+  /**
+   * Moves an issue to a different project. If the target project equals the source project or the
+   * user has insufficient permissions to move an issue, error 400 together with an explaining error
+   * message is returned.
+   *
+   * <p>If a given label and/or milestone with the same name also exists in the target project, it
+   * will then be assigned to the issue that is being moved.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:projectId/issues/:issue_iid/move</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueIid the IID of the issue to move
+   * @param toProjectId the ID of the project to move the issue to
+   * @return an Issue instance for the moved issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Issue moveIssue(
+      final Object projectIdOrPath, final Long issueIid, final Object toProjectId)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("to_project_id", toProjectId, true);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "move");
+    return (response.readEntity(Issue.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/JobApi.java
+++ b/src/main/java/org/gitlab4j/api/JobApi.java
@@ -1,5 +1,10 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response.Status;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -9,585 +14,827 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.Response.Status;
 import org.gitlab4j.api.models.ArtifactsFile;
 import org.gitlab4j.api.models.Job;
 import org.gitlab4j.api.models.JobAttributes;
 
-/**
- * This class provides an entry point to all the GitLab API job calls.
- */
+/** This class provides an entry point to all the GitLab API job calls. */
 public class JobApi extends AbstractApi implements Constants {
 
-    public JobApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public JobApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a list containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Job> getJobs(final Object projectIdOrPath) throws GitLabApiException {
+    return (getJobs(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of jobs in a project in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the jobs for
+   * @param page the page to get
+   * @param perPage the number of Job instances per page
+   * @return a list containing the jobs for the specified project ID in the specified page range
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Job> getJobs(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs");
+    return (response.readEntity(new GenericType<List<Job>>() {}));
+  }
+
+  /**
+   * Get a Pager of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the jobs for
+   * @param itemsPerPage the number of Job instances that will be fetched per page
+   * @return a Pager containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Job> getJobs(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Job>(
+        this,
+        Job.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "jobs"));
+  }
+
+  /**
+   * Get a Stream of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Stream containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Job> getJobsStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getJobs(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the jobs for
+   * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED,
+   *     SKIPPED, MANUAL
+   * @return a list containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Job> getJobs(final Object projectIdOrPath, final JobScope scope)
+      throws GitLabApiException {
+    return (getJobs(projectIdOrPath, scope, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the jobs for
+   * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED,
+   *     SKIPPED, MANUAL
+   * @param itemsPerPage the number of Job instances that will be fetched per page
+   * @return a list containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Job> getJobs(
+      final Object projectIdOrPath, final JobScope scope, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("scope", scope);
+    return (new Pager<Job>(
+        this,
+        Job.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "jobs"));
+  }
+
+  /**
+   * Get a Stream of jobs in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the jobs for
+   * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED,
+   *     SKIPPED, MANUAL
+   * @return a Stream containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Job> getJobsStream(final Object projectIdOrPath, final JobScope scope)
+      throws GitLabApiException {
+    return (getJobs(projectIdOrPath, scope, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of jobs in a pipeline.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the pipelines for
+   * @param pipelineId the pipeline ID to get the list of jobs for
+   * @return a list containing the jobs for the specified project ID and pipeline ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Job> getJobsForPipeline(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines",
+            pipelineId,
+            "jobs");
+    return (response.readEntity(new GenericType<List<Job>>() {}));
+  }
+
+  /**
+   * Get a list of jobs in a pipeline.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the pipelines for
+   * @param pipelineId the pipeline ID to get the list of jobs for
+   * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED,
+   *     SKIPPED, MANUAL
+   * @return a list containing the jobs for the specified project ID and pipeline ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Job> getJobsForPipeline(
+      final Object projectIdOrPath, final long pipelineId, final JobScope scope)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("scope", scope)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines",
+            pipelineId,
+            "jobs");
+    return (response.readEntity(new GenericType<List<Job>>() {}));
+  }
+
+  /**
+   * Get a Pager of jobs in a pipeline.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the pipelines for
+   * @param pipelineId the pipeline ID to get the list of jobs for
+   * @param itemsPerPage the number of Job instances that will be fetched per page
+   * @return a list containing the jobs for the specified project ID and pipeline ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Job> getJobsForPipeline(
+      final Object projectIdOrPath, final long pipelineId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Job>(
+        this,
+        Job.class,
+        itemsPerPage,
+        getDefaultPerPageParam(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines",
+        pipelineId,
+        "jobs"));
+  }
+
+  /**
+   * Get a Stream of jobs in a pipeline.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param pipelineId the pipeline ID to get the list of jobs for
+   * @return a Stream containing the jobs for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Job> getJobsStream(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    return (getJobsForPipeline(projectIdOrPath, pipelineId, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get single job in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the job for
+   * @param jobId the job ID to get
+   * @return a single job for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job getJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId);
+    return (response.readEntity(Job.class));
+  }
+
+  /**
+   * Get single job in a project as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the job for
+   * @param jobId the job ID to get
+   * @return a single job for the specified project ID as an Optional intance
+   */
+  public Optional<Job> getOptionalJob(final Object projectIdOrPath, final Long jobId) {
+    try {
+      return (Optional.ofNullable(getJob(projectIdOrPath, jobId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get a list of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a list containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Job> getJobs(Object projectIdOrPath) throws GitLabApiException {
-        return (getJobs(projectIdOrPath, getDefaultPerPage()).all());
+  /**
+   * Download the artifacts file from the given reference name and job provided the job finished
+   * successfully. The file will be saved to the specified directory. If the file already exists in
+   * the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/artifacts/:ref_name/download?job=name</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param ref the ref from a repository
+   * @param jobName the name of the job to download the artifacts for
+   * @param directory the File instance of the directory to save the file to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the download of the specified artifacts file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadArtifactsFile(
+      final Object projectIdOrPath, final String ref, final String jobName, File directory)
+      throws GitLabApiException {
+
+    final Form formData = new GitLabApiForm().withParam("job", jobName, true);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            "artifacts",
+            urlEncode(ref),
+            "download");
+
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = jobName + "-artifacts.zip";
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
+  }
 
-    /**
-     * Get a list of jobs in a project in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the jobs for
-     * @param page the page to get
-     * @param perPage the number of Job instances per page
-     * @return a list containing the jobs for the specified project ID in the specified page range
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Job> getJobs(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "jobs");
-        return (response.readEntity(new GenericType<List<Job>>() {}));
+  /**
+   * Get an InputStream pointing to the artifacts file from the given reference name and job
+   * provided the job finished successfully. The file will be saved to the specified directory. If
+   * the file already exists in the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/artifacts/:ref_name/download?job=name</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param ref the ref from a repository
+   * @param jobName the name of the job to download the artifacts for
+   * @return an InputStream to read the specified artifacts file from
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream downloadArtifactsFile(
+      final Object projectIdOrPath, final String ref, final String jobName)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("job", jobName, true);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            "artifacts",
+            urlEncode(ref),
+            "download");
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Download the job artifacts file for the specified job ID. The artifacts file will be saved in
+   * the specified directory with the following name pattern: job-{jobid}-artifacts.zip. If the file
+   * already exists in the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the job ID to get the artifacts for
+   * @param directory the File instance of the directory to save the file to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the download of the specified job artifacts file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadArtifactsFile(final Object projectIdOrPath, final Long jobId, File directory)
+      throws GitLabApiException {
+
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            null,
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts");
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = "job-" + jobId + "-artifacts.zip";
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
+  }
 
-    /**
-     * Get a Pager of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the jobs for
-     * @param itemsPerPage the number of Job instances that will be fetched per page
-     * @return a Pager containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Job> getJobs(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Job>(this, Job.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "jobs"));
+  /**
+   * Get an InputStream pointing to the job artifacts file for the specified job ID.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the job ID to get the artifacts for
+   * @return an InputStream to read the specified job artifacts file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream downloadArtifactsFile(final Object projectIdOrPath, final Long jobId)
+      throws GitLabApiException {
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            null,
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts");
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Download a single artifact file from within the job's artifacts archive.
+   *
+   * <p>Only a single file is going to be extracted from the archive and streamed to a client.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the unique job identifier
+   * @param artifactsFile an ArtifactsFile instance for the artifact to download
+   * @param directory the File instance of the directory to save the file to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the download of the specified artifacts file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadArtifactsFile(
+      final Object projectIdOrPath,
+      final Long jobId,
+      final ArtifactsFile artifactsFile,
+      File directory)
+      throws GitLabApiException {
+
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts",
+            artifactsFile.getFilename());
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = artifactsFile.getFilename();
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
+  }
 
-    /**
-     * Get a Stream of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Stream containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Job> getJobsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getJobs(projectIdOrPath, getDefaultPerPage()).stream());
+  /**
+   * Download a single artifact file from within the job's artifacts archive.
+   *
+   * <p>Only a single file is going to be extracted from the archive and streamed to a client.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the unique job identifier
+   * @param artifactsFile an ArtifactsFile instance for the artifact to download
+   * @return an InputStream to read the specified artifacts file from
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream downloadArtifactsFile(
+      final Object projectIdOrPath, final Long jobId, final ArtifactsFile artifactsFile)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts",
+            artifactsFile.getFilename());
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Download a single artifact file from within the job's artifacts archive.
+   *
+   * <p>Only a single file is going to be extracted from the archive and streamed to a client.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the unique job identifier
+   * @param artifactPath the Path to a file inside the artifacts archive
+   * @param directory the File instance of the directory to save the file to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the download of the specified artifacts file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File downloadSingleArtifactsFile(
+      final Object projectIdOrPath, final Long jobId, final Path artifactPath, File directory)
+      throws GitLabApiException {
+
+    final String path = artifactPath.toString().replace("\\", "/");
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts",
+            path);
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = artifactPath.getFileName().toString();
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
+  }
 
-    /**
-     * Get a list of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the jobs for
-     * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED, SKIPPED, MANUAL
-     * @return a list containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Job> getJobs(Object projectIdOrPath, JobScope scope) throws GitLabApiException {
-        return (getJobs(projectIdOrPath, scope, getDefaultPerPage()).all());
+  /**
+   * Download a single artifact file from within the job's artifacts archive.
+   *
+   * <p>Only a single file is going to be extracted from the archive and streamed to a client.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the unique job identifier
+   * @param artifactPath the Path to a file inside the artifacts archive
+   * @return an InputStream to read the specified artifacts file from
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream downloadSingleArtifactsFile(
+      final Object projectIdOrPath, final Long jobId, final Path artifactPath)
+      throws GitLabApiException {
+    final String path = artifactPath.toString().replace("\\", "/");
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "artifacts",
+            path);
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Get a trace of a specific job of a project
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:id/trace</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path to get the specified job's trace for
+   * @param jobId the job ID to get the trace for
+   * @return a String containing the specified job's trace
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public String getTrace(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "trace");
+    return (response.readEntity(String.class));
+  }
+
+  /**
+   * Cancel specified job in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/cancel</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to cancel job
+   * @return job instance which just canceled
+   * @throws GitLabApiException if any exception occurs during execution
+   * @deprecated replaced by {@link #cancelJob(Object, Long)}
+   */
+  @Deprecated
+  public Job cancleJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    return (cancelJob(projectIdOrPath, jobId));
+  }
+
+  /**
+   * Cancel specified job in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/cancel</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to cancel job
+   * @return job instance which just canceled
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job cancelJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "cancel");
+    return (response.readEntity(Job.class));
+  }
+
+  /**
+   * Retry specified job in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/retry</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to retry job
+   * @return job instance which just retried
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job retryJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "retry");
+    return (response.readEntity(Job.class));
+  }
+
+  /**
+   * Erase specified job in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/erase</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to erase job
+   * @return job instance which just erased
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job eraseJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "erase");
+    return (response.readEntity(Job.class));
+  }
+
+  /**
+   * Play specified job in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/play</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to play job
+   * @return job instance which just played
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job playJob(final Object projectIdOrPath, final Long jobId) throws GitLabApiException {
+    return playJob(projectIdOrPath, jobId, null);
+  }
+
+  /**
+   * Play specified job with parameters in a project.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/play</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to play job
+   * @param jobAttributes attributes for the played job
+   * @return job instance which just played
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job playJob(
+      final Object projectIdOrPath, final Long jobId, final JobAttributes jobAttributes)
+      throws GitLabApiException {
+    final Response response;
+    if (jobAttributes == null) {
+      final GitLabApiForm formData = null;
+      response =
+          post(
+              Status.CREATED,
+              formData,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "jobs",
+              jobId,
+              "play");
+    } else {
+      response =
+          post(
+              Status.CREATED,
+              jobAttributes,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "jobs",
+              jobId,
+              "play");
     }
+    return (response.readEntity(Job.class));
+  }
 
-    /**
-     * Get a list of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the jobs for
-     * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED, SKIPPED, MANUAL
-     * @param itemsPerPage the number of Job instances that will be fetched per page
-     * @return a list containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Job> getJobs(Object projectIdOrPath, JobScope scope, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("scope", scope);
-        return (new Pager<Job>(this, Job.class, itemsPerPage, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs"));
-    }
+  /**
+   * Prevents artifacts from being deleted when expiration is set.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/keep</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to keep artifacts for
+   * @return the Job instance that was just modified
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Job keepArtifacts(final Object projectIdOrPath, final Long jobId)
+      throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "jobs",
+            jobId,
+            "keep");
+    return (response.readEntity(Job.class));
+  }
 
-    /**
-     * Get a Stream of jobs in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the jobs for
-     * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED, SKIPPED, MANUAL
-     * @return a Stream containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Job> getJobsStream(Object projectIdOrPath, JobScope scope) throws GitLabApiException {
-        return (getJobs(projectIdOrPath, scope, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of jobs in a pipeline.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the pipelines for
-     * @param pipelineId the pipeline ID to get the list of jobs for
-     * @return a list containing the jobs for the specified project ID and pipeline ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Job> getJobsForPipeline(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "jobs");
-        return (response.readEntity(new GenericType<List<Job>>() {}));
-    }
-
-    /**
-     * Get a list of jobs in a pipeline.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the pipelines for
-     * @param pipelineId the pipeline ID to get the list of jobs for
-     * @param scope the scope of jobs, one of: CREATED, PENDING, RUNNING, FAILED, SUCCESS, CANCELED, SKIPPED, MANUAL
-     * @return a list containing the jobs for the specified project ID and pipeline ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Job> getJobsForPipeline(Object projectIdOrPath, long pipelineId, JobScope scope) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("scope", scope).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "jobs");
-        return (response.readEntity(new GenericType<List<Job>>() {}));
-    }
-
-    /**
-     * Get a Pager of jobs in a pipeline.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the pipelines for
-     * @param pipelineId      the pipeline ID to get the list of jobs for
-     * @param itemsPerPage    the number of Job instances that will be fetched per page
-     * @return a list containing the jobs for the specified project ID and pipeline ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Job> getJobsForPipeline(Object projectIdOrPath, long pipelineId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Job>(this, Job.class, itemsPerPage, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "jobs"));
-    }
-
-    /**
-     * Get a Stream of jobs in a pipeline.
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id/jobs</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param pipelineId      the pipeline ID to get the list of jobs for
-     * @return a Stream containing the jobs for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Job> getJobsStream(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-        return (getJobsForPipeline(projectIdOrPath, pipelineId, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get single job in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the job for
-     * @param jobId the job ID to get
-     * @return a single job for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job getJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId);
-        return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Get single job in a project as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path to get the job for
-     * @param jobId the job ID to get
-     * @return a single job for the specified project ID as an Optional intance
-     */
-    public Optional<Job> getOptionalJob(Object projectIdOrPath, Long jobId) {
-        try {
-            return (Optional.ofNullable(getJob(projectIdOrPath, jobId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Download the artifacts file from the given reference name and job provided the job finished successfully.
-     * The file will be saved to the specified directory. If the file already exists in the directory it will
-     * be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/artifacts/:ref_name/download?job=name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param ref the ref from a repository
-     * @param jobName the name of the job to download the artifacts for
-     * @param directory the File instance of the directory to save the file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the specified artifacts file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadArtifactsFile(Object projectIdOrPath, String ref, String jobName, File directory) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm().withParam("job", jobName, true);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", "artifacts", urlEncode(ref), "download");
-
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = jobName + "-artifacts.zip";
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Get an InputStream pointing to the artifacts file from the given reference name and job
-     * provided the job finished successfully. The file will be saved to the specified directory.
-     * If the file already exists in the directory it will be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/artifacts/:ref_name/download?job=name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param ref the ref from a repository
-     * @param jobName the name of the job to download the artifacts for
-     * @return an InputStream to read the specified artifacts file from
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream downloadArtifactsFile(Object projectIdOrPath, String ref, String jobName) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("job", jobName, true);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", "artifacts", urlEncode(ref), "download");
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Download the job artifacts file for the specified job ID.  The artifacts file will be saved in the
-     * specified directory with the following name pattern: job-{jobid}-artifacts.zip.  If the file already
-     * exists in the directory it will be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the job ID to get the artifacts for
-     * @param directory the File instance of the directory to save the file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the specified job artifacts file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadArtifactsFile(Object projectIdOrPath, Long jobId, File directory) throws GitLabApiException {
-
-        Response response = getWithAccepts(Response.Status.OK, null, MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts");
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = "job-" + jobId + "-artifacts.zip";
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Get an InputStream pointing to the job artifacts file for the specified job ID.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the job ID to get the artifacts for
-     * @return an InputStream to read the specified job artifacts file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream downloadArtifactsFile(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        Response response = getWithAccepts(Response.Status.OK, null, MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts");
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Download a single artifact file from within the job's artifacts archive.
-     *
-     * Only a single file is going to be extracted from the archive and streamed to a client.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the unique job identifier
-     * @param artifactsFile an ArtifactsFile instance for the artifact to download
-     * @param directory the File instance of the directory to save the file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the specified artifacts file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadArtifactsFile(Object projectIdOrPath, Long jobId, ArtifactsFile artifactsFile, File directory) throws GitLabApiException {
-
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", artifactsFile.getFilename());
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = artifactsFile.getFilename();
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Download a single artifact file from within the job's artifacts archive.
-     *
-     * Only a single file is going to be extracted from the archive and streamed to a client.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the unique job identifier
-     * @param artifactsFile an ArtifactsFile instance for the artifact to download
-     * @return an InputStream to read the specified artifacts file from
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream downloadArtifactsFile(Object projectIdOrPath, Long jobId, ArtifactsFile artifactsFile) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", artifactsFile.getFilename());
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Download a single artifact file from within the job's artifacts archive.
-     *
-     * Only a single file is going to be extracted from the archive and streamed to a client.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the unique job identifier
-     * @param artifactPath the Path to a file inside the artifacts archive
-     * @param directory the File instance of the directory to save the file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the specified artifacts file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, Path artifactPath, File directory) throws GitLabApiException {
-
-        String path = artifactPath.toString().replace("\\", "/");
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", path);
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = artifactPath.getFileName().toString();
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Download a single artifact file from within the job's artifacts archive.
-     *
-     * Only a single file is going to be extracted from the archive and streamed to a client.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:job_id/artifacts/*artifact_path</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the unique job identifier
-     * @param artifactPath the Path to a file inside the artifacts archive
-     * @return an InputStream to read the specified artifacts file from
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, Path artifactPath) throws GitLabApiException {
-        String path = artifactPath.toString().replace("\\", "/");
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", path);
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Get a trace of a specific job of a project
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/jobs/:id/trace</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     *                        to get the specified job's trace for
-     * @param jobId the job ID to get the trace for
-     * @return a String containing the specified job's trace
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-     public String getTrace(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "trace");
-        return (response.readEntity(String.class));
-     }
-
-    /**
-     * Cancel specified job in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/cancel</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to cancel job
-     * @return job instance which just canceled
-     * @throws GitLabApiException if any exception occurs during execution
-     * @deprecated replaced by {@link #cancelJob(Object, Long)}
-     */
-     @Deprecated
-    public Job cancleJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-	return (cancelJob(projectIdOrPath, jobId));
-    }
-
-    /**
-     * Cancel specified job in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/cancel</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to cancel job
-     * @return job instance which just canceled
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job cancelJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        GitLabApiForm formData = null;
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "cancel");
-        return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Retry specified job in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/retry</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to retry job
-     * @return job instance which just retried
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job retryJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        GitLabApiForm formData = null;
-        Response response = post(Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "retry");
-        return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Erase specified job in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/erase</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to erase job
-     * @return job instance which just erased
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job eraseJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        GitLabApiForm formData = null;
-        Response response = post(Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "erase");
-        return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Play specified job in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/play</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to play job
-     * @return job instance which just played
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job playJob(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-      return playJob(projectIdOrPath, jobId, null);
-    }
-
-    /**
-     * Play specified job with parameters in a project.
-     *
-     * <pre>
-     * <code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/play</code>
-     * </pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID
-     *                        or path
-     * @param jobId           the ID to play job
-     * @param jobAttributes   attributes for the played job
-     * @return job instance which just played
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job playJob(Object projectIdOrPath, Long jobId, JobAttributes jobAttributes)
-        throws GitLabApiException {
-      Response response;
-      if (jobAttributes == null) {
-        GitLabApiForm formData = null;
-        response = post(Status.CREATED, formData, "projects",
-            getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "play");
-      } else {
-        response = post(Status.CREATED, jobAttributes, "projects",
-            getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "play");
-      }
-      return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Prevents artifacts from being deleted when expiration is set.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/jobs/:job_id/keep</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to keep artifacts for
-     * @return the Job instance that was just modified
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Job keepArtifacts(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-	GitLabApiForm formData = null;
-        Response response = post(Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "keep");
-        return (response.readEntity(Job.class));
-    }
-
-    /**
-     * Delete artifacts of a job.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/jobs/:job_id/artifacts</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jobId the ID to delete artifacts for
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deleteArtifacts(Object projectIdOrPath, Long jobId) throws GitLabApiException {
-        delete(Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts");
-    }
+  /**
+   * Delete artifacts of a job.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/jobs/:job_id/artifacts</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jobId the ID to delete artifacts for
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deleteArtifacts(final Object projectIdOrPath, final Long jobId)
+      throws GitLabApiException {
+    delete(
+        Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "jobs",
+        jobId,
+        "artifacts");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/KeysApi.java
+++ b/src/main/java/org/gitlab4j/api/KeysApi.java
@@ -1,18 +1,17 @@
 package org.gitlab4j.api;
 
-import org.gitlab4j.api.models.Key;
-
-import javax.ws.rs.core.MultivaluedHashMap;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
 import java.util.Collections;
+import jakarta.ws.rs.core.MultivaluedHashMap;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
+import org.gitlab4j.api.models.Key;
 
 /**
  * See:
  * https://docs.gitlab.com/ee/api/keys.html#get-user-by-fingerprint-of-ssh-key
  */
 public class KeysApi extends AbstractApi {
-    public KeysApi(GitLabApi gitLabApi) {
+    public KeysApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -21,10 +20,10 @@ public class KeysApi extends AbstractApi {
      * @return The Key which includes the user who owns the key
      * @throws GitLabApiException If anything goes wrong
      */
-    public Key getUserBySSHKeyFingerprint(String fingerprint) throws GitLabApiException {
-        MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
+    public Key getUserBySSHKeyFingerprint(final String fingerprint) throws GitLabApiException {
+        final MultivaluedMap<String, String> queryParams = new MultivaluedHashMap<>();
         queryParams.put("fingerprint", Collections.singletonList(fingerprint));
-        Response response = get(Response.Status.OK, queryParams, "keys");
+        final Response response = get(Response.Status.OK, queryParams, "keys");
         return response.readEntity(Key.class);
     }
 }

--- a/src/main/java/org/gitlab4j/api/LabelsApi.java
+++ b/src/main/java/org/gitlab4j/api/LabelsApi.java
@@ -3,10 +3,8 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Label;
 
 /**
@@ -17,549 +15,740 @@ import org.gitlab4j.api.models.Label;
  */
 public class LabelsApi extends AbstractApi {
 
-    public LabelsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public LabelsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Get all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's labels
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Label> getProjectLabels(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectLabels(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Get all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's labels
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Label> getProjectLabels(final Object projectIdOrPath) throws GitLabApiException {
+    return (getProjectLabels(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Pager of all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of items per page
-     * @return a list of project's labels in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Label> getProjectLabels(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Label>(this, Label.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels"));
-    }
+  /**
+   * Get a Pager of all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of items per page
+   * @return a list of project's labels in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Label> getProjectLabels(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Label>(
+        this,
+        Label.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "labels"));
+  }
 
-    /**
-     * Get a Stream of all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's labels
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Label> getProjectLabelsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectLabels(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's labels
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Label> getProjectLabelsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectLabels(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get a single project label.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return a Label instance holding the information for the group label
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label getProjectLabel(Object projectIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Get a single project label.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return a Label instance holding the information for the group label
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label getProjectLabel(final Object projectIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName));
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Get a single project label as the value of an Optional.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return a Optional instance with a Label instance as its value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<Label> getOptionalProjectLabel(Object projectIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getProjectLabel(projectIdOrPath, labelIdOrName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+  /**
+   * Get a single project label as the value of an Optional.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return a Optional instance with a Label instance as its value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<Label> getOptionalProjectLabel(
+      final Object projectIdOrPath, final Object labelIdOrName) throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getProjectLabel(projectIdOrPath, labelIdOrName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Create a project label.  A Label instance is used to set the label properties.
-     * withXXX() methods are provided to set the properties of the label to create:
-     * <pre><code>
-     *   // name and color properties are required
-     *   Label labelProperties = new Label()
-     *          .withName("a-pink-project-label")
-     *          .withColor("pink")
-     *          .withDescription("A new pink project label")
-     *       .withPriority(10);
-     *   gitLabApi.getLabelsApi().createProjectLabel(projectId, labelProperties);
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/labels</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelProperties a Label instance holding the properties for the new group label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label createProjectLabel(Object projectIdOrPath, Label labelProperties) throws GitLabApiException {
-        GitLabApiForm formData = labelProperties.getForm(true);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "labels");
-        return (response.readEntity(Label.class));
+  /**
+   * Create a project label. A Label instance is used to set the label properties. withXXX() methods
+   * are provided to set the properties of the label to create:
+   *
+   * <pre><code>
+   *   // name and color properties are required
+   *   Label labelProperties = new Label()
+   *          .withName("a-pink-project-label")
+   *          .withColor("pink")
+   *          .withDescription("A new pink project label")
+   *       .withPriority(10);
+   *   gitLabApi.getLabelsApi().createProjectLabel(projectId, labelProperties);
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/labels</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelProperties a Label instance holding the properties for the new group label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label createProjectLabel(final Object projectIdOrPath, final Label labelProperties)
+      throws GitLabApiException {
+    final GitLabApiForm formData = labelProperties.getForm(true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels");
+    return (response.readEntity(Label.class));
+  }
+
+  /**
+   * Update the specified project label. The name, color, and description can be updated. A Label
+   * instance is used to set the properties of the label to update, withXXX() methods are provided
+   * to set the properties to update:
+   *
+   * <pre><code>
+   *   Label labelUpdates = new Label()
+   *        .withName("a-new-name")
+   *        .withColor("red")
+   *        .withDescription("A red group label");
+   *   gitLabApi.getLabelsApi().updateGroupLabel(projectId, labelId, labelUpdates);
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/labels/:label_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @param labelConfig a Label instance holding the label properties to update
+   * @return the updated Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label updateProjectLabel(
+      final Object projectIdOrPath, final Object labelIdOrName, final Label labelConfig)
+      throws GitLabApiException {
+    final GitLabApiForm formData = labelConfig.getForm(false);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName));
+    return (response.readEntity(Label.class));
+  }
+
+  /**
+   * Delete the specified project label.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteProjectLabel(final Object projectIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "labels",
+        getLabelIdOrName(labelIdOrName));
+  }
+
+  /**
+   * Subscribe a specified project label.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label subscribeProjectLabel(final Object projectIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.NOT_MODIFIED,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName),
+            "subscribe");
+    return (response.readEntity(Label.class));
+  }
+
+  /**
+   * Unsubscribe a specified project label.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label unsubscribeProjectLabel(final Object projectIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.NOT_MODIFIED,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName),
+            "unsubscribe");
+    return (response.readEntity(Label.class));
+  }
+
+  /**
+   * Get all labels of the specified group.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a list of group's labels
+   * @throws org.gitlab4j.api.GitLabApiException if any exception occurs
+   */
+  public List<Label> getGroupLabels(final Object groupIdOrPath) throws GitLabApiException {
+    return (getGroupLabels(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of all labels of the specified group.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param itemsPerPage the number of items per page
+   * @return a list of group's labels in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Label> getGroupLabels(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Label>(
+        this,
+        Label.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "labels"));
+  }
+
+  /**
+   * Get a Stream of all labels of the specified group.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a Stream of group's labels
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Label> getGroupLabelsStream(final Object groupIdOrPath) throws GitLabApiException {
+    return (getGroupLabels(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single group label.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return a Label instance holding the information for the group label
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label getGroupLabel(final Object groupIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName));
+    return (response.readEntity(Label.class));
+  }
+
+  /**
+   * Get a single group label as the value of an Optional.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return a Optional instance with a Label instance as its value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<Label> getOptionalGroupLabel(
+      final Object groupIdOrPath, final Object labelIdOrName) throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getGroupLabel(groupIdOrPath, labelIdOrName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Update the specified project label. The name, color, and description can be updated.
-     * A Label instance is used to set the properties of the label to update,
-     * withXXX() methods are provided to set the properties to update:
-     * <pre><code>
-     *   Label labelUpdates = new Label()
-     *        .withName("a-new-name")
-     *        .withColor("red")
-     *        .withDescription("A red group label");
-     *   gitLabApi.getLabelsApi().updateGroupLabel(projectId, labelId, labelUpdates);
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/labels/:label_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @param labelConfig a Label instance holding the label properties to update
-     * @return the updated Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label updateProjectLabel(Object projectIdOrPath, Object labelIdOrName, Label labelConfig) throws GitLabApiException {
-        GitLabApiForm formData = labelConfig.getForm(false);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Create a group label. A Label instance is used to set the label properties. withXXX() methods
+   * are provided to set the properties of the label to create:
+   *
+   * <pre><code>
+   *   Label labelProperties = new Label()
+   *       .withName("a-name")
+   *       .withColor("green")
+   *       .withDescription("A new green group label");
+   *   gitLabApi.getLabelsApi().createGroupLabel(projectId, labelProperties);
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/labels</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelProperties a Label instance holding the properties for the new group label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label createGroupLabel(final Object groupIdOrPath, final Label labelProperties)
+      throws GitLabApiException {
+    final GitLabApiForm formData = labelProperties.getForm(true);
+    final Response response =
+        post(
+            Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "labels");
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Delete the specified project label.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteProjectLabel(Object projectIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-    }
+  /**
+   * Update the specified label. The name, color, and description can be updated. A Label instance
+   * is used to set the properties of the label to update, withXXX() methods are provided to set the
+   * properties to update:
+   *
+   * <pre><code>
+   *   Label labelUpdates = new Label()
+   *       .withName("a-new-name")
+   *       .withColor("red")
+   *       .withDescription("A red group label");
+   *   gitLabApi.getLabelsApi().updateGroupLabel(projectId, labelId, labelUpdates);
+   * </code></pre>
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/labels/:label_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @param labelConfig a Label instance holding the label properties to update
+   * @return the updated Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label updateGroupLabel(
+      final Object groupIdOrPath, final Object labelIdOrName, final Label labelConfig)
+      throws GitLabApiException {
+    final GitLabApiForm formData = labelConfig.getForm(false);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName));
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Subscribe a specified project label.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label subscribeProjectLabel(Object projectIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = post(Response.Status.NOT_MODIFIED, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels", getLabelIdOrName(labelIdOrName), "subscribe");
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Delete the specified label
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteGroupLabel(final Object groupIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "labels",
+        getLabelIdOrName(labelIdOrName));
+  }
 
-    /**
-     * Unsubscribe a specified project label.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label unsubscribeProjectLabel(Object projectIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = post(Response.Status.NOT_MODIFIED, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels", getLabelIdOrName(labelIdOrName), "unsubscribe");
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Subscribe a specified group label.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label subscribeGroupLabel(final Object groupIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.NOT_MODIFIED,
+            getDefaultPerPageParam(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName),
+            "subscribe");
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Get all labels of the specified group.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a list of group's labels
-     * @throws org.gitlab4j.api.GitLabApiException if any exception occurs
-     */
-    public List<Label> getGroupLabels(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupLabels(groupIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Unsubscribe a specified group label.
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Label unsubscribeGroupLabel(final Object groupIdOrPath, final Object labelIdOrName)
+      throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.NOT_MODIFIED,
+            getDefaultPerPageParam(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "labels",
+            getLabelIdOrName(labelIdOrName),
+            "unsubscribe");
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Get a Pager of all labels of the specified group.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param itemsPerPage the number of items per page
-     * @return a list of group's labels in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Label> getGroupLabels(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Label>(this, Label.class, itemsPerPage, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "labels"));
-    }
+  /**
+   * Get all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's labels
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #getProjectLabels(Object)} method.
+   */
+  @Deprecated
+  public List<Label> getLabels(final Object projectIdOrPath) throws GitLabApiException {
+    return (getLabels(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Stream of all labels of the specified group.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a Stream of group's labels
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Label> getGroupLabelsStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupLabels(groupIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get all labels of the specified project to using the specified page and per page setting
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of items per page
+   * @return a list of project's labels in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in the next major release (6.0.0)
+   */
+  @Deprecated
+  public List<Label> getLabels(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            jakarta.ws.rs.core.Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels");
+    return (response.readEntity(new GenericType<List<Label>>() {}));
+  }
 
-    /**
-     * Get a single group label.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return a Label instance holding the information for the group label
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label getGroupLabel(Object groupIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Get a Pager of all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of items per page
+   * @return a list of project's labels in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #getProjectLabels(Object, int)} method.
+   */
+  @Deprecated
+  public Pager<Label> getLabels(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Label>(
+        this,
+        Label.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "labels"));
+  }
 
-    /**
-     * Get a single group label as the value of an Optional.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return a Optional instance with a Label instance as its value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<Label> getOptionalGroupLabel(Object groupIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getGroupLabel(groupIdOrPath, labelIdOrName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
+  /**
+   * Get a Stream of all labels of the specified project.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's labels
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #getProjectLabelsStream(Object)} method.
+   */
+  @Deprecated
+  public Stream<Label> getLabelsStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getLabels(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Create a group label.  A Label instance is used to set the label properties.
-     * withXXX() methods are provided to set the properties of the label to create:
-     * <pre><code>
-     *   Label labelProperties = new Label()
-     *       .withName("a-name")
-     *       .withColor("green")
-     *       .withDescription("A new green group label");
-     *   gitLabApi.getLabelsApi().createGroupLabel(projectId, labelProperties);
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/labels</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelProperties a Label instance holding the properties for the new group label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label createGroupLabel(Object groupIdOrPath, Label labelProperties) throws GitLabApiException {
-        GitLabApiForm formData = labelProperties.getForm(true);
-        Response response = post(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "labels");
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Create a label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param color the color for the label
+   * @param description the description for the label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
+   */
+  @Deprecated
+  public Label createLabel(
+      final Object projectIdOrPath, final String name, final String color, final String description)
+      throws GitLabApiException {
+    return (createLabel(projectIdOrPath, name, color, description, null));
+  }
 
-    /**
-     * Update the specified label. The name, color, and description can be updated.
-     * A Label instance is used to set the properties of the label to update,
-     * withXXX() methods are provided to set the properties to update:
-     * <pre><code>
-     *   Label labelUpdates = new Label()
-     *       .withName("a-new-name")
-     *       .withColor("red")
-     *       .withDescription("A red group label");
-     *   gitLabApi.getLabelsApi().updateGroupLabel(projectId, labelId, labelUpdates);
-     * </code></pre>
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/labels/:label_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @param labelConfig a Label instance holding the label properties to update
-     * @return the updated Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label updateGroupLabel(Object groupIdOrPath, Object labelIdOrName, Label labelConfig) throws GitLabApiException {
-        GitLabApiForm formData = labelConfig.getForm(false);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "groups", getGroupIdOrPath(groupIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Create a label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param color the color for the label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
+   */
+  @Deprecated
+  public Label createLabel(final Object projectIdOrPath, final String name, final String color)
+      throws GitLabApiException {
+    return (createLabel(projectIdOrPath, name, color, null, null));
+  }
 
-    /**
-     * Delete the specified label
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteGroupLabel(Object groupIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        delete(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "labels", getLabelIdOrName(labelIdOrName));
-    }
+  /**
+   * Create a label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param color the color for the label
+   * @param priority the priority for the label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
+   */
+  @Deprecated
+  public Label createLabel(
+      final Object projectIdOrPath, final String name, final String color, final Integer priority)
+      throws GitLabApiException {
+    return (createLabel(projectIdOrPath, name, color, null, priority));
+  }
 
-    /**
-     * Subscribe a specified group label.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label subscribeGroupLabel(Object groupIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = post(Response.Status.NOT_MODIFIED, getDefaultPerPageParam(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "labels", getLabelIdOrName(labelIdOrName), "subscribe");
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Create a label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param color the color for the label
+   * @param description the description for the label
+   * @param priority the priority for the label
+   * @return the created Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
+   */
+  @Deprecated
+  public Label createLabel(
+      final Object projectIdOrPath,
+      final String name,
+      final String color,
+      final String description,
+      final Integer priority)
+      throws GitLabApiException {
+    final Label labelProperties =
+        new Label()
+            .withName(name)
+            .withColor(color)
+            .withDescription(description)
+            .withPriority(priority);
+    return (createProjectLabel(projectIdOrPath, labelProperties));
+  }
 
-    /**
-     * Unsubscribe a specified group label.
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param labelIdOrName the label in the form of an Long(ID), String(name), or Label instance
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Label unsubscribeGroupLabel(Object groupIdOrPath, Object labelIdOrName) throws GitLabApiException {
-        Response response = post(Response.Status.NOT_MODIFIED, getDefaultPerPageParam(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "labels", getLabelIdOrName(labelIdOrName), "unsubscribe");
-        return (response.readEntity(Label.class));
-    }
+  /**
+   * Update the specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param newName the new name for the label
+   * @param description the description for the label
+   * @param priority the priority for the label
+   * @return the modified Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)}
+   *     method.
+   */
+  @Deprecated
+  public Label updateLabelName(
+      final Object projectIdOrPath,
+      final String name,
+      final String newName,
+      final String description,
+      final Integer priority)
+      throws GitLabApiException {
+    return (updateLabel(projectIdOrPath, name, newName, null, description, priority));
+  }
 
+  /**
+   * Update the specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param color the color for the label
+   * @param description the description for the label
+   * @param priority the priority for the label
+   * @return the modified Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)}
+   *     method.
+   */
+  @Deprecated
+  public Label updateLabelColor(
+      final Object projectIdOrPath,
+      final String name,
+      final String color,
+      final String description,
+      final Integer priority)
+      throws GitLabApiException {
+    return (updateLabel(projectIdOrPath, name, null, color, description, priority));
+  }
 
-    /**
-     * Get all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's labels
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #getProjectLabels(Object)} method.
-     */
-    @Deprecated
-    public List<Label> getLabels(Object projectIdOrPath) throws GitLabApiException {
-        return (getLabels(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Update the specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @param newName the new name for the label
+   * @param color the color for the label
+   * @param description the description for the label
+   * @param priority the priority for the label
+   * @return the modified Label instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)}
+   *     method.
+   */
+  @Deprecated
+  public Label updateLabel(
+      final Object projectIdOrPath,
+      final String name,
+      final String newName,
+      final String color,
+      final String description,
+      final Integer priority)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("new_name", newName)
+            .withParam("color", color)
+            .withParam("description", description)
+            .withParam("priority", priority);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "labels");
+    return (response.readEntity(Label.class));
+  }
 
-    /**
-     * Get all labels of the specified project to using the specified page and per page setting
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of items per page
-     * @return a list of project's labels in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in the next major release (6.0.0)
-     */
-    @Deprecated
-    public List<Label> getLabels(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(javax.ws.rs.core.Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels");
-        return (response.readEntity(new GenericType<List<Label>>() {}));
-    }
+  /**
+   * Delete the specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param name the name for the label
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #deleteProjectLabel(Object, Object)} method.
+   */
+  @Deprecated
+  public void deleteLabel(final Object projectIdOrPath, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("name", name, true);
+    delete(
+        Response.Status.OK,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "labels");
+  }
 
-    /**
-     * Get a Pager of all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of items per page
-     * @return a list of project's labels in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #getProjectLabels(Object, int)} method.
-     */
-    @Deprecated
-    public Pager<Label> getLabels(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Label>(this, Label.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels"));
-    }
+  /**
+   * Subscribe a specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelId the label ID
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #subscribeProjectLabel(Object, Object)} method.
+   */
+  @Deprecated
+  public Label subscribeLabel(final Object projectIdOrPath, final Long labelId)
+      throws GitLabApiException {
+    return (subscribeProjectLabel(projectIdOrPath, labelId));
+  }
 
-    /**
-     * Get a Stream of all labels of the specified project.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's labels
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #getProjectLabelsStream(Object)} method.
-     */
-    @Deprecated
-    public Stream<Label> getLabelsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getLabels(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Create a label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name        the name for the label
-     * @param color       the color for the label
-     * @param description the description for the label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
-     */
-    @Deprecated
-    public Label createLabel(Object projectIdOrPath, String name, String color, String description) throws GitLabApiException {
-        return (createLabel(projectIdOrPath, name, color, description, null));
-    }
-
-    /**
-     * Create a label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param color the color for the label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
-     */
-    @Deprecated
-    public Label createLabel(Object projectIdOrPath, String name, String color) throws GitLabApiException {
-        return (createLabel(projectIdOrPath, name, color, null, null));
-    }
-
-    /**
-     * Create a label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param color the color for the label
-     * @param priority the priority for the label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
-     */
-    @Deprecated
-    public Label createLabel(Object projectIdOrPath, String name, String color, Integer priority) throws GitLabApiException {
-        return (createLabel(projectIdOrPath, name, color, null, priority));
-    }
-
-    /**
-     *  Create a label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param color the color for the label
-     * @param description the description for the label
-     * @param priority the priority for the label
-     * @return the created Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #createProjectLabel(Object, Label)} method.
-     */
-    @Deprecated
-    public Label createLabel(Object projectIdOrPath, String name, String color, String description, Integer priority) throws GitLabApiException {
-        Label labelProperties = new Label()
-                .withName(name)
-                .withColor(color)
-                .withDescription(description)
-                .withPriority(priority);
-        return (createProjectLabel(projectIdOrPath, labelProperties));
-    }
-
-    /**
-     * Update the specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param newName the new name for the label
-     * @param description the description for the label
-     * @param priority the priority for the label
-     * @return the modified Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)} method.
-     */
-    @Deprecated
-    public Label updateLabelName(Object projectIdOrPath, String name, String newName, String description, Integer priority) throws GitLabApiException {
-        return (updateLabel(projectIdOrPath, name, newName, null, description, priority));
-    }
-
-    /**
-     * Update the specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param color the color for the label
-     * @param description the description for the label
-     * @param priority the priority for the label
-     * @return the modified Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)} method.
-     */
-    @Deprecated
-    public Label updateLabelColor(Object projectIdOrPath, String name, String color, String description, Integer priority) throws GitLabApiException {
-        return (updateLabel(projectIdOrPath, name, null, color, description, priority));
-    }
-
-    /**
-     * Update the specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @param newName the new name for the label
-     * @param color the color for the label
-     * @param description the description for the label
-     * @param priority the priority for the label
-     * @return the modified Label instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated @deprecated Replaced by the {@link #updateProjectLabel(Object, Object, Label)} method.
-     */
-    @Deprecated
-    public Label updateLabel(Object projectIdOrPath, String name, String newName, String color, String description, Integer priority) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("new_name", newName)
-                .withParam("color", color)
-                .withParam("description", description)
-                .withParam("priority", priority);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "labels");
-        return (response.readEntity(Label.class));
-    }
-
-    /**
-     * Delete the specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param name the name for the label
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #deleteProjectLabel(Object, Object)} method.
-     */
-    @Deprecated
-    public void deleteLabel(Object projectIdOrPath, String name) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("name", name, true);
-        delete(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "labels");
-    }
-
-    /**
-     * Subscribe a specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelId the label ID
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #subscribeProjectLabel(Object, Object)} method.
-     */
-    @Deprecated
-    public Label subscribeLabel(Object projectIdOrPath, Long labelId) throws GitLabApiException {
-        return (subscribeProjectLabel(projectIdOrPath, labelId));
-    }
-
-    /**
-     * Unsubscribe a specified label
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param labelId the label ID
-     * @return HttpStatusCode 503
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Replaced by the {@link #unsubscribeProjectLabel(Object, Object)} method.
-     */
-    @Deprecated
-    public Label unsubscribeLabel(Object projectIdOrPath, Long labelId) throws GitLabApiException {
-        return (unsubscribeProjectLabel(projectIdOrPath, labelId));
-    }
+  /**
+   * Unsubscribe a specified label
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param labelId the label ID
+   * @return HttpStatusCode 503
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Replaced by the {@link #unsubscribeProjectLabel(Object, Object)} method.
+   */
+  @Deprecated
+  public Label unsubscribeLabel(final Object projectIdOrPath, final Long labelId)
+      throws GitLabApiException {
+    return (unsubscribeProjectLabel(projectIdOrPath, labelId));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/LicenseApi.java
+++ b/src/main/java/org/gitlab4j/api/LicenseApi.java
@@ -3,9 +3,7 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.License;
 
 /**
@@ -14,7 +12,7 @@ import org.gitlab4j.api.models.License;
  */
 public class LicenseApi extends AbstractApi {
 
-    public LicenseApi(GitLabApi gitLabApi) {
+    public LicenseApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -27,7 +25,7 @@ public class LicenseApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public License getLicense() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "license");
+        final Response response = get(Response.Status.OK, null, "license");
         return (response.readEntity(License.class));
     }
 
@@ -41,7 +39,7 @@ public class LicenseApi extends AbstractApi {
     public Optional<License> getOptionalLicense() {
         try {
             return (Optional.ofNullable(getLicense()));
-        } catch (GitLabApiException glae) {
+        } catch (final GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
     }
@@ -80,7 +78,7 @@ public class LicenseApi extends AbstractApi {
      * @return a Pager of license template
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<License> getAllLicenses(int itemsPerPage) throws GitLabApiException {
+    public Pager<License> getAllLicenses(final int itemsPerPage) throws GitLabApiException {
         return (new Pager<License>(this, License.class, itemsPerPage, null, "licenses"));
     }
 
@@ -93,9 +91,9 @@ public class LicenseApi extends AbstractApi {
      * @return a License instance for the added license
      * @throws GitLabApiException if any exception occurs
      */
-    public License addLicense(String licenseString) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("license", licenseString, true);
-        Response response = post(Response.Status.CREATED, formData, "license");
+    public License addLicense(final String licenseString) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("license", licenseString, true);
+        final Response response = post(Response.Status.CREATED, formData, "license");
         return (response.readEntity(License.class));
     }
 
@@ -108,8 +106,8 @@ public class LicenseApi extends AbstractApi {
      * @return a License instance for the delete license
      * @throws GitLabApiException if any exception occurs
      */
-    public License deleteLicense(Long licenseId) throws GitLabApiException {
-        Response response = delete(Response.Status.OK, null, "license", licenseId);
+    public License deleteLicense(final Long licenseId) throws GitLabApiException {
+        final Response response = delete(Response.Status.OK, null, "license", licenseId);
         return (response.readEntity(License.class));
     }
 }

--- a/src/main/java/org/gitlab4j/api/LicenseTemplatesApi.java
+++ b/src/main/java/org/gitlab4j/api/LicenseTemplatesApi.java
@@ -3,9 +3,7 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.LicenseTemplate;
 
 /**
@@ -14,7 +12,7 @@ import org.gitlab4j.api.models.LicenseTemplate;
  */
 public class LicenseTemplatesApi extends AbstractApi {
 
-    public LicenseTemplatesApi(GitLabApi gitLabApi) {
+    public LicenseTemplatesApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -51,7 +49,7 @@ public class LicenseTemplatesApi extends AbstractApi {
      * @return a Pager of LicenseTemplate instances
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<LicenseTemplate> getLicenseTemplates(int itemsPerPage) throws GitLabApiException {
+    public Pager<LicenseTemplate> getLicenseTemplates(final int itemsPerPage) throws GitLabApiException {
         return (getLicenseTemplates(false, itemsPerPage));
     }
 
@@ -89,8 +87,8 @@ public class LicenseTemplatesApi extends AbstractApi {
      * @return a Pager of LicenseTemplate instances
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<LicenseTemplate> getLicenseTemplates(Boolean popular, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("popular", popular);
+    public Pager<LicenseTemplate> getLicenseTemplates(final Boolean popular, final int itemsPerPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("popular", popular);
         return (new Pager<LicenseTemplate>(this, LicenseTemplate.class, itemsPerPage, formData.asMap(), "templates", "licenses"));
     }
 
@@ -103,8 +101,8 @@ public class LicenseTemplatesApi extends AbstractApi {
      * @return a LicenseTemplate instance
      * @throws GitLabApiException if any exception occurs
      */
-    public LicenseTemplate getLicenseTemplate(String key) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "licenses", key);
+    public LicenseTemplate getLicenseTemplate(final String key) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, null, "licenses", key);
         return (response.readEntity(LicenseTemplate.class));
     }
 
@@ -116,10 +114,10 @@ public class LicenseTemplatesApi extends AbstractApi {
      * @param key The key of the license template
      * @return a single license template as the value of an Optional.
      */
-    public Optional<LicenseTemplate> getOptionalLicenseTemplate(String key) {
+    public Optional<LicenseTemplate> getOptionalLicenseTemplate(final String key) {
         try {
             return (Optional.ofNullable(getLicenseTemplate(key)));
-        } catch (GitLabApiException glae) {
+        } catch (final GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
     }

--- a/src/main/java/org/gitlab4j/api/MarkdownApi.java
+++ b/src/main/java/org/gitlab4j/api/MarkdownApi.java
@@ -1,17 +1,16 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Markdown;
 import org.gitlab4j.api.models.MarkdownRequest;
-
-import javax.ws.rs.core.Response;
 
 /**
  * This class provides an entry point to all the GitLab API markdown calls.
  */
 public class MarkdownApi extends AbstractApi {
 
-    public MarkdownApi(GitLabApi gitLabApi) {
+    public MarkdownApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -25,7 +24,7 @@ public class MarkdownApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      * @since GitLab 11.0
      */
-    public Markdown getMarkdown(String text) throws GitLabApiException {
+    public Markdown getMarkdown(final String text) throws GitLabApiException {
 
         if (!isApiVersion(ApiVersion.V4)) {
             throw new GitLabApiException("Api version must be v4");
@@ -44,13 +43,13 @@ public class MarkdownApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      * @since GitLab 11.0
      */
-    public Markdown getMarkdown(MarkdownRequest markdownRequest) throws GitLabApiException {
+    public Markdown getMarkdown(final MarkdownRequest markdownRequest) throws GitLabApiException {
 
         if (!isApiVersion(ApiVersion.V4)) {
             throw new GitLabApiException("Api version must be v4");
         }
 
-        Response response = post(Response.Status.OK, markdownRequest, "markdown");
+        final Response response = post(Response.Status.OK, markdownRequest, "markdown");
         return (response.readEntity(Markdown.class));
     }
 }

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -3,12 +3,10 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.AcceptMergeRequestParams;
 import org.gitlab4j.api.models.ApprovalRule;
@@ -25,494 +23,700 @@ import org.gitlab4j.api.models.Pipeline;
 
 /**
  * This class implements the client side API for the GitLab merge request calls.
- * @see <a href="https://docs.gitlab.com/ce/api/merge_requests.html">Merge requests API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/merge_request_approvals.html">Merge request approvals API at GitLab</a>
+ *
+ * @see <a href="https://docs.gitlab.com/ce/api/merge_requests.html">Merge requests API at
+ *     GitLab</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/merge_request_approvals.html">Merge request
+ *     approvals API at GitLab</a>
  */
 public class MergeRequestApi extends AbstractApi {
 
-    public MergeRequestApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public MergeRequestApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get all merge requests matching the filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
+   *
+   * @param filter a MergeRequestFilter instance with the filter settings
+   * @return all merge requests for the specified project matching the filter
+   * @throws GitLabApiException if any exception occursput
+   */
+  public List<MergeRequest> getMergeRequests(final MergeRequestFilter filter)
+      throws GitLabApiException {
+    return (getMergeRequests(filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all merge requests matching the filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
+   *
+   * @param filter a MergeRequestFilter instance with the filter settings
+   * @param page the page to get
+   * @param perPage the number of MergeRequest instances per page
+   * @return all merge requests for the specified project matching the filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequests(
+      final MergeRequestFilter filter, final int page, final int perPage)
+      throws GitLabApiException {
+
+    final MultivaluedMap<String, String> queryParams =
+        (filter != null
+            ? filter.getQueryParams(page, perPage).asMap()
+            : getPageQueryParams(page, perPage));
+    final Response response;
+    if (filter != null && (filter.getProjectId() != null && filter.getProjectId().intValue() > 0)
+        || (filter.getIids() != null && filter.getIids().size() > 0)) {
+
+      if (filter.getProjectId() == null || filter.getProjectId().intValue() == 0) {
+        throw new RuntimeException("project ID cannot be null or 0");
+      }
+
+      response =
+          get(Response.Status.OK, queryParams, "projects", filter.getProjectId(), "merge_requests");
+    } else {
+      response = get(Response.Status.OK, queryParams, "merge_requests");
     }
 
-    /**
-     * Get all merge requests matching the filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
-     *
-     * @param filter a MergeRequestFilter instance with the filter settings
-     * @return all merge requests for the specified project matching the filter
-     * @throws GitLabApiException if any exception occursput
-     */
-    public List<MergeRequest> getMergeRequests(MergeRequestFilter filter) throws GitLabApiException {
-        return (getMergeRequests(filter, getDefaultPerPage()).all());
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
+
+  /**
+   * Get all merge requests matching the filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
+   *
+   * @param filter a MergeRequestFilter instance with the filter settings
+   * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+   * @return all merge requests for the specified project/group matching the filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<MergeRequest> getMergeRequests(
+      final MergeRequestFilter filter, final int itemsPerPage) throws GitLabApiException {
+
+    final MultivaluedMap<String, String> queryParams =
+        (filter != null ? filter.getQueryParams().asMap() : null);
+    if (filter != null
+        && ((filter.getProjectId() != null && filter.getProjectId().intValue() > 0)
+            || (filter.getIids() != null && filter.getIids().size() > 0))) {
+
+      if (filter.getProjectId() == null || filter.getProjectId().intValue() == 0) {
+        throw new RuntimeException("project ID cannot be null or 0");
+      }
+
+      return (new Pager<MergeRequest>(
+          this,
+          MergeRequest.class,
+          itemsPerPage,
+          queryParams,
+          "projects",
+          filter.getProjectId(),
+          "merge_requests"));
+    } else if (filter != null
+        && filter.getGroupId() != null
+        && filter.getGroupId().intValue() > 0) {
+      return (new Pager<MergeRequest>(
+          this,
+          MergeRequest.class,
+          itemsPerPage,
+          queryParams,
+          "groups",
+          filter.getGroupId(),
+          "merge_requests"));
+    } else {
+      return (new Pager<MergeRequest>(
+          this, MergeRequest.class, itemsPerPage, queryParams, "merge_requests"));
     }
+  }
 
-    /**
-     * Get all merge requests matching the filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
-     *
-     * @param filter a MergeRequestFilter instance with the filter settings
-     * @param page the page to get
-     * @param perPage the number of MergeRequest instances per page
-     * @return all merge requests for the specified project matching the filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequests(MergeRequestFilter filter, int page, int perPage) throws GitLabApiException {
+  /**
+   * Get all merge requests matching the filter as a Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
+   *
+   * @param filter a MergeRequestFilter instance with the filter settings
+   * @return a Stream containing all the merge requests for the specified project matching the
+   *     filter
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<MergeRequest> getMergeRequestsStream(final MergeRequestFilter filter)
+      throws GitLabApiException {
+    return (getMergeRequests(filter, getDefaultPerPage()).stream());
+  }
 
-        MultivaluedMap<String, String> queryParams = (filter != null ?
-            filter.getQueryParams(page, perPage).asMap() : getPageQueryParams(page, perPage));
-        Response response;
-        if (filter != null && (filter.getProjectId() != null && filter.getProjectId().intValue() > 0) ||
-                (filter.getIids() != null && filter.getIids().size() > 0)) {
+  /**
+   * Get all merge requests for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequests(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-            if (filter.getProjectId() == null || filter.getProjectId().intValue() == 0) {
-                throw new RuntimeException("project ID cannot be null or 0");
-            }
+  /**
+   * Get all merge requests for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of MergeRequest instances per page
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests");
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
 
-            response = get(Response.Status.OK, queryParams, "projects", filter.getProjectId(), "merge_requests");
-        } else {
-            response = get(Response.Status.OK, queryParams, "merge_requests");
-        }
+  /**
+   * Get all merge requests for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<MergeRequest> getMergeRequests(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<MergeRequest>(
+        this,
+        MergeRequest.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests"));
+  }
 
-        return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  /**
+   * Get all merge requests for the specified project as a Stream
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream with all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<MergeRequest> getMergeRequestsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get all merge requests with a specific state for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests?state=:state</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the state parameter can be used to get only merge requests with a given state
+   *     (opened, closed, or merged) or all of them (all).
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath, final MergeRequestState state) throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, state, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get all merge requests for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the state parameter can be used to get only merge requests with a given state
+   *     (opened, closed, or merged) or all of them (all).
+   * @param page the page to get
+   * @param perPage the number of MergeRequest instances per page
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath,
+      final MergeRequestState state,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests");
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
+
+  /**
+   * Get all merge requests for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the state parameter can be used to get only merge requests with a given state
+   *     (opened, closed, or merged) or all of them (all).
+   * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+   * @return all merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<MergeRequest> getMergeRequests(
+      final Object projectIdOrPath, final MergeRequestState state, final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("state", state);
+    return (new Pager<MergeRequest>(
+        this,
+        MergeRequest.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests"));
+  }
+
+  /**
+   * Get all merge requests with a specific state for the specified project as a Stream.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests?state=:state</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the state parameter can be used to get only merge requests with a given state
+   *     (opened, closed, or merged) or all of them (all).
+   * @return a Stream with all the merge requests for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<MergeRequest> getMergeRequestsStream(
+      final Object projectIdOrPath, final MergeRequestState state) throws GitLabApiException {
+    return (getMergeRequests(projectIdOrPath, state, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get information about a single merge request.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return the specified MergeRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getMergeRequest(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return getMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null);
+  }
+
+  /**
+   * Get information about a single merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param renderHtml if true response includes rendered HTML for title and description, can be
+   *     null
+   * @param includeDivergedCommitCount if true response includes the commits behind the target
+   *     branch, can be null
+   * @param includeRebaseInProgress if true response includes whether a rebase operation is in
+   *     progress, can be null
+   * @return a MergeRequest instance as specified by the parameters
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Boolean renderHtml,
+      final Boolean includeDivergedCommitCount,
+      final Boolean includeRebaseInProgress)
+      throws GitLabApiException {
+
+    final GitLabApiForm queryParams =
+        new GitLabApiForm()
+            .withParam("render_html", renderHtml)
+            .withParam("include_diverged_commits_count", includeDivergedCommitCount)
+            .withParam("include_rebase_in_progress", includeRebaseInProgress);
+
+    final Response response =
+        get(
+            Response.Status.OK,
+            queryParams.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid);
+    return (response.readEntity(MergeRequest.class));
+  }
+
+  /**
+   * Get information about a single merge request as an Optional instance.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return the specified MergeRequest as an Optional instance instance
+   */
+  public Optional<MergeRequest> getOptionalMergeRequest(
+      final Object projectIdOrPath, final Long mergeRequestIid) {
+    return getOptionalMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null);
+  }
+
+  /**
+   * Get information about a single merge request as an Optional instance.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param renderHtml if true response includes rendered HTML for title and description, can be
+   *     null
+   * @param includeDivergedCommitCount if true response includes the commits behind the target
+   *     branch, can be null
+   * @param includeRebaseInProgress if true response includes whether a rebase operation is in
+   *     progress, can be null
+   * @return the specified MergeRequest as an Optional instance instance
+   */
+  public Optional<MergeRequest> getOptionalMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Boolean renderHtml,
+      final Boolean includeDivergedCommitCount,
+      final Boolean includeRebaseInProgress) {
+    try {
+      return (Optional.ofNullable(
+          getMergeRequest(
+              projectIdOrPath,
+              mergeRequestIid,
+              renderHtml,
+              includeDivergedCommitCount,
+              includeRebaseInProgress)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get all merge requests matching the filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
-     *
-     * @param filter a MergeRequestFilter instance with the filter settings
-     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return all merge requests for the specified project/group matching the filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<MergeRequest> getMergeRequests(MergeRequestFilter filter, int itemsPerPage) throws GitLabApiException {
+  /**
+   * Get a list of merge request commits.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a list containing the commits for the specified merge request
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
 
-        MultivaluedMap<String, String> queryParams = (filter != null ? filter.getQueryParams().asMap() : null);
-        if (filter != null && ((filter.getProjectId() != null && filter.getProjectId().intValue() > 0) ||
-                (filter.getIids() != null && filter.getIids().size() > 0))) {
+  /**
+   * Get a list of merge request commits.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param page the page to get
+   * @param perPage the number of commits per page
+   * @return a list containing the commits for the specified merge request
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public List<Commit> getCommits(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("owned", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "commits");
+    return (response.readEntity(new GenericType<List<Commit>>() {}));
+  }
 
-            if (filter.getProjectId() == null || filter.getProjectId().intValue() == 0) {
-                throw new RuntimeException("project ID cannot be null or 0");
-            }
+  /**
+   * Get a Pager of merge request commits.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param itemsPerPage the number of Commit instances that will be fetched per page
+   * @return a Pager containing the commits for the specified merge request
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Commit> getCommits(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Commit>(
+        this,
+        Commit.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "commits"));
+  }
 
-            return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "projects", filter.getProjectId(), "merge_requests"));
-        } else if (filter != null && filter.getGroupId() != null && filter.getGroupId().intValue() > 0) {
-            return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "groups", filter.getGroupId(), "merge_requests"));
-        } else {
-            return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, queryParams, "merge_requests"));
-        }
+  /**
+   * Get a Stream of merge request commits.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Stream containing the commits for the specified merge request
+   * @throws GitLabApiException GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Commit> getCommitsStream(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getCommits(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of merge request diff versions.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a List of merge request diff versions for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequestDiff> getMergeRequestDiffs(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of merge request diff versions.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+   * @return a Pager of merge request diff versions for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<MergeRequestDiff> getMergeRequestDiffs(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<MergeRequestDiff>(
+        this,
+        MergeRequestDiff.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "versions"));
+  }
+
+  /**
+   * Get a Stream of merge request diff versions.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Stream of merge request diff versions for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<MergeRequestDiff> getMergeRequestDiffsStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single merge request diff version.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param versionId the ID of the merge request diff version
+   * @return a MergeRequestDiff instance for the specified MR diff version
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequestDiff getMergeRequestDiff(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long versionId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "versions",
+            versionId);
+    return (response.readEntity(MergeRequestDiff.class));
+  }
+
+  /**
+   * Get a single merge request diff version as an Optional instance.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param versionId the ID of the merge request diff version
+   * @return the specified MergeRequestDiff as an Optional instance instance
+   */
+  public Optional<MergeRequestDiff> getOptionalMergeRequestDiff(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long versionId) {
+    try {
+      return (Optional.ofNullable(
+          getMergeRequestDiff(projectIdOrPath, mergeRequestIid, versionId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get all merge requests matching the filter as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /merge_requests</code></pre>
-     *
-     * @param filter a MergeRequestFilter instance with the filter settings
-     * @return a Stream containing all the merge requests for the specified project matching the filter
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<MergeRequest> getMergeRequestsStream(MergeRequestFilter filter) throws GitLabApiException {
-        return (getMergeRequests(filter, getDefaultPerPage()).stream());
-    }
+  /**
+   * Creates a merge request.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param params a MergeRequestParams instance holding the info to create the merge request
+   * @return the created MergeRequest instance
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab Starter 8.17, GitLab CE 11.0.
+   */
+  public MergeRequest createMergeRequest(
+      final Object projectIdOrPath, final MergeRequestParams params) throws GitLabApiException {
+    final GitLabApiForm form = params.getForm(true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            form,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-    /**
-     * Get all merge requests for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Creates a merge request.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sourceBranch the source branch, required
+   * @param targetBranch the target branch, required
+   * @param title the title for the merge request, required
+   * @param description the description of the merge request
+   * @param assigneeId the Assignee user ID, optional
+   * @param targetProjectId the ID of a target project, optional
+   * @param labels labels for MR, optional
+   * @param milestoneId the ID of a milestone, optional
+   * @param removeSourceBranch Flag indicating if a merge request should remove the source branch
+   *     when merging, optional
+   * @param squash Squash commits into a single commit when merging, optional
+   * @return the created MergeRequest instance
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab Starter 8.17, GitLab CE 11.0.
+   */
+  public MergeRequest createMergeRequest(
+      final Object projectIdOrPath,
+      final String sourceBranch,
+      final String targetBranch,
+      final String title,
+      final String description,
+      final Long assigneeId,
+      final Long targetProjectId,
+      final String[] labels,
+      final Long milestoneId,
+      final Boolean removeSourceBranch,
+      final Boolean squash)
+      throws GitLabApiException {
 
-    /**
-     * Get all merge requests for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of MergeRequest instances per page
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests");
-        return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
-    }
-
-    /**
-     * Get all merge requests for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<MergeRequest> getMergeRequests(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests"));
-    }
-
-    /**
-     * Get all merge requests for the specified project as a Stream
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream with all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<MergeRequest> getMergeRequestsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get all merge requests with a specific state for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests?state=:state</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the state parameter can be used to get only merge requests with a given state (opened, closed, or merged) or all of them (all).
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath, MergeRequestState state) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, state, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get all merge requests for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the state parameter can be used to get only merge requests with a given state (opened, closed, or merged) or all of them (all).
-     * @param page the page to get
-     * @param perPage the number of MergeRequest instances per page
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequests(Object projectIdOrPath, MergeRequestState state, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("state", state)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests");
-        return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
-    }
-
-    /**
-     * Get all merge requests for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the state parameter can be used to get only merge requests with a given state (opened, closed, or merged) or all of them (all).
-     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return all merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<MergeRequest> getMergeRequests(Object projectIdOrPath, MergeRequestState state, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("state", state);
-        return (new Pager<MergeRequest>(this, MergeRequest.class, itemsPerPage, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests"));
-    }
-
-    /**
-     * Get all merge requests with a specific state for the specified project as a Stream.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests?state=:state</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the state parameter can be used to get only merge requests with a given state (opened, closed, or merged) or all of them (all).
-     * @return a Stream with all the merge requests for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<MergeRequest> getMergeRequestsStream(Object projectIdOrPath, MergeRequestState state) throws GitLabApiException {
-        return (getMergeRequests(projectIdOrPath, state, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get information about a single merge request.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return the specified MergeRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return getMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null);
-    }
-
-    /**
-     * Get information about a single merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param renderHtml if true response includes rendered HTML for title and description, can be null
-     * @param includeDivergedCommitCount if true response includes the commits behind the target branch, can be null
-     * @param includeRebaseInProgress if true response includes whether a rebase operation is in progress, can be null
-     * @return a MergeRequest instance as specified by the parameters
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-                                        Boolean renderHtml, Boolean includeDivergedCommitCount, Boolean includeRebaseInProgress) throws GitLabApiException {
-
-        GitLabApiForm queryParams = new GitLabApiForm()
-                .withParam("render_html", renderHtml)
-                .withParam("include_diverged_commits_count", includeDivergedCommitCount)
-                .withParam("include_rebase_in_progress", includeRebaseInProgress);
-
-        Response response = get(Response.Status.OK, queryParams.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid);
-        return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Get information about a single merge request as an Optional instance.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return the specified MergeRequest as an Optional instance instance
-     */
-    public Optional<MergeRequest> getOptionalMergeRequest(Object projectIdOrPath, Long mergeRequestIid) {
-        return getOptionalMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null);
-    }
-
-    /**
-     * Get information about a single merge request as an Optional instance.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param renderHtml if true response includes rendered HTML for title and description, can be null
-     * @param includeDivergedCommitCount if true response includes the commits behind the target branch, can be null
-     * @param includeRebaseInProgress if true response includes whether a rebase operation is in progress, can be null
-     * @return the specified MergeRequest as an Optional instance instance
-     */
-    public Optional<MergeRequest> getOptionalMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-                                                          Boolean renderHtml, Boolean includeDivergedCommitCount , Boolean includeRebaseInProgress) {
-        try {
-            return (Optional.ofNullable(getMergeRequest(projectIdOrPath, mergeRequestIid, renderHtml, includeDivergedCommitCount, includeRebaseInProgress)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Get a list of merge request commits.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a list containing the commits for the specified merge request
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of merge request commits.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param page the page to get
-     * @param perPage the number of commits per page
-     * @return a list containing the commits for the specified merge request
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public List<Commit> getCommits(Object projectIdOrPath, Long mergeRequestIid, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("owned", true).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "commits");
-        return (response.readEntity(new GenericType<List<Commit>>() {}));
-    }
-
-    /**
-     * Get a Pager of merge request commits.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param itemsPerPage the number of Commit instances that will be fetched per page
-     * @return a Pager containing the commits for the specified merge request
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Commit> getCommits(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Commit>(this, Commit.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "commits"));
-    }
-
-    /**
-     * Get a Stream of merge request commits.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/commits</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Stream containing the commits for the specified merge request
-     * @throws GitLabApiException GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Commit> getCommitsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getCommits(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of merge request diff versions.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a List of merge request diff versions for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-	return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of merge request diff versions.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
-     * @return a Pager of merge request diff versions for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<MergeRequestDiff>(this, MergeRequestDiff.class, itemsPerPage, null,
-        	"projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "versions"));
-    }
-
-    /**
-     * Get a Stream of merge request diff versions.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Stream of merge request diff versions for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<MergeRequestDiff> getMergeRequestDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single merge request diff version.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param versionId the ID of the merge request diff version
-     * @return a MergeRequestDiff instance for the specified MR diff version
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequestDiff getMergeRequestDiff(Object projectIdOrPath,
-	    Long mergeRequestIid, Long versionId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "versions", versionId);
-        return (response.readEntity(MergeRequestDiff.class));
-    }
-
-    /**
-     * Get a single merge request diff version as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param versionId the ID of the merge request diff version
-     * @return the specified MergeRequestDiff as an Optional instance instance
-     */
-    public Optional<MergeRequestDiff> getOptionalMergeRequestDiff(
-	    Object projectIdOrPath, Long mergeRequestIid, Long versionId) {
-        try {
-            return (Optional.ofNullable(getMergeRequestDiff(projectIdOrPath, mergeRequestIid, versionId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a merge request.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param params a MergeRequestParams instance holding the info to create the merge request
-     * @return the created MergeRequest instance
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab Starter 8.17, GitLab CE 11.0.
-     */
-    public MergeRequest createMergeRequest(Object projectIdOrPath, MergeRequestParams params) throws GitLabApiException {
-	GitLabApiForm form = params.getForm(true);
-        Response response = post(Response.Status.CREATED, form, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests");
-        return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Creates a merge request.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sourceBranch the source branch, required
-     * @param targetBranch the target branch, required
-     * @param title the title for the merge request, required
-     * @param description the description of the merge request
-     * @param assigneeId the Assignee user ID, optional
-     * @param targetProjectId the ID of a target project, optional
-     * @param labels labels for MR, optional
-     * @param milestoneId the ID of a milestone, optional
-     * @param removeSourceBranch Flag indicating if a merge request should remove the source branch when merging, optional
-     * @param squash Squash commits into a single commit when merging, optional
-     * @return the created MergeRequest instance
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab Starter 8.17, GitLab CE 11.0.
-     */
-    public MergeRequest createMergeRequest(Object projectIdOrPath, String sourceBranch, String targetBranch, String title, String description, Long assigneeId,
-            Long targetProjectId, String[] labels, Long milestoneId, Boolean removeSourceBranch, Boolean squash) throws GitLabApiException {
-
-        MergeRequestParams params = new MergeRequestParams()
+    final MergeRequestParams params =
+        new MergeRequestParams()
             .withSourceBranch(sourceBranch)
             .withTargetBranch(targetBranch)
             .withTitle(title)
@@ -524,792 +728,1147 @@ public class MergeRequestApi extends AbstractApi {
             .withRemoveSourceBranch(removeSourceBranch)
             .withSquash(squash);
 
-        return(createMergeRequest(projectIdOrPath, params));
+    return (createMergeRequest(projectIdOrPath, params));
+  }
+
+  /**
+   * Creates a merge request.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sourceBranch the source branch, required
+   * @param targetBranch the target branch, required
+   * @param title the title for the merge request, required
+   * @param description the description of the merge request
+   * @param assigneeId the Assignee user ID, optional
+   * @param targetProjectId the ID of a target project, optional
+   * @param labels labels for MR, optional
+   * @param milestoneId the ID of a milestone, optional
+   * @param removeSourceBranch Flag indicating if a merge request should remove the source branch
+   *     when merging, optional
+   * @return the created MergeRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest createMergeRequest(
+      final Object projectIdOrPath,
+      final String sourceBranch,
+      final String targetBranch,
+      final String title,
+      final String description,
+      final Long assigneeId,
+      final Long targetProjectId,
+      final String[] labels,
+      final Long milestoneId,
+      final Boolean removeSourceBranch)
+      throws GitLabApiException {
+
+    final MergeRequestParams params =
+        new MergeRequestParams()
+            .withSourceBranch(sourceBranch)
+            .withTargetBranch(targetBranch)
+            .withTitle(title)
+            .withDescription(description)
+            .withAssigneeId(assigneeId)
+            .withTargetProjectId(targetProjectId)
+            .withLabels(labels)
+            .withMilestoneId(milestoneId)
+            .withRemoveSourceBranch(removeSourceBranch);
+
+    return (createMergeRequest(projectIdOrPath, params));
+  }
+
+  /**
+   * Creates a merge request and optionally assigns a reviewer to it.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sourceBranch the source branch, required
+   * @param targetBranch the target branch, required
+   * @param title the title for the merge request, required
+   * @param description the description of the merge request
+   * @param assigneeId the Assignee user ID, optional
+   * @return the created MergeRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest createMergeRequest(
+      final Object projectIdOrPath,
+      final String sourceBranch,
+      final String targetBranch,
+      final String title,
+      final String description,
+      final Long assigneeId)
+      throws GitLabApiException {
+
+    final MergeRequestParams params =
+        new MergeRequestParams()
+            .withSourceBranch(sourceBranch)
+            .withTargetBranch(targetBranch)
+            .withTitle(title)
+            .withDescription(description)
+            .withAssigneeId(assigneeId);
+
+    return (createMergeRequest(projectIdOrPath, params));
+  }
+
+  /**
+   * Updates an existing merge request. You can change branches, title, or even close the merge
+   * request.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request to update
+   * @param params a MergeRequestParams instance holding the info to update the merge request
+   * @return the updated merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest updateMergeRequest(
+      final Object projectIdOrPath, final Long mergeRequestIid, final MergeRequestParams params)
+      throws GitLabApiException {
+    final GitLabApiForm form = params.getForm(false);
+    final Response response =
+        put(
+            Response.Status.OK,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid);
+    return (response.readEntity(MergeRequest.class));
+  }
+
+  /**
+   * Updates an existing merge request. You can change branches, title, or even close the MR.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request to update
+   * @param targetBranch the target branch, optional
+   * @param title the title for the merge request
+   * @param assigneeId the Assignee user ID, optional
+   * @param description the description of the merge request, optional
+   * @param stateEvent new state for the merge request, optional
+   * @param labels comma separated list of labels, optional
+   * @param milestoneId the ID of a milestone, optional
+   * @param removeSourceBranch Flag indicating if a merge request should remove the source branch
+   *     when merging, optional
+   * @param squash Squash commits into a single commit when merging, optional
+   * @param discussionLocked Flag indicating if the merge request's discussion is locked, optional
+   * @param allowCollaboration Allow commits from members who can merge to the target branch,
+   *     optional
+   * @return the updated merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest updateMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String targetBranch,
+      final String title,
+      final Long assigneeId,
+      final String description,
+      final StateEvent stateEvent,
+      final String labels,
+      final Long milestoneId,
+      final Boolean removeSourceBranch,
+      final Boolean squash,
+      final Boolean discussionLocked,
+      final Boolean allowCollaboration)
+      throws GitLabApiException {
+
+    String[] labelsArray = null;
+    if (labels != null) {
+      labelsArray = labels.split(",", -1);
     }
 
-    /**
-     * Creates a merge request.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sourceBranch the source branch, required
-     * @param targetBranch the target branch, required
-     * @param title the title for the merge request, required
-     * @param description the description of the merge request
-     * @param assigneeId the Assignee user ID, optional
-     * @param targetProjectId the ID of a target project, optional
-     * @param labels labels for MR, optional
-     * @param milestoneId the ID of a milestone, optional
-     * @param removeSourceBranch Flag indicating if a merge request should remove the source branch when merging, optional
-     * @return the created MergeRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest createMergeRequest(Object projectIdOrPath, String sourceBranch, String targetBranch, String title, String description, Long assigneeId,
-                Long targetProjectId, String[] labels, Long milestoneId, Boolean removeSourceBranch) throws GitLabApiException {
+    final MergeRequestParams params =
+        new MergeRequestParams()
+            .withTargetBranch(targetBranch)
+            .withTitle(title)
+            .withAssigneeId(assigneeId)
+            .withDescription(description)
+            .withStateEvent(stateEvent)
+            .withLabels(labelsArray)
+            .withMilestoneId(milestoneId)
+            .withRemoveSourceBranch(removeSourceBranch)
+            .withDiscussionLocked(discussionLocked)
+            .withAllowCollaboration(allowCollaboration)
+            .withSquash(squash);
 
-	MergeRequestParams params = new MergeRequestParams()
-	    .withSourceBranch(sourceBranch)
-	    .withTargetBranch(targetBranch)
-	    .withTitle(title)
-	    .withDescription(description)
-	    .withAssigneeId(assigneeId)
-	    .withTargetProjectId(targetProjectId)
-	    .withLabels(labels)
-	    .withMilestoneId(milestoneId)
-	    .withRemoveSourceBranch(removeSourceBranch);
+    return (updateMergeRequest(projectIdOrPath, mergeRequestIid, params));
+  }
 
-	return(createMergeRequest(projectIdOrPath, params));
+  /**
+   * Only for admins and project owners. Soft deletes the specified merge.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMergeRequest(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Creates a merge request and optionally assigns a reviewer to it.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sourceBranch the source branch, required
-     * @param targetBranch the target branch, required
-     * @param title the title for the merge request, required
-     * @param description the description of the merge request
-     * @param assigneeId the Assignee user ID, optional
-     * @return the created MergeRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest createMergeRequest(Object projectIdOrPath, String sourceBranch, String targetBranch, String title, String description, Long assigneeId)
-            throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid);
+  }
 
-	MergeRequestParams params = new MergeRequestParams()
-	    .withSourceBranch(sourceBranch)
-	    .withTargetBranch(targetBranch)
-	    .withTitle(title)
-	    .withDescription(description)
-	    .withAssigneeId(assigneeId);
+  /**
+   * Merge changes to the merge request. If the MR has any conflicts and can not be merged, you'll
+   * get a 405 and the error message 'Branch cannot be merged'. If merge request is already merged
+   * or closed, you'll get a 406 and the error message 'Method Not Allowed'. If the sha parameter is
+   * passed and does not match the HEAD of the source, you'll get a 409 and the error message 'SHA
+   * does not match HEAD of source branch'. If you don't have permissions to accept this merge
+   * request, you'll get a 401.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param params the MergeRequest instance holding the parameters for accepting the merge request
+   * @return the merged merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest acceptMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final AcceptMergeRequestParams params)
+      throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.OK,
+            params.getForm().asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "merge");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-	return(createMergeRequest(projectIdOrPath, params));
+  /**
+   * Merge changes to the merge request. If the MR has any conflicts and can not be merged, you'll
+   * get a 405 and the error message 'Branch cannot be merged'. If merge request is already merged
+   * or closed, you'll get a 406 and the error message 'Method Not Allowed'. If the sha parameter is
+   * passed and does not match the HEAD of the source, you'll get a 409 and the error message 'SHA
+   * does not match HEAD of source branch'. If you don't have permissions to accept this merge
+   * request, you'll get a 401.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return the merged merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest acceptMergeRequest(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (acceptMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null, null));
+  }
+
+  /**
+   * Merge changes to the merge request. If the MR has any conflicts and can not be merged, you'll
+   * get a 405 and the error message 'Branch cannot be merged'. If merge request is already merged
+   * or closed, you'll get a 406 and the error message 'Method Not Allowed'. If the sha parameter is
+   * passed and does not match the HEAD of the source, you'll get a 409 and the error message 'SHA
+   * does not match HEAD of source branch'. If you don't have permissions to accept this merge
+   * request, you'll get a 401.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   * Additionally, mergeWhenPipelineSucceeds sets the merge_when_build_succeeds flag for GitLab API
+   * V3.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param mergeCommitMessage custom merge commit message, optional
+   * @param shouldRemoveSourceBranch if true removes the source branch, optional
+   * @param mergeWhenPipelineSucceeds if true the MR is merged when the pipeline, optional
+   * @return the merged merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest acceptMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String mergeCommitMessage,
+      final Boolean shouldRemoveSourceBranch,
+      final Boolean mergeWhenPipelineSucceeds)
+      throws GitLabApiException {
+    return (acceptMergeRequest(
+        projectIdOrPath,
+        mergeRequestIid,
+        mergeCommitMessage,
+        shouldRemoveSourceBranch,
+        mergeWhenPipelineSucceeds,
+        null));
+  }
+
+  /**
+   * Merge changes to the merge request. If the MR has any conflicts and can not be merged, you'll
+   * get a 405 and the error message 'Branch cannot be merged'. If merge request is already merged
+   * or closed, you'll get a 406 and the error message 'Method Not Allowed'. If the sha parameter is
+   * passed and does not match the HEAD of the source, you'll get a 409 and the error message 'SHA
+   * does not match HEAD of source branch'. If you don't have permissions to accept this merge
+   * request, you'll get a 401.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   * Additionally, mergeWhenPipelineSucceeds sets the merge_when_build_succeeds flag for GitLab API
+   * V3.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param mergeCommitMessage custom merge commit message, optional
+   * @param shouldRemoveSourceBranch if true removes the source branch, optional
+   * @param mergeWhenPipelineSucceeds if true the MR is merged when the pipeline, optional
+   * @param sha if present, then this SHA must match the HEAD of the source branch, otherwise the
+   *     merge will fail, optional
+   * @return the merged merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest acceptMergeRequest(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final String mergeCommitMessage,
+      final Boolean shouldRemoveSourceBranch,
+      final Boolean mergeWhenPipelineSucceeds,
+      final String sha)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Updates an existing merge request. You can change branches, title, or even close the merge request.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request to update
-     * @param params a MergeRequestParams instance holding the info to update the merge request
-     * @return the updated merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest updateMergeRequest(Object projectIdOrPath, Long mergeRequestIid, MergeRequestParams params) throws GitLabApiException {
-	GitLabApiForm form = params.getForm(false);
-	Response response = put(Response.Status.OK, form.asMap(),
-		"projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid);
-	 return (response.readEntity(MergeRequest.class));
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("merge_commit_message", mergeCommitMessage)
+            .withParam("should_remove_source_branch", shouldRemoveSourceBranch)
+            .withParam(
+                (isApiVersion(ApiVersion.V3)
+                    ? "merge_when_build_succeeds"
+                    : "merge_when_pipeline_succeeds"),
+                mergeWhenPipelineSucceeds)
+            .withParam("sha", sha);
+
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "merge");
+    return (response.readEntity(MergeRequest.class));
+  }
+
+  /**
+   * Cancel merge when pipeline succeeds. If you don't have permissions to accept this merge
+   * request, you'll get a 401. If the merge request is already merged or closed, you get 405 and
+   * error message 'Method Not Allowed'. In case the merge request is not set to be merged when the
+   * pipeline succeeds, you'll also get a 406 error.
+   *
+   * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/cancel_merge_when_pipeline_succeeds</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return the updated merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest cancelMergeRequest(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Updates an existing merge request. You can change branches, title, or even close the MR.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request to update
-     * @param targetBranch the target branch, optional
-     * @param title the title for the merge request
-     * @param assigneeId the Assignee user ID, optional
-     * @param description the description of the merge request, optional
-     * @param stateEvent new state for the merge request, optional
-     * @param labels comma separated list of labels, optional
-     * @param milestoneId the ID of a milestone, optional
-     * @param removeSourceBranch Flag indicating if a merge request should remove the source
-     *                           branch when merging, optional
-     * @param squash Squash commits into a single commit when merging, optional
-     * @param discussionLocked Flag indicating if the merge request's discussion is locked, optional
-     * @param allowCollaboration Allow commits from members who can merge to the target branch,
-     *                           optional
-     * @return the updated merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest updateMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-            String targetBranch, String title, Long assigneeId, String description,
-            StateEvent stateEvent, String labels, Long milestoneId, Boolean removeSourceBranch,
-            Boolean squash, Boolean discussionLocked, Boolean allowCollaboration)
-            throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "cancel_merge_when_pipeline_succeeds");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-	String[] labelsArray = null;
-	if (labels != null) {
-	    labelsArray = labels.split(",", -1);
-	}
+  /**
+   * Get the merge request with approval information.
+   *
+   * <p>Note: This API endpoint is only available on 8.9 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approvals</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a MergeRequest instance with approval information included
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getMergeRequestApprovals(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getApprovals(projectIdOrPath, mergeRequestIid));
+  }
 
-	MergeRequestParams params = new MergeRequestParams()
-	        .withTargetBranch(targetBranch)
-	        .withTitle(title)
-	        .withAssigneeId(assigneeId)
-	        .withDescription(description)
-	        .withStateEvent(stateEvent)
-	        .withLabels(labelsArray)
-	        .withMilestoneId(milestoneId)
-	        .withRemoveSourceBranch(removeSourceBranch)
-	        .withDiscussionLocked(discussionLocked)
-	        .withAllowCollaboration(allowCollaboration)
-	        .withSquash(squash);
+  /**
+   * Get the merge request with approval information.
+   *
+   * <p>Note: This API endpoint is only available on 8.9 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approvals</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a MergeRequest instance with approval information included
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getApprovals(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
 
-        return (updateMergeRequest(projectIdOrPath, mergeRequestIid, params));
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Only for admins and project owners. Soft deletes the specified merge.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "approvals");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Get the approval state of a merge request. Note: This API endpoint is only available on 12.3
+   * Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_state</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a ApprovalState instance with approval state
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ApprovalState getApprovalState(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
 
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid);
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Merge changes to the merge request. If the MR has any conflicts and can not be merged,
-     * you'll get a 405 and the error message 'Branch cannot be merged'. If merge request is
-     * already merged or closed, you'll get a 406 and the error message 'Method Not Allowed'.
-     * If the sha parameter is passed and does not match the HEAD of the source, you'll get
-     * a 409 and the error message 'SHA does not match HEAD of source branch'.  If you don't
-     * have permissions to accept this merge request, you'll get a 401.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param params the MergeRequest instance holding the parameters for accepting the merge request
-     * @return the merged merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest acceptMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-            AcceptMergeRequestParams params) throws GitLabApiException {
-        Response response = put(Response.Status.OK, params.getForm().asMap(), "projects",
-        	getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "merge");
-        return (response.readEntity(MergeRequest.class));
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "approval_state");
+    return (response.readEntity(ApprovalState.class));
+  }
+
+  /**
+   * Get a list of the merge request level approval rules. Note: This API endpoint is only available
+   * on 12.3 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a List of ApprovalRule instances for the specified merge request.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ApprovalRule> getApprovalRules(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getApprovalRules(projectIdOrPath, mergeRequestIid, -1).all());
+  }
+
+  /**
+   * Get a Pager of the merge request level approval rules. Note: This API endpoint is only
+   * available on 12.3 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param itemsPerPage the number of ApprovalRule instances that will be fetched per page
+   * @return a Pager of ApprovalRule instances for the specified merge request.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ApprovalRule> getApprovalRules(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Merge changes to the merge request. If the MR has any conflicts and can not be merged,
-     * you'll get a 405 and the error message 'Branch cannot be merged'. If merge request is
-     * already merged or closed, you'll get a 406 and the error message 'Method Not Allowed'.
-     * If the sha parameter is passed and does not match the HEAD of the source, you'll get
-     * a 409 and the error message 'SHA does not match HEAD of source branch'.  If you don't
-     * have permissions to accept this merge request, you'll get a 401.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return the merged merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest acceptMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (acceptMergeRequest(projectIdOrPath, mergeRequestIid, null, null, null, null));
+    return (new Pager<ApprovalRule>(
+        this,
+        ApprovalRule.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "approval_rules"));
+  }
+
+  /**
+   * Get a Stream of the merge request level approval rules. Note: This API endpoint is only
+   * available on 12.3 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Stream of ApprovalRule instances for the specified merge request.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ApprovalRule> getApprovalRulesStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getApprovalRules(projectIdOrPath, mergeRequestIid, -1).stream());
+  }
+
+  /**
+   * Create a merge request level approval rule. Note: This API endpoint is only available on 12.3
+   * Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/approval_rules</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param projectRuleId the ID of a project-level approval rule
+   * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
+   * @return a ApprovalRule instance with approval configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ApprovalRule createApprovalRule(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Long projectRuleId,
+      final ApprovalRuleParams params)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Merge changes to the merge request. If the MR has any conflicts and can not be merged,
-     * you'll get a 405 and the error message 'Branch cannot be merged'. If merge request is
-     * already merged or closed, you'll get a 406 and the error message 'Method Not Allowed'.
-     * If the sha parameter is passed and does not match the HEAD of the source, you'll get
-     * a 409 and the error message 'SHA does not match HEAD of source branch'.  If you don't
-     * have permissions to accept this merge request, you'll get a 401.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.  Additionally,
-     * mergeWhenPipelineSucceeds sets the merge_when_build_succeeds flag for GitLab API V3.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param mergeCommitMessage custom merge commit message, optional
-     * @param shouldRemoveSourceBranch if true removes the source branch, optional
-     * @param mergeWhenPipelineSucceeds if true the MR is merged when the pipeline, optional
-     * @return the merged merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest acceptMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-            String mergeCommitMessage, Boolean shouldRemoveSourceBranch, Boolean mergeWhenPipelineSucceeds)
-            throws GitLabApiException {
-        return (acceptMergeRequest(projectIdOrPath, mergeRequestIid, mergeCommitMessage,
-                shouldRemoveSourceBranch, mergeWhenPipelineSucceeds, null));
+    final GitLabApiForm formData = params.getForm();
+    formData.withParam("approval_project_rule_id", projectRuleId);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "approval_rules");
+    return (response.readEntity(ApprovalRule.class));
+  }
+
+  /**
+   * Update the specified the merge request level approval rule. Note: This API endpoint is only
+   * available on 12.3 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/approval_rules/:approval_rule_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param approvalRuleId the ID of the approval rule
+   * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
+   *     update
+   * @return a ApprovalRule instance with approval configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ApprovalRule updateApprovalRule(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Long approvalRuleId,
+      final ApprovalRuleParams params)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Merge changes to the merge request. If the MR has any conflicts and can not be merged,
-     * you'll get a 405 and the error message 'Branch cannot be merged'. If merge request is
-     * already merged or closed, you'll get a 406 and the error message 'Method Not Allowed'.
-     * If the sha parameter is passed and does not match the HEAD of the source, you'll get
-     * a 409 and the error message 'SHA does not match HEAD of source branch'.  If you don't
-     * have permissions to accept this merge request, you'll get a 401.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.  Additionally,
-     * mergeWhenPipelineSucceeds sets the merge_when_build_succeeds flag for GitLab API V3.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/merge</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param mergeCommitMessage custom merge commit message, optional
-     * @param shouldRemoveSourceBranch if true removes the source branch, optional
-     * @param mergeWhenPipelineSucceeds if true the MR is merged when the pipeline, optional
-     * @param sha if present, then this SHA must match the HEAD of the source branch, otherwise the merge will fail, optional
-     * @return the merged merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest acceptMergeRequest(Object projectIdOrPath, Long mergeRequestIid,
-            String mergeCommitMessage, Boolean shouldRemoveSourceBranch, Boolean mergeWhenPipelineSucceeds, String sha)
-            throws GitLabApiException {
-
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
-
-        Form formData = new GitLabApiForm()
-                .withParam("merge_commit_message", mergeCommitMessage)
-                .withParam("should_remove_source_branch", shouldRemoveSourceBranch)
-                .withParam((isApiVersion(ApiVersion.V3) ?
-                        "merge_when_build_succeeds" : "merge_when_pipeline_succeeds"),
-                        mergeWhenPipelineSucceeds)
-                .withParam("sha", sha);
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "merge");
-        return (response.readEntity(MergeRequest.class));
+    if (approvalRuleId == null) {
+      throw new RuntimeException("approvalRuleId cannot be null");
     }
 
-    /**
-     * Cancel merge when pipeline succeeds. If you don't have permissions to accept this merge request,
-     * you'll get a 401. If the merge request is already merged or closed, you get 405 and
-     * error message 'Method Not Allowed'. In case the merge request is not set to be merged when the
-     * pipeline succeeds, you'll also get a 406 error.
-     *
-     * <p>NOTE: GitLab API V4 uses IID (internal ID), V3 uses ID to identify the merge request.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/cancel_merge_when_pipeline_succeeds</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return the updated merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest cancelMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+    final GitLabApiForm formData = params.getForm();
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "approval_rules",
+            approvalRuleId);
+    return (response.readEntity(ApprovalRule.class));
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Delete the specified the merge request level approval rule. Note: This API endpoint is only
+   * available on 12.3 Starter and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/approval_rules/:approval_rule_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param approvalRuleId the ID of the approval rule
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteApprovalRule(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long approvalRuleId)
+      throws GitLabApiException {
 
-        Response response = put(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "cancel_merge_when_pipeline_succeeds");
-        return (response.readEntity(MergeRequest.class));
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Get the merge request with approval information.
-     *
-     * Note: This API endpoint is only available on 8.9 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approvals</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a MergeRequest instance with approval information included
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getMergeRequestApprovals(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getApprovals(projectIdOrPath, mergeRequestIid));
+    if (approvalRuleId == null) {
+      throw new RuntimeException("approvalRuleId cannot be null");
     }
 
-    /**
-     * Get the merge request with approval information.
-     *
-     * Note: This API endpoint is only available on 8.9 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approvals</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a MergeRequest instance with approval information included
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getApprovals(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "approval_rules",
+        approvalRuleId);
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Approve a merge request.
+   *
+   * <p>Note: This API endpoint is only available on 8.9 EE and above.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/approve</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param sha the HEAD of the merge request, optional
+   * @return a MergeRequest instance with approval information included
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest approveMergeRequest(
+      final Object projectIdOrPath, final Long mergeRequestIid, final String sha)
+      throws GitLabApiException {
 
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approvals");
-        return (response.readEntity(MergeRequest.class));
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Get the approval state of a merge request.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_state</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a ApprovalState instance with approval state
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ApprovalState getApprovalState(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("sha", sha);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "approve");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Unapprove a merge request.
+   *
+   * <p>Note: This API endpoint is only available on 8.9 EE and above.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/unapprove</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a MergeRequest instance with approval information included
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest unapproveMergeRequest(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
 
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approval_state");
-        return (response.readEntity(ApprovalState.class));
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Get a list of the merge request level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a List of ApprovalRule instances for the specified merge request.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ApprovalRule> getApprovalRules(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getApprovalRules(projectIdOrPath, mergeRequestIid, -1).all());
-    }
+    final Response response =
+        post(
+            Response.Status.OK,
+            (Form) null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "unapprove");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-    /**
-     * Get a Pager of the merge request level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param itemsPerPage the number of ApprovalRule instances that will be fetched per page
-     * @return a Pager of ApprovalRule instances for the specified merge request.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ApprovalRule> getApprovalRules(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+  /**
+   * Get merge request with changes information.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/changes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the IID of the merge request to get
+   * @return a merge request including its changes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getMergeRequestChanges(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "changes");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-	if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-	}
+  /**
+   * Get list of participants of merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the IID of the merge request to get
+   * @return a List containing all participants for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Participant> getParticipants(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getParticipants(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
 
-	return (new Pager<ApprovalRule>(this, ApprovalRule.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approval_rules"));
-    }
+  /**
+   * Get list of participants of merge request and in the specified page range.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the IID of the merge request to get
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a List containing all participants for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Participant> getParticipants(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "participants");
+    return (response.readEntity(new GenericType<List<Participant>>() {}));
+  }
 
-    /**
-     * Get a Stream of the merge request level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Stream of ApprovalRule instances for the specified merge request.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ApprovalRule> getApprovalRulesStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getApprovalRules(projectIdOrPath, mergeRequestIid, -1).stream());
-    }
+  /**
+   * Get a Pager of the participants of merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the IID of the merge request to get
+   * @param itemsPerPage the number of Participant instances that will be fetched per page
+   * @return a Pager containing all participants for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Participant> getParticipants(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Participant>(
+        this,
+        Participant.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "participants");
+  }
 
-    /**
-     * Create a merge request level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param projectRuleId the ID of a project-level approval rule
-     * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
-     * @return a ApprovalRule instance with approval configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ApprovalRule createApprovalRule(Object projectIdOrPath, Long mergeRequestIid,
-	    Long projectRuleId, ApprovalRuleParams params) throws GitLabApiException {
+  /**
+   * Get Stream of participants of merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the IID of the merge request to get
+   * @return a Stream containing all participants for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Participant> getParticipantsStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getParticipants(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Get list containing all the issues that would be closed by merging the provided merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request to get the closes issues for
+   * @return a List containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getClosesIssues(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
 
-        GitLabApiForm formData = params.getForm();
-        formData.withParam("approval_project_rule_id", projectRuleId);
-        Response response = post(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approval_rules");
-        return (response.readEntity(ApprovalRule.class));
-    }
+  /**
+   * Get list containing all the issues that would be closed by merging the provided merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request to get the closes issues for
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return a List containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getClosesIssues(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "closes_issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
 
-    /**
-     * Update the specified the merge request level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/approval_rules/:approval_rule_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param approvalRuleId the ID of the approval rule
-     * @param params the ApprovalRuleParams instance holding the parameters for the approval rule update
-     * @return a ApprovalRule instance with approval configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ApprovalRule updateApprovalRule(Object projectIdOrPath, Long mergeRequestIid,
-            Long approvalRuleId, ApprovalRuleParams params) throws GitLabApiException {
+  /**
+   * Get a Pager containing all the issues that would be closed by merging the provided merge
+   * request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request to get the closes issues for
+   * @param itemsPerPage the number of Issue instances that will be fetched per page
+   * @return a Pager containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getClosesIssues(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "closes_issues");
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Get Stream containing all the issues that would be closed by merging the provided merge
+   * request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request to get the closes issues for
+   * @return a Stream containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getClosesIssuesStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+  }
 
-        if (approvalRuleId == null) {
-            throw new RuntimeException("approvalRuleId cannot be null");
-        }
+  /**
+   * Get list containing all the issues that would be closed by merging the provided merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request to get the closes issues for
+   * @return a List containing all the issues that would be closed by merging the provided merge
+   *     request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getApprovalStatus(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
 
-        GitLabApiForm formData = params.getForm();
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approval_rules", approvalRuleId);
-        return (response.readEntity(ApprovalRule.class));
-    }
+  /**
+   * Automatically rebase the source_branch of the merge request against its target_branch.
+   *
+   * <p>This is an asynchronous request. The API will return a 202 Accepted response if the request
+   * is enqueued successfully
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/rebase</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request to rebase
+   * @return the merge request info containing the status of a merge request rebase
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest rebaseMergeRequest(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.ACCEPTED,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "rebase");
+    return (response.readEntity(MergeRequest.class));
+  }
 
-    /**
-     * Delete the specified the merge request level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/approval_rules/:approval_rule_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param approvalRuleId the ID of the approval rule
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteApprovalRule(Object projectIdOrPath, Long mergeRequestIid, Long approvalRuleId) throws GitLabApiException {
+  /**
+   * Get the merge request info containing the status of a merge request rebase.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request being rebased
+   * @return the merge request info containing the status of a merge request rebase
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MergeRequest getRebaseStatus(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return getMergeRequest(projectIdOrPath, mergeRequestIid, null, null, true);
+  }
 
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
+  /**
+   * Get a list of pipelines for a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a list containing the pipelines for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getMergeRequestPipelines(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestPipelines(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+  }
 
-        if (approvalRuleId == null) {
-            throw new RuntimeException("approvalRuleId cannot be null");
-        }
+  /**
+   * Get a Pager of pipelines for a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @param itemsPerPage the number of Pipeline instances that will be fetched per page
+   * @return a Pager containing the pipelines for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Pipeline> getMergeRequestPipelines(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Pipeline>(
+        this,
+        Pipeline.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "pipelines"));
+  }
 
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "approval_rules", approvalRuleId);
-    }
+  /**
+   * Get a Stream of pipelines for a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Stream containing the pipelines for the specified merge request
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Pipeline> getMergeRequestPipelinesStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestPipelines(projectIdOrPath, mergeRequestIid, getDefaultPerPage())
+        .stream());
+  }
 
-    /**
-     * Approve a merge request.
-     *
-     * Note: This API endpoint is only available on 8.9 EE and above.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/approve</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param sha the HEAD of the merge request, optional
-     * @return a MergeRequest instance with approval information included
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest approveMergeRequest(Object projectIdOrPath, Long mergeRequestIid, String sha) throws GitLabApiException {
-
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
-
-        Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "approve");
-        return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Unapprove a merge request.
-     *
-     * Note: This API endpoint is only available on 8.9 EE and above.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/unapprove</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a MergeRequest instance with approval information included
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest unapproveMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
-
-        Response response = post(Response.Status.OK, (Form)null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "unapprove");
-        return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Get merge request with changes information.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/changes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the IID of the merge request to get
-     * @return a merge request including its changes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getMergeRequestChanges(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "changes");
-        return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Get list of participants of merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the IID of the merge request to get
-     * @return a List containing all participants for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Participant> getParticipants(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getParticipants(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list of participants of merge request and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the IID of the merge request to get
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a List containing all participants for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Participant> getParticipants(Object projectIdOrPath, Long mergeRequestIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                    "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "participants");
-        return (response.readEntity(new GenericType<List<Participant>>() { }));
-    }
-
-    /**
-     * Get a Pager of the participants of merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the IID of the merge request to get
-     * @param itemsPerPage the number of Participant instances that will be fetched per page
-     * @return a Pager containing all participants for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Participant> getParticipants(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Participant>(this, Participant.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "participants");
-    }
-
-    /**
-     * Get Stream of participants of merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/participants</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the IID of the merge request to get
-     * @return a Stream containing all participants for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Participant> getParticipantsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getParticipants(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get list containing all the issues that would be closed by merging the provided merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request to get the closes issues for
-     * @return a List containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getClosesIssues(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list containing all the issues that would be closed by merging the provided merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request to get the closes issues for
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return a List containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getClosesIssues(Object projectIdOrPath, Long mergeRequestIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                    "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "closes_issues");
-        return (response.readEntity(new GenericType<List<Issue>>() { }));
-    }
-
-    /**
-     * Get a Pager containing all the issues that would be closed by merging the provided merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request to get the closes issues for
-     * @param itemsPerPage the number of Issue instances that will be fetched per page
-     * @return a Pager containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getClosesIssues(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Issue>(this, Issue.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "closes_issues");
-    }
-
-    /**
-     * Get Stream containing all the issues that would be closed by merging the provided merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request to get the closes issues for
-     * @return a Stream containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getClosesIssuesStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get list containing all the issues that would be closed by merging the provided merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/closes_issues</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request to get the closes issues for
-     * @return a List containing all the issues that would be closed by merging the provided merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getApprovalStatus(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getClosesIssues(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Automatically rebase the source_branch of the merge request against its target_branch.
-     *
-     * This is an asynchronous request. The API will return a 202 Accepted response if the
-     * request is enqueued successfully
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/rebase</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request to rebase
-     * @return the merge request info containing the status of a merge request rebase
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest rebaseMergeRequest(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-	Response response = put(Response.Status.ACCEPTED, null,
-		"projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "rebase");
-	 return (response.readEntity(MergeRequest.class));
-    }
-
-    /**
-     * Get the merge request info containing the status of a merge request rebase.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request being rebased
-     * @return the merge request info containing the status of a merge request rebase
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MergeRequest getRebaseStatus(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return getMergeRequest(projectIdOrPath, mergeRequestIid, null, null, true);
-    }
-
-    /**
-     * Get a list of pipelines for a merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a list containing the pipelines for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getMergeRequestPipelines(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestPipelines(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of pipelines for a merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @param itemsPerPage the number of Pipeline instances that will be fetched per page
-     * @return a Pager containing the pipelines for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Pipeline> getMergeRequestPipelines(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Pipeline>(this, Pipeline.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "pipelines"));
-    }
-
-    /**
-     * Get a Stream of pipelines for a merge request.
-     *
-    * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Stream containing the pipelines for the specified merge request
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Pipeline> getMergeRequestPipelinesStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestPipelines(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * <p>Create a new pipeline for a merge request. A pipeline created via this endpoint will not run
-     * a regular branch/tag pipeline, it requires .gitlab-ci.yml to be configured with only:
-     * [merge_requests] to create jobs.</p>
-     *
-     * The new pipeline can be:
-     *    A detached merge request pipeline.
-     *    A pipeline for merged results if the project setting is enabled.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the internal ID of the merge request
-     * @return a Pipeline instance with the newly created pipeline info
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline createMergeRequestPipeline(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-	Response response = post(Response.Status.CREATED, (Form)null,
-            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "pipelines");
-        return (response.readEntity(Pipeline.class));
-    }
+  /**
+   * Create a new pipeline for a merge request. A pipeline created via this endpoint will not run a
+   * regular branch/tag pipeline, it requires .gitlab-ci.yml to be configured with only:
+   * [merge_requests] to create jobs. The new pipeline can be: A detached merge request pipeline. A
+   * pipeline for merged results if the project setting is enabled.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/pipelines</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the internal ID of the merge request
+   * @return a Pipeline instance with the newly created pipeline info
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline createMergeRequestPipeline(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (Form) null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "pipelines");
+    return (response.readEntity(Pipeline.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/MilestonesApi.java
+++ b/src/main/java/org/gitlab4j/api/MilestonesApi.java
@@ -3,613 +3,857 @@ package org.gitlab4j.api;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Issue;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.Milestone;
 
 /**
  * This class implements the client side API for the GitLab milestones calls.
+ *
  * @see <a href="https://docs.gitlab.com/ce/api/milestones.html">Project milestones API</a>
  * @see <a href="https://docs.gitlab.com/ce/api/group_milestones.html">Group milestones API</a>
  */
 public class MilestonesApi extends AbstractApi {
 
-    public MilestonesApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public MilestonesApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of group milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getGroupMilestones(final Object groupIdOrPath) throws GitLabApiException {
+    return (getGroupMilestones(groupIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of group milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param page the page number to get
+   * @param perPage how many milestones per page
+   * @return the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getGroupMilestones(
+      final Object groupIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a Page of group milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param itemsPerPage The number of Milestone instances that will be fetched per page
+   * @return the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Milestone> getGroupMilestones(final Object groupIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Milestone>(
+        this,
+        Milestone.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "milestones"));
+  }
+
+  /**
+   * Get a Stream of group milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @return a Stream of the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Milestone> getGroupMilestonesStream(final Object groupIdOrPath)
+      throws GitLabApiException {
+    return (getGroupMilestones(groupIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of group milestones that have the specified state.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param state the milestone state
+   * @return the milestones associated with the specified group and state
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getGroupMilestones(final Object groupIdOrPath, final MilestoneState state)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a list of group milestones that have match the search string.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param search the search string
+   * @return the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getGroupMilestones(final Object groupIdOrPath, final String search)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("search", search)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a list of group milestones that have the specified state and match the search string.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param state the milestone state
+   * @param search the search string
+   * @return the milestones associated with the specified group
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getGroupMilestones(
+      final Object groupIdOrPath, final MilestoneState state, final String search)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam("search", search)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the ID of the milestone tp get
+   * @return a Milestone instance for the specified IDs
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone getGroupMilestone(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Get the list of issues associated with the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @return a List of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getGroupIssues(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, milestoneId, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get the Pager of issues associated with the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @param itemsPerPage The number of Milestone instances that will be fetched per page
+   * @return a Pager of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getGroupIssues(
+      final Object groupIdOrPath, final Long milestoneId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "groups",
+        getGroupIdOrPath(groupIdOrPath),
+        "milestones",
+        milestoneId,
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of issues associated with the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @return a Stream of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getGroupIssuesStream(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    return (getGroupIssues(groupIdOrPath, milestoneId, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the list of merge requests associated with the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/merge_requests</code>
+   * </pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to get the merge requests for
+   * @return a list of merge requests associated with the specified milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getGroupMergeRequest(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones",
+            milestoneId,
+            "merge_requests");
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
+
+  /**
+   * Create a group milestone.
+   *
+   * <pre><code>GitLab Endpoint: POST /groups/:id/milestones</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param title the title for the milestone
+   * @param description the description for the milestone
+   * @param dueDate the due date for the milestone
+   * @param startDate the start date for the milestone
+   * @return the created Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone createGroupMilestone(
+      final Object groupIdOrPath,
+      final String title,
+      final String description,
+      final Date dueDate,
+      final Date startDate)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("description", description)
+            .withParam("due_date", dueDate)
+            .withParam("start_date", startDate);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones");
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Close a group milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to close
+   * @return the closed Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone closeGroupMilestone(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a list of group milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getGroupMilestones(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupMilestones(groupIdOrPath, getDefaultPerPage()).all());
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("state_event", MilestoneState.CLOSE);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Activate a group milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to activate
+   * @return the activated Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone activateGroupMilestone(final Object groupIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a list of group milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param page the page number to get
-     * @param perPage how many milestones per page
-     * @return the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getGroupMilestones(Object groupIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("state_event", MilestoneState.ACTIVATE);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Update the specified group milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
+   * @param milestoneId the milestone ID to update
+   * @param title the updated title for the milestone
+   * @param description the updated description for the milestone
+   * @param dueDate the updated due date for the milestone
+   * @param startDate the updated start date for the milestone
+   * @param milestoneState the updated milestone state
+   * @return the updated Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone updateGroupMilestone(
+      final Object groupIdOrPath,
+      final Long milestoneId,
+      final String title,
+      final String description,
+      final Date dueDate,
+      final Date startDate,
+      final MilestoneState milestoneState)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a Page of group milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param itemsPerPage The number of Milestone instances that will be fetched per page
-     * @return the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Milestone> getGroupMilestones(Object groupIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Milestone>(this, Milestone.class, itemsPerPage, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones"));
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("description", description)
+            .withParam("due_date", dueDate)
+            .withParam("start_date", startDate)
+            .withParam("state_event", milestoneState);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "groups",
+            getGroupIdOrPath(groupIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Get a list of project milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getMilestones(final Object projectIdOrPath) throws GitLabApiException {
+    return (getMilestones(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page number to get
+   * @param perPage how many milestones per page
+   * @return the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getMilestones(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a Pager of project milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage The number of Milestone instances that will be fetched per page
+   * @return the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Milestone> getMilestones(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Milestone>(
+        this,
+        Milestone.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "milestones"));
+  }
+
+  /**
+   * Get a Stream of project milestones.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Milestone> getMilestonesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getMilestones(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of project milestones that have the specified state.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the milestone state
+   * @return the milestones associated with the specified project and state
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getMilestones(final Object projectIdOrPath, final MilestoneState state)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a list of project milestones that have match the search string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param search the search string
+   * @return the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getMilestones(final Object projectIdOrPath, final String search)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("search", search)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get a list of project milestones that have the specified state and match the search string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param state the milestone state
+   * @param search the search string
+   * @return the milestones associated with the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Milestone> getMilestones(
+      final Object projectIdOrPath, final MilestoneState state, final String search)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam("search", search)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones");
+    return (response.readEntity(new GenericType<List<Milestone>>() {}));
+  }
+
+  /**
+   * Get the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the ID of the milestone tp get
+   * @return a Milestone instance for the specified IDs
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone getMilestone(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Get the list of issues associated with the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @return a List of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Issue> getIssues(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    return (getIssues(projectIdOrPath, milestoneId, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of issues associated with the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @param itemsPerPage the number of Milestone instances that will be fetched per page
+   * @return a Pager of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Issue> getIssues(
+      final Object projectIdOrPath, final Long milestoneId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "milestones",
+        milestoneId,
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of issues associated with the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to get the issues for
+   * @return a Stream of Issue for the milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Issue> getIssuesStream(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    return (getIssues(projectIdOrPath, milestoneId, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the list of merge requests associated with the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/merge_requests</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to get the merge requests for
+   * @return a list of merge requests associated with the specified milestone
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<MergeRequest> getMergeRequest(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones",
+            milestoneId,
+            "merge_requests");
+    return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
+  }
+
+  /**
+   * Create a milestone.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/milestones</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param title the title for the milestone
+   * @param description the description for the milestone
+   * @param dueDate the due date for the milestone
+   * @param startDate the start date for the milestone
+   * @return the created Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone createMilestone(
+      final Object projectIdOrPath,
+      final String title,
+      final String description,
+      final Date dueDate,
+      final Date startDate)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("description", description)
+            .withParam("due_date", dueDate)
+            .withParam("start_date", startDate);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones");
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Close a milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to close
+   * @return the closed Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone closeMilestone(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a Stream of group milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @return a Stream of the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Milestone> getGroupMilestonesStream(Object groupIdOrPath) throws GitLabApiException {
-        return (getGroupMilestones(groupIdOrPath, getDefaultPerPage()).stream());
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("state_event", MilestoneState.CLOSE);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Activate a milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to activate
+   * @return the activated Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone activateMilestone(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a list of group milestones that have the specified state.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param state the milestone state
-     * @return the milestones associated with the specified group and state
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getGroupMilestones(Object groupIdOrPath, MilestoneState state) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("state", state).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("state_event", MilestoneState.ACTIVATE);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
+
+  /**
+   * Update the specified milestone.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to update
+   * @param title the updated title for the milestone
+   * @param description the updated description for the milestone
+   * @param dueDate the updated due date for the milestone
+   * @param startDate the updated start date for the milestone
+   * @param milestoneState the updated milestone state
+   * @return the updated Milestone instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Milestone updateMilestone(
+      final Object projectIdOrPath,
+      final Long milestoneId,
+      final String title,
+      final String description,
+      final Date dueDate,
+      final Date startDate,
+      final MilestoneState milestoneState)
+      throws GitLabApiException {
+
+    if (milestoneId == null) {
+      throw new RuntimeException("milestoneId cannot be null");
     }
 
-    /**
-     * Get a list of group milestones that have match the search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param search the search string
-     * @return the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getGroupMilestones(Object groupIdOrPath, String search) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title, true)
+            .withParam("description", description)
+            .withParam("due_date", dueDate)
+            .withParam("start_date", startDate)
+            .withParam("state_event", milestoneState);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "milestones",
+            milestoneId);
+    return (response.readEntity(Milestone.class));
+  }
 
-    /**
-     * Get a list of group milestones that have the specified state and match the search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param state the milestone state
-     * @param search the search string
-     * @return the milestones associated with the specified group
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getGroupMilestones(Object groupIdOrPath, MilestoneState state, String search) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("state", state)
-                .withParam("search", search)
-                .withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
-
-    /**
-     * Get the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the ID of the milestone tp get
-     * @return a Milestone instance for the specified IDs
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone getGroupMilestone(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Get the list of issues associated with the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @return a List of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getGroupIssues(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-        return (getGroupIssues(groupIdOrPath, milestoneId, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get the Pager of issues associated with the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @param itemsPerPage The number of Milestone instances that will be fetched per page
-     * @return a Pager of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getGroupIssues(Object groupIdOrPath, Long milestoneId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null,
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId, "issues"));
-    }
-
-    /**
-     * Get a Stream of issues associated with the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @return a Stream of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getGroupIssuesStream(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-        return (getGroupIssues(groupIdOrPath, milestoneId, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the list of merge requests associated with the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/milestones/:milestone_id/merge_requests</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to get the merge requests for
-     * @return a list of merge requests associated with the specified milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getGroupMergeRequest(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId, "merge_requests");
-        return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
-    }
-
-    /**
-     * Create a group milestone.
-     *
-     * <pre><code>GitLab Endpoint: POST /groups/:id/milestones</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param title the title for the milestone
-     * @param description the description for the milestone
-     * @param dueDate the due date for the milestone
-     * @param startDate the start date for the milestone
-     * @return the created Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone createGroupMilestone(Object groupIdOrPath, String title, String description, Date dueDate, Date startDate) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("description", description)
-                .withParam("due_date", dueDate)
-                .withParam("start_date", startDate);
-        Response response = post(Response.Status.CREATED, formData, "groups", getGroupIdOrPath(groupIdOrPath), "milestones");
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Close a group milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to close
-     * @return the closed Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone closeGroupMilestone(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("state_event", MilestoneState.CLOSE);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Activate a group milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to activate
-     * @return the activated Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone activateGroupMilestone(Object groupIdOrPath, Long milestoneId) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("state_event", MilestoneState.ACTIVATE);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Update the specified group milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param groupIdOrPath the group in the form of an Long(ID), String(path), or Group instance
-     * @param milestoneId the milestone ID to update
-     * @param title the updated title for the milestone
-     * @param description the updated description for the milestone
-     * @param dueDate the updated due date for the milestone
-     * @param startDate the updated start date for the milestone
-     * @param milestoneState the updated milestone state
-     * @return the updated Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone updateGroupMilestone(Object groupIdOrPath, Long milestoneId, String title, String description,
-                                     Date dueDate, Date startDate, MilestoneState milestoneState) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("description", description)
-                .withParam("due_date", dueDate)
-                .withParam("start_date", startDate)
-                .withParam("state_event", milestoneState);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "groups", getGroupIdOrPath(groupIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Get a list of project milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getMilestones(Object projectIdOrPath) throws GitLabApiException {
-        return (getMilestones(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of project milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page number to get
-     * @param perPage how many milestones per page
-     * @return the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getMilestones(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
-
-    /**
-     * Get a Pager of project milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage The number of Milestone instances that will be fetched per page
-     * @return the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Milestone> getMilestones(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Milestone>(this, Milestone.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones"));
-    }
-
-    /**
-     * Get a Stream of project milestones.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Milestone> getMilestonesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getMilestones(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of project milestones that have the specified state.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the milestone state
-     * @return the milestones associated with the specified project and state
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getMilestones(Object projectIdOrPath, MilestoneState state) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("state", state).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
-
-    /**
-     * Get a list of project milestones that have match the search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param search the search string
-     * @return the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getMilestones(Object projectIdOrPath, String search) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
-
-    /**
-     * Get a list of project milestones that have the specified state and match the search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param state the milestone state
-     * @param search the search string
-     * @return the milestones associated with the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Milestone> getMilestones(Object projectIdOrPath, MilestoneState state, String search) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("state", state)
-                .withParam("search", search)
-                .withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones");
-        return (response.readEntity(new GenericType<List<Milestone>>() {}));
-    }
-
-    /**
-     * Get the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the ID of the milestone tp get
-     * @return a Milestone instance for the specified IDs
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone getMilestone(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Get the list of issues associated with the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @return a List of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Issue> getIssues(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, milestoneId, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of issues associated with the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @param itemsPerPage the number of Milestone instances that will be fetched per page
-     * @return a Pager of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Issue> getIssues(Object projectIdOrPath, Long milestoneId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId, "issues"));
-    }
-
-    /**
-     * Get a Stream of issues associated with the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to get the issues for
-     * @return a Stream of Issue for the milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Issue> getIssuesStream(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, milestoneId, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the list of merge requests associated with the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/milestones/:milestone_id/merge_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to get the merge requests for
-     * @return a list of merge requests associated with the specified milestone
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<MergeRequest> getMergeRequest(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId, "merge_requests");
-        return (response.readEntity(new GenericType<List<MergeRequest>>() {}));
-    }
-
-    /**
-     * Create a milestone.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/milestones</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param title the title for the milestone
-     * @param description the description for the milestone
-     * @param dueDate the due date for the milestone
-     * @param startDate the start date for the milestone
-     * @return the created Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone createMilestone(Object projectIdOrPath, String title, String description, Date dueDate, Date startDate) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("description", description)
-                .withParam("due_date", dueDate)
-                .withParam("start_date", startDate);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones");
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Close a milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to close
-     * @return the closed Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone closeMilestone(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("state_event", MilestoneState.CLOSE);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Activate a milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to activate
-     * @return the activated Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone activateMilestone(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("state_event", MilestoneState.ACTIVATE);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Update the specified milestone.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/milestones/:milestone_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to update
-     * @param title the updated title for the milestone
-     * @param description the updated description for the milestone
-     * @param dueDate the updated due date for the milestone
-     * @param startDate the updated start date for the milestone
-     * @param milestoneState the updated milestone state
-     * @return the updated Milestone instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Milestone updateMilestone(Object projectIdOrPath, Long milestoneId, String title, String description,
-            Date dueDate, Date startDate, MilestoneState milestoneState) throws GitLabApiException {
-
-        if (milestoneId == null) {
-            throw new RuntimeException("milestoneId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title, true)
-                .withParam("description", description)
-                .withParam("due_date", dueDate)
-                .withParam("start_date", startDate)
-                .withParam("state_event", milestoneState);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId);
-        return (response.readEntity(Milestone.class));
-    }
-
-    /**
-     * Delete a project milestone.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param milestoneId the milestone ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMilestone(Object projectIdOrPath, Long milestoneId) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "milestones", milestoneId);
-    }
+  /**
+   * Delete a project milestone.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param milestoneId the milestone ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMilestone(final Object projectIdOrPath, final Long milestoneId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "milestones",
+        milestoneId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/NamespaceApi.java
+++ b/src/main/java/org/gitlab4j/api/NamespaceApi.java
@@ -2,10 +2,8 @@ package org.gitlab4j.api;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Namespace;
 
 /**
@@ -13,7 +11,7 @@ import org.gitlab4j.api.models.Namespace;
  */
 public class NamespaceApi extends AbstractApi {
 
-    public NamespaceApi(GitLabApi gitLabApi) {
+    public NamespaceApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -41,8 +39,8 @@ public class NamespaceApi extends AbstractApi {
      * @return a List of Namespace instances in the specified page range
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Namespace> getNamespaces(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "namespaces");
+    public List<Namespace> getNamespaces(final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "namespaces");
         return (response.readEntity(new GenericType<List<Namespace>>() {}));
     }
 
@@ -56,7 +54,7 @@ public class NamespaceApi extends AbstractApi {
      * @return a Pager of Namespace instances
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Namespace> getNamespaces(int itemsPerPage) throws GitLabApiException {
+    public Pager<Namespace> getNamespaces(final int itemsPerPage) throws GitLabApiException {
         return (new Pager<Namespace>(this, Namespace.class, itemsPerPage, null, "namespaces"));
     }
 
@@ -82,7 +80,7 @@ public class NamespaceApi extends AbstractApi {
      * @return the Namespace List with the matching namespaces
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Namespace> findNamespaces(String query) throws GitLabApiException {
+    public List<Namespace> findNamespaces(final String query) throws GitLabApiException {
         return (findNamespaces(query, getDefaultPerPage()).all());
     }
 
@@ -97,9 +95,9 @@ public class NamespaceApi extends AbstractApi {
      * @return the Namespace List with the matching namespaces
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Namespace> findNamespaces(String query, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("search", query, true).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM,  perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "namespaces");
+    public List<Namespace> findNamespaces(final String query, final int page, final int perPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("search", query, true).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM,  perPage);
+        final Response response = get(Response.Status.OK, formData.asMap(), "namespaces");
         return (response.readEntity(new GenericType<List<Namespace>>() {}));
     }
 
@@ -113,8 +111,8 @@ public class NamespaceApi extends AbstractApi {
      * @return a Pager of Namespace instances with the matching namespaces
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Namespace> findNamespaces(String query, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("search", query, true);
+    public Pager<Namespace> findNamespaces(final String query, final int itemsPerPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("search", query, true);
         return (new Pager<Namespace>(this, Namespace.class, itemsPerPage, formData.asMap(), "namespaces"));
     }
 
@@ -127,7 +125,7 @@ public class NamespaceApi extends AbstractApi {
      * @return a Stream with the matching namespaces
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Namespace> findNamespacesStream(String query) throws GitLabApiException {
+    public Stream<Namespace> findNamespacesStream(final String query) throws GitLabApiException {
         return (findNamespaces(query, getDefaultPerPage()).stream());
     }
 }

--- a/src/main/java/org/gitlab4j/api/NotesApi.java
+++ b/src/main/java/org/gitlab4j/api/NotesApi.java
@@ -3,431 +3,623 @@ package org.gitlab4j.api;
 import java.util.Date;
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Note;
 
 public class NotesApi extends AbstractApi {
 
-    public NotesApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public NotesApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of the issues's notes.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue ID to get the notes for
+   * @return a list of the issues's notes
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long)}
+   */
+  @Deprecated
+  public List<Note> getNotes(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueNotes(projectIdOrPath, issueIid));
+  }
+
+  /**
+   * Get a list of the issue's notes using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to get the notes for
+   * @param page the page to get
+   * @param perPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long, int, int)}
+   */
+  @Deprecated
+  public List<Note> getNotes(
+      final Object projectIdOrPath, final Long issueIid, final int page, final int perPage)
+      throws GitLabApiException {
+    return (getIssueNotes(projectIdOrPath, issueIid, page, perPage));
+  }
+
+  /**
+   * Get a Pager of issues's notes.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to get the notes for
+   * @param itemsPerPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long, int)}
+   */
+  @Deprecated
+  public Pager<Note> getNotes(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getIssueNotes(projectIdOrPath, issueIid, itemsPerPage));
+  }
+
+  /**
+   * Get a list of the issues's notes.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue ID to get the notes for
+   * @return a list of the issues's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getIssueNotes(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueNotes(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of the issue's notes using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to get the notes for
+   * @param page the page to get
+   * @param perPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getIssueNotes(
+      final Object projectIdOrPath, final Long issueIid, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes");
+    return (response.readEntity(new GenericType<List<Note>>() {}));
+  }
+
+  /**
+   * Get a Pager of issues's notes.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to get the notes for
+   * @param itemsPerPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Note> getIssueNotes(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Note>(
+        this,
+        Note.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "notes"));
+  }
+
+  /**
+   * Get a Stream of the issues's notes.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue ID to get the notes for
+   * @return a Stream of the issues's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Note> getIssueNotesStream(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueNotes(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the specified issues's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to get the notes for
+   * @param noteId the ID of the Note to get
+   * @return a Note instance for the specified IDs
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note getIssueNote(final Object projectIdOrPath, final Long issueIid, final Long noteId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Create a issues's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance @param projectIdOrPath the project ID to create the issues for
+   * @param issueIid the issue IID to create the notes for
+   * @param body the content of note
+   * @return the created Note instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note createIssueNote(final Object projectIdOrPath, final Long issueIid, final String body)
+      throws GitLabApiException {
+    return (createIssueNote(projectIdOrPath, issueIid, body, null));
+  }
+
+  /**
+   * Create a issues's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to create the notes for
+   * @param body the content of note
+   * @param createdAt the created time of note
+   * @return the created Note instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note createIssueNote(
+      final Object projectIdOrPath, final Long issueIid, final String body, final Date createdAt)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("body", body, true).withParam("created_at", createdAt);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes");
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Update the specified issues's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to update the notes for
+   * @param noteId the ID of the node to update
+   * @param body the update content for the Note
+   * @return the modified Note instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note updateIssueNote(
+      final Object projectIdOrPath, final Long issueIid, final Long noteId, final String body)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Delete the specified issues's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param issueIid the issue IID to delete the notes for
+   * @param noteId the ID of the node to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteIssueNote(final Object projectIdOrPath, final Long issueIid, final Long noteId)
+      throws GitLabApiException {
+
+    if (issueIid == null) {
+      throw new RuntimeException("issueIid cannot be null");
     }
 
-    /**
-     * Get a list of the issues's notes.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue ID to get the notes for
-     * @return a list of the issues's notes
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long)}
-     */
-    @Deprecated
-    public List<Note> getNotes(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueNotes(projectIdOrPath, issueIid));
+    if (noteId == null) {
+      throw new RuntimeException("noteId cannot be null");
     }
 
-    /**
-     * Get a list of the issue's notes using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to get the notes for
-     * @param page the page to get
-     * @param perPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long, int, int)}
-     */
-    @Deprecated
-    public List<Note> getNotes(Object projectIdOrPath, Long issueIid, int page, int perPage) throws GitLabApiException {
-        return (getIssueNotes(projectIdOrPath, issueIid, page, perPage));
+    final Response.Status expectedStatus =
+        (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        getDefaultPerPageParam(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "notes",
+        noteId);
+  }
+
+  /**
+   * Gets a list of all notes for a single merge request
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the issue ID to get the notes for
+   * @return a list of the merge request's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getMergeRequestNotes(final Object projectIdOrPath, final Long mergeRequestIid)
+      throws GitLabApiException {
+    return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Gets a list of all notes for a single merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the issue ID to get the notes for
+   * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
+   * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is
+   *     CREATED_AT
+   * @return a list of the merge request's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getMergeRequestNotes(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final SortOrder sortOrder,
+      final Note.OrderBy orderBy)
+      throws GitLabApiException {
+    return (getMergeRequestNotes(
+            projectIdOrPath, mergeRequestIid, sortOrder, orderBy, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Gets a list of all notes for a single merge request using the specified page and per page
+   * settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to get the notes for
+   * @param page the page to get
+   * @param perPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getMergeRequestNotes(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int page, final int perPage)
+      throws GitLabApiException {
+    return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, page, perPage));
+  }
+
+  /**
+   * Gets a list of all notes for a single merge request using the specified page and per page
+   * settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to get the notes for
+   * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
+   * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is
+   *     CREATED_AT
+   * @param page the page to get
+   * @param perPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Note> getMergeRequestNotes(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final SortOrder sortOrder,
+      final Note.OrderBy orderBy,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("sort", sortOrder)
+            .withParam("order_by", orderBy)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes");
+    return (response.readEntity(new GenericType<List<Note>>() {}));
+  }
+
+  /**
+   * Get a Pager of all notes for a single merge request
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to get the notes for
+   * @param itemsPerPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Note> getMergeRequestNotes(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, itemsPerPage));
+  }
+
+  /**
+   * Gets a Stream of all notes for a single merge request
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the issue ID to get the notes for
+   * @return a Stream of the merge request's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Note> getMergeRequestNotesStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a Pager of all notes for a single merge request
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to get the notes for
+   * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
+   * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is
+   *     CREATED_AT
+   * @param itemsPerPage the number of notes per page
+   * @return the list of notes in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Note> getMergeRequestNotes(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final SortOrder sortOrder,
+      final Note.OrderBy orderBy,
+      final int itemsPerPage)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("sort", sortOrder)
+            .withParam("order_by", orderBy)
+            .withParam(PAGE_PARAM, 1)
+            .withParam(PER_PAGE_PARAM, itemsPerPage);
+    return (new Pager<Note>(
+        this,
+        Note.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "notes"));
+  }
+
+  /**
+   * Gets a Stream of all notes for a single merge request.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the issue ID to get the notes for
+   * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
+   * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is
+   *     CREATED_AT
+   * @return a Stream of the merge request's notes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Note> getMergeRequestNotesStream(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final SortOrder sortOrder,
+      final Note.OrderBy orderBy)
+      throws GitLabApiException {
+    return (getMergeRequestNotes(
+        projectIdOrPath, mergeRequestIid, sortOrder, orderBy, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get the specified merge request's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to get the notes for
+   * @param noteId the ID of the Note to get
+   * @return a Note instance for the specified IDs
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note getMergeRequestNote(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long noteId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Create a merge request's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to create the notes for
+   * @param body the content of note
+   * @return the created Note instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note createMergeRequestNote(
+      final Object projectIdOrPath, final Long mergeRequestIid, final String body)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes");
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Update the specified merge request's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to update the notes for
+   * @param noteId the ID of the node to update
+   * @param body the update content for the Note
+   * @return the modified Note instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Note updateMergeRequestNote(
+      final Object projectIdOrPath,
+      final Long mergeRequestIid,
+      final Long noteId,
+      final String body)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "notes",
+            noteId);
+    return (response.readEntity(Note.class));
+  }
+
+  /**
+   * Delete the specified merge request's note.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mergeRequestIid the merge request IID to delete the notes for
+   * @param noteId the ID of the node to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMergeRequestNote(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long noteId)
+      throws GitLabApiException {
+
+    if (mergeRequestIid == null) {
+      throw new RuntimeException("mergeRequestIid cannot be null");
     }
 
-    /**
-     * Get a Pager of issues's notes.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to get the notes for
-     * @param itemsPerPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated As of release 4.7.0, replaced by {@link #getIssueNotes(Object, Long, int)}
-     */
-    @Deprecated
-    public Pager<Note> getNotes(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (getIssueNotes(projectIdOrPath, issueIid, itemsPerPage));
+    if (noteId == null) {
+      throw new RuntimeException("noteId cannot be null");
     }
 
-    /**
-     * Get a list of the issues's notes.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue ID to get the notes for
-     * @return a list of the issues's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getIssueNotes(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueNotes(projectIdOrPath, issueIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of the issue's notes using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to get the notes for
-     * @param page the page to get
-     * @param perPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getIssueNotes(Object projectIdOrPath, Long issueIid, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),"projects",
-                getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes");
-        return (response.readEntity(new GenericType<List<Note>>() {}));
-    }
-
-    /**
-     * Get a Pager of issues's notes.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to get the notes for
-     * @param itemsPerPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Note> getIssueNotes(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Note>(this, Note.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes"));
-    }
-
-    /**
-     * Get a Stream of the issues's notes.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue ID to get the notes for
-     * @return a Stream of the issues's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Note> getIssueNotesStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueNotes(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the specified issues's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to get the notes for
-     * @param noteId the ID of the Note to get
-     * @return a Note instance for the specified IDs
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note getIssueNote(Object projectIdOrPath, Long issueIid, Long noteId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Create a issues's note.
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance @param projectIdOrPath the project ID to create the issues for
-     * @param issueIid the issue IID to create the notes for
-     * @param body the content of note
-     * @return the created Note instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note createIssueNote(Object projectIdOrPath, Long issueIid, String body) throws GitLabApiException {
-        return (createIssueNote(projectIdOrPath, issueIid, body, null));
-    }
-
-    /**
-     * Create a issues's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to create the notes for
-     * @param body the content of note
-     * @param createdAt the created time of note
-     * @return the created Note instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note createIssueNote(Object projectIdOrPath, Long issueIid, String body, Date createdAt) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("body", body, true)
-                .withParam("created_at", createdAt);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes");
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Update the specified issues's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to update the notes for
-     * @param noteId the ID of the node to update
-     * @param body the update content for the Note
-     * @return the modified Note instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note updateIssueNote(Object projectIdOrPath, Long issueIid, Long noteId, String body) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Delete the specified issues's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param issueIid the issue IID to delete the notes for
-     * @param noteId the ID of the node to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteIssueNote(Object projectIdOrPath, Long issueIid, Long noteId) throws GitLabApiException {
-
-        if (issueIid == null) {
-            throw new RuntimeException("issueIid cannot be null");
-        }
-
-        if (noteId == null) {
-            throw new RuntimeException("noteId cannot be null");
-        }
-
-        Response.Status expectedStatus = (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes", noteId);
-    }
-
-    /**
-     * Gets a list of all notes for a single merge request
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the issue ID to get the notes for
-     * @return a list of the merge request's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a list of all notes for a single merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the issue ID to get the notes for
-     * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
-     * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is CREATED_AT
-     * @return a list of the merge request's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid, SortOrder sortOrder, Note.OrderBy orderBy) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, sortOrder, orderBy, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a list of all notes for a single merge request using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the merge request IID to get the notes for
-     * @param page the page to get
-     * @param perPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid, int page, int perPage) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, page, perPage));
-    }
-
-    /**
-     * Gets a list of all notes for a single merge request using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the merge request IID to get the notes for
-     * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
-     * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is CREATED_AT
-     * @param page the page to get
-     * @param perPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid,
-            SortOrder sortOrder, Note.OrderBy orderBy, int page, int perPage) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("sort", sortOrder)
-                .withParam("order_by", orderBy)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes");
-        return (response.readEntity(new GenericType<List<Note>>() {}));
-    }
-
-    /**
-     * Get a Pager of all notes for a single merge request
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the merge request IID to get the notes for
-     * @param itemsPerPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, itemsPerPage));
-    }
-
-    /**
-     * Gets a Stream of all notes for a single merge request
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the issue ID to get the notes for
-     * @return a Stream of the merge request's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Note> getMergeRequestNotesStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, null, null, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a Pager of all notes for a single merge request
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the merge request IID to get the notes for
-     * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
-     * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is CREATED_AT
-     * @param itemsPerPage the number of notes per page
-     * @return the list of notes in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Note> getMergeRequestNotes(Object projectIdOrPath, Long mergeRequestIid,
-            SortOrder sortOrder, Note.OrderBy orderBy, int itemsPerPage) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("sort", sortOrder)
-                .withParam("order_by", orderBy)
-                .withParam(PAGE_PARAM, 1)
-                .withParam(PER_PAGE_PARAM, itemsPerPage);
-        return (new Pager<Note>(this, Note.class, itemsPerPage, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes"));
-    }
-
-    /**
-     * Gets a Stream of all notes for a single merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the issue ID to get the notes for
-     * @param sortOrder return merge request notes sorted in the specified sort order, default is DESC
-     * @param orderBy return merge request notes ordered by CREATED_AT or UPDATED_AT, default is CREATED_AT
-     * @return a Stream of the merge request's notes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Note> getMergeRequestNotesStream(Object projectIdOrPath, Long mergeRequestIid, SortOrder sortOrder, Note.OrderBy orderBy) throws GitLabApiException {
-        return (getMergeRequestNotes(projectIdOrPath, mergeRequestIid, sortOrder, orderBy, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the specified merge request's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid  the merge request IID to get the notes for
-     * @param noteId the ID of the Note to get
-     * @return a Note instance for the specified IDs
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note getMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, Long noteId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Create a merge request's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid  the merge request IID to create the notes for
-     * @param body the content of note
-     * @return the created Note instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note createMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, String body) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes");
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Update the specified merge request's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid  the merge request IID to update the notes for
-     * @param noteId the ID of the node to update
-     * @param body the update content for the Note
-     * @return the modified Note instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Note updateMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, Long noteId, String body) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId);
-        return (response.readEntity(Note.class));
-    }
-
-    /**
-     * Delete the specified merge request's note.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mergeRequestIid the merge request IID to delete the notes for
-     * @param noteId the ID of the node to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, Long noteId) throws GitLabApiException {
-
-        if (mergeRequestIid == null) {
-            throw new RuntimeException("mergeRequestIid cannot be null");
-        }
-
-        if (noteId == null) {
-            throw new RuntimeException("noteId cannot be null");
-        }
-
-        Response.Status expectedStatus = (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "notes", noteId);
-    }
+    final Response.Status expectedStatus =
+        (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "notes",
+        noteId);
+  }
 }

--- a/src/main/java/org/gitlab4j/api/NotificationSettingsApi.java
+++ b/src/main/java/org/gitlab4j/api/NotificationSettingsApi.java
@@ -1,161 +1,174 @@
 package org.gitlab4j.api;
 
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.NotificationSettings;
 import org.gitlab4j.api.models.NotificationSettings.Events;
 
 public class NotificationSettingsApi extends AbstractApi {
 
-    public NotificationSettingsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public NotificationSettingsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get the global notification settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /notification_settings</code></pre>
+   *
+   * @return a NotificationSettings instance containing the global notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings getGlobalNotificationSettings() throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
+
+  /**
+   * Update the global notification settings.
+   *
+   * <pre><code>GitLab Endpoint: PUT /notification_settings</code></pre>
+   *
+   * @param settings a NotificationSettings instance with the new settings
+   * @return a NotificationSettings instance containing the updated global notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings updateGlobalNotificationSettings(final NotificationSettings settings)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("level", settings.getLevel())
+            .withParam("email", settings.getEmail());
+
+    final Events events = settings.getEvents();
+    if (events != null) {
+      formData
+          .withParam("new_note", events.getNewNote())
+          .withParam("new_issue", events.getNewIssue())
+          .withParam("reopen_issue", events.getReopenIssue())
+          .withParam("close_issue", events.getCloseIssue())
+          .withParam("reassign_issue", events.getReassignIssue())
+          .withParam("new_merge_request", events.getNewMergeRequest())
+          .withParam("reopen_merge_request", events.getReopenMergeRequest())
+          .withParam("close_merge_request", events.getCloseMergeRequest())
+          .withParam("reassign_merge_request", events.getReassignMergeRequest())
+          .withParam("merge_merge_request", events.getMergeMergeRequest())
+          .withParam("failed_pipeline", events.getFailedPipeline())
+          .withParam("success_pipeline", events.getSuccessPipeline());
     }
 
-    /**
-     * Get the global notification settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /notification_settings</code></pre>
-     *
-     * @return a NotificationSettings instance containing the global notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings getGlobalNotificationSettings() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
+    final Response response = put(Response.Status.OK, formData.asMap(), "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
+
+  /**
+   * Get the notification settings for a group.
+   *
+   * <pre><code>GitLab Endpoint: GET /groups/:id/notification_settings</code></pre>
+   *
+   * @param groupId the group ID to get the notification settings for
+   * @return a NotificationSettings instance containing the specified group's notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings getGroupNotificationSettings(final long groupId) throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "groups", groupId, "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
+
+  /**
+   * Update the notification settings for a group
+   *
+   * <pre><code>GitLab Endpoint: PUT /groups/:id/notification_settings</code></pre>
+   *
+   * @param groupId the group ID to update the notification settings for
+   * @param settings a NotificationSettings instance with the new settings
+   * @return a NotificationSettings instance containing the updated group notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings updateGroupNotificationSettings(
+      final long groupId, final NotificationSettings settings) throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("level", settings.getLevel())
+            .withParam("email", settings.getEmail());
+
+    final Events events = settings.getEvents();
+    if (events != null) {
+      formData
+          .withParam("new_note", events.getNewNote())
+          .withParam("new_issue", events.getNewIssue())
+          .withParam("reopen_issue", events.getReopenIssue())
+          .withParam("close_issue", events.getCloseIssue())
+          .withParam("reassign_issue", events.getReassignIssue())
+          .withParam("new_merge_request", events.getNewMergeRequest())
+          .withParam("reopen_merge_request", events.getReopenMergeRequest())
+          .withParam("close_merge_request", events.getCloseMergeRequest())
+          .withParam("reassign_merge_request", events.getReassignMergeRequest())
+          .withParam("merge_merge_request", events.getMergeMergeRequest())
+          .withParam("failed_pipeline", events.getFailedPipeline())
+          .withParam("success_pipeline", events.getSuccessPipeline());
     }
 
-    /**
-     * Update the global notification settings.
-     *
-     * <pre><code>GitLab Endpoint: PUT /notification_settings</code></pre>
-     *
-     * @param settings a NotificationSettings instance with the new settings
-     * @return a NotificationSettings instance containing the updated global notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings updateGlobalNotificationSettings(NotificationSettings settings) throws GitLabApiException {
+    final Response response =
+        put(Response.Status.OK, formData.asMap(), "groups", groupId, "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("level",  settings.getLevel())
-                .withParam("email",  settings.getEmail());
+  /**
+   * Get the notification settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/notification_settings</code></pre>
+   *
+   * @param projectId the project ID to get the notification settings for
+   * @return a NotificationSettings instance containing the specified project's notification
+   *     settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings getProjectNotificationSettings(final long projectId)
+      throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", projectId, "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
 
-        Events events = settings.getEvents();
-        if (events != null) {
-                formData.withParam("new_note", events.getNewNote())
-                .withParam("new_issue", events.getNewIssue())
-                .withParam("reopen_issue", events.getReopenIssue())
-                .withParam("close_issue", events.getCloseIssue())
-                .withParam("reassign_issue", events.getReassignIssue())
-                .withParam("new_merge_request", events.getNewMergeRequest())
-                .withParam("reopen_merge_request", events.getReopenMergeRequest())
-                .withParam("close_merge_request", events.getCloseMergeRequest())
-                .withParam("reassign_merge_request", events.getReassignMergeRequest())
-                .withParam("merge_merge_request", events.getMergeMergeRequest())
-                .withParam("failed_pipeline", events.getFailedPipeline())
-                .withParam("success_pipeline", events.getSuccessPipeline());
-        }
+  /**
+   * Update the notification settings for a project
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/notification_settings</code></pre>
+   *
+   * @param projectId the project ID to update the notification settings for
+   * @param settings a NotificationSettings instance with the new settings
+   * @return a NotificationSettings instance containing the updated project notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public NotificationSettings updateProjectNotificationSettings(
+      final long projectId, final NotificationSettings settings) throws GitLabApiException {
 
-        Response response = put(Response.Status.OK, formData.asMap(), "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("level", settings.getLevel())
+            .withParam("email", settings.getEmail());
+
+    final Events events = settings.getEvents();
+    if (events != null) {
+      formData
+          .withParam("new_note", events.getNewNote())
+          .withParam("new_issue", events.getNewIssue())
+          .withParam("reopen_issue", events.getReopenIssue())
+          .withParam("close_issue", events.getCloseIssue())
+          .withParam("reassign_issue", events.getReassignIssue())
+          .withParam("new_merge_request", events.getNewMergeRequest())
+          .withParam("reopen_merge_request", events.getReopenMergeRequest())
+          .withParam("close_merge_request", events.getCloseMergeRequest())
+          .withParam("reassign_merge_request", events.getReassignMergeRequest())
+          .withParam("merge_merge_request", events.getMergeMergeRequest())
+          .withParam("failed_pipeline", events.getFailedPipeline())
+          .withParam("success_pipeline", events.getSuccessPipeline());
     }
 
-    /**
-     * Get the notification settings for a group.
-     *
-     * <pre><code>GitLab Endpoint: GET /groups/:id/notification_settings</code></pre>
-     *
-     * @param groupId the group ID to get the notification settings for
-     * @return a NotificationSettings instance containing the specified group's notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings getGroupNotificationSettings(long groupId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "groups", groupId, "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
-    }
-
-    /**
-     * Update the notification settings for a group
-     *
-     * <pre><code>GitLab Endpoint: PUT /groups/:id/notification_settings</code></pre>
-     *
-     * @param groupId the group ID to update the notification settings for
-     * @param settings a NotificationSettings instance with the new settings
-     * @return a NotificationSettings instance containing the updated group notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings updateGroupNotificationSettings(long groupId, NotificationSettings settings) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("level",  settings.getLevel())
-                .withParam("email",  settings.getEmail());
-
-        Events events = settings.getEvents();
-        if (events != null) {
-                formData.withParam("new_note", events.getNewNote())
-                .withParam("new_issue", events.getNewIssue())
-                .withParam("reopen_issue", events.getReopenIssue())
-                .withParam("close_issue", events.getCloseIssue())
-                .withParam("reassign_issue", events.getReassignIssue())
-                .withParam("new_merge_request", events.getNewMergeRequest())
-                .withParam("reopen_merge_request", events.getReopenMergeRequest())
-                .withParam("close_merge_request", events.getCloseMergeRequest())
-                .withParam("reassign_merge_request", events.getReassignMergeRequest())
-                .withParam("merge_merge_request", events.getMergeMergeRequest())
-                .withParam("failed_pipeline", events.getFailedPipeline())
-                .withParam("success_pipeline", events.getSuccessPipeline());
-        }
-
-        Response response = put(Response.Status.OK, formData.asMap(), "groups", groupId, "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
-    }
-
-    /**
-     * Get the notification settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/notification_settings</code></pre>
-     *
-     * @param projectId the project ID to get the notification settings for
-     * @return a NotificationSettings instance containing the specified project's notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings getProjectNotificationSettings(long projectId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", projectId, "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
-    }
-
-    /**
-     * Update the notification settings for a project
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/notification_settings</code></pre>
-     *
-     * @param projectId the project ID to update the notification settings for
-     * @param settings a NotificationSettings instance with the new settings
-     * @return a NotificationSettings instance containing the updated project notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public NotificationSettings updateProjectNotificationSettings(long projectId, NotificationSettings settings) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("level",  settings.getLevel())
-                .withParam("email",  settings.getEmail());
-
-        Events events = settings.getEvents();
-        if (events != null) {
-                formData.withParam("new_note", events.getNewNote())
-                .withParam("new_issue", events.getNewIssue())
-                .withParam("reopen_issue", events.getReopenIssue())
-                .withParam("close_issue", events.getCloseIssue())
-                .withParam("reassign_issue", events.getReassignIssue())
-                .withParam("new_merge_request", events.getNewMergeRequest())
-                .withParam("reopen_merge_request", events.getReopenMergeRequest())
-                .withParam("close_merge_request", events.getCloseMergeRequest())
-                .withParam("reassign_merge_request", events.getReassignMergeRequest())
-                .withParam("merge_merge_request", events.getMergeMergeRequest())
-                .withParam("failed_pipeline", events.getFailedPipeline())
-                .withParam("success_pipeline", events.getSuccessPipeline());
-        }
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", projectId, "notification_settings");
-        return (response.readEntity(NotificationSettings.class));
-    }
+    final Response response =
+        put(Response.Status.OK, formData.asMap(), "projects", projectId, "notification_settings");
+    return (response.readEntity(NotificationSettings.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/PackagesApi.java
+++ b/src/main/java/org/gitlab4j/api/PackagesApi.java
@@ -25,11 +25,9 @@ package org.gitlab4j.api;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Package;
 import org.gitlab4j.api.models.PackageFile;
 import org.gitlab4j.api.models.PackageFilter;
@@ -37,12 +35,12 @@ import org.gitlab4j.api.models.PackageFilter;
 /**
  * <p>This class implements the client side API for the GitLab Packages API.
  * See <a href="https://docs.gitlab.com/ee/api/packages.html">Packages API at GitLab</a> for more information.</p>
- * 
+ *
  * NOTE: This API is not available in the Community edition of GitLab.
  */
 public class PackagesApi extends AbstractApi {
 
-    public PackagesApi(GitLabApi gitLabApi) {
+    public PackagesApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -56,7 +54,7 @@ public class PackagesApi extends AbstractApi {
      * @return a list of pages in the project's packages
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Package> getPackages(Object projectIdOrPath) throws GitLabApiException {
+    public List<Package> getPackages(final Object projectIdOrPath) throws GitLabApiException {
         return (getPackages(projectIdOrPath, getDefaultPerPage()).all());
     }
 
@@ -72,8 +70,8 @@ public class PackagesApi extends AbstractApi {
      * @return a list of project packages for the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Package> getPackages(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
+    public List<Package> getPackages(final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
                 "projects", getProjectIdOrPath(projectIdOrPath), "packages");
         return response.readEntity(new GenericType<List<Package>>() {});
     }
@@ -89,7 +87,7 @@ public class PackagesApi extends AbstractApi {
      * @return a Pager of project packages for the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Package> getPackages(Object projectIdOrPath,  int itemsPerPage) throws GitLabApiException {
+    public Pager<Package> getPackages(final Object projectIdOrPath,  final int itemsPerPage) throws GitLabApiException {
         return getPackages(projectIdOrPath,null,itemsPerPage);
     }
 
@@ -105,8 +103,8 @@ public class PackagesApi extends AbstractApi {
      * @return a Pager of project packages for the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Package> getPackages(Object projectIdOrPath, PackageFilter filter, int itemsPerPage) throws GitLabApiException {
-        MultivaluedMap query = filter!=null?filter.getQueryParams().asMap():null;
+    public Pager<Package> getPackages(final Object projectIdOrPath, final PackageFilter filter, final int itemsPerPage) throws GitLabApiException {
+        final MultivaluedMap query = filter!=null?filter.getQueryParams().asMap():null;
         return (new Pager<Package>(this, Package.class, itemsPerPage, query,
             "projects", getProjectIdOrPath(projectIdOrPath), "packages"));
     }
@@ -121,7 +119,7 @@ public class PackagesApi extends AbstractApi {
      * @return a Stream of pages in the project's packages
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Package> getPackagesStream(Object projectIdOrPath) throws GitLabApiException {
+    public Stream<Package> getPackagesStream(final Object projectIdOrPath) throws GitLabApiException {
         return (getPackages(projectIdOrPath, getDefaultPerPage()).stream());
     }
 
@@ -136,7 +134,7 @@ public class PackagesApi extends AbstractApi {
      * @return a Stream of pages in the project's packages
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Package> getPackagesStream(Object projectIdOrPath, PackageFilter filter) throws GitLabApiException {
+    public Stream<Package> getPackagesStream(final Object projectIdOrPath, final PackageFilter filter) throws GitLabApiException {
         return (getPackages(projectIdOrPath, filter, getDefaultPerPage()).stream());
     }
 
@@ -150,8 +148,8 @@ public class PackagesApi extends AbstractApi {
      * @return a Package instance for the specified package ID
      * @throws GitLabApiException if any exception occurs
      */
-    public Package getPackage(Object projectIdOrPath, Long packageId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
+    public Package getPackage(final Object projectIdOrPath, final Long packageId) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "packages", packageId);
         return (response.readEntity(Package.class));
     }
@@ -166,7 +164,7 @@ public class PackagesApi extends AbstractApi {
      * @return a list of PackageFile instances for the specified package ID
      * @throws GitLabApiException if any exception occurs
      */
-    public List<PackageFile> getPackageFiles(Object projectIdOrPath, Long packageId) throws GitLabApiException {
+    public List<PackageFile> getPackageFiles(final Object projectIdOrPath, final Long packageId) throws GitLabApiException {
         return (getPackageFiles(projectIdOrPath, packageId, getDefaultPerPage()).all());
     }
 
@@ -182,14 +180,14 @@ public class PackagesApi extends AbstractApi {
      * @return a list of PackageFile instances for the specified package ID
      * @throws GitLabApiException if any exception occurs
      */
-    public List<PackageFile> getPackageFiles(Object projectIdOrPath, Long packageId, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
+    public List<PackageFile> getPackageFiles(final Object projectIdOrPath, final Long packageId, final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
                 "projects", getProjectIdOrPath(projectIdOrPath), "packages", packageId, "package_files");
         return response.readEntity(new GenericType<List<PackageFile>>() {});
     }
 
     /**
-     * Get a Pager of project package files. 
+     * Get a Pager of project package files.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/packages/:package_id/package_files</code></pre>
      *
@@ -199,13 +197,13 @@ public class PackagesApi extends AbstractApi {
      * @return a Pager of PackageFile instances for the specified package ID
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<PackageFile> getPackageFiles(Object projectIdOrPath,  Long packageId, int itemsPerPage) throws GitLabApiException {
+    public Pager<PackageFile> getPackageFiles(final Object projectIdOrPath,  final Long packageId, final int itemsPerPage) throws GitLabApiException {
         return (new Pager<PackageFile>(this, PackageFile.class, itemsPerPage, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "packages", packageId, "package_files"));
     }
 
     /**
-     * Get a Stream of project package files. 
+     * Get a Stream of project package files.
      *
      * <pre><code>GitLab Endpoint: GET /projects/:id/packages/:package_id/package_files</code></pre>
      *
@@ -214,7 +212,7 @@ public class PackagesApi extends AbstractApi {
      * @return a Stream of PackageFile instances for the specified package ID
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<PackageFile> getPackagesStream(Object projectIdOrPath, Long packageId) throws GitLabApiException {
+    public Stream<PackageFile> getPackagesStream(final Object projectIdOrPath, final Long packageId) throws GitLabApiException {
         return (getPackageFiles(projectIdOrPath, packageId, getDefaultPerPage()).stream());
     }
 
@@ -227,7 +225,7 @@ public class PackagesApi extends AbstractApi {
      * @param packageId the ID of the package to delete
      * @throws GitLabApiException if any exception occurs
      */
-    public void deletePackage(Object projectIdOrPath, Long packageId) throws GitLabApiException {
+    public void deletePackage(final Object projectIdOrPath, final Long packageId) throws GitLabApiException {
 
         if (packageId == null) {
             throw new RuntimeException("packageId cannot be null");

--- a/src/main/java/org/gitlab4j/api/Pager.java
+++ b/src/main/java/org/gitlab4j/api/Pager.java
@@ -1,5 +1,9 @@
 package org.gitlab4j.api;
 
+import com.fasterxml.jackson.databind.JavaType;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
@@ -8,21 +12,14 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.databind.JavaType;
-import com.fasterxml.jackson.databind.ObjectMapper;
-
 /**
- * <p>This class defines an Iterator implementation that is used as a paging iterator for all API methods that
- * return a List of objects.  It hides the details of interacting with the GitLab API when paging is involved
- * simplifying accessing large lists of objects.</p>
+ * This class defines an Iterator implementation that is used as a paging iterator for all API
+ * methods that return a List of objects. It hides the details of interacting with the GitLab API
+ * when paging is involved simplifying accessing large lists of objects.
  *
- * <p>Example usage:</p>
+ * <p>Example usage:
  *
  * <pre>
  *   // Get a Pager instance that will page through the projects with 10 projects per page
@@ -41,379 +38,395 @@ import com.fasterxml.jackson.databind.ObjectMapper;
  */
 public class Pager<T> implements Iterator<List<T>>, Constants {
 
-    private int itemsPerPage;
-    private int totalPages;
-    private int totalItems;
-    private int currentPage;
-    private int kaminariNextPage;
+  private int itemsPerPage;
+  private int totalPages;
+  private int totalItems;
+  private int currentPage;
+  private int kaminariNextPage;
 
-    private List<String> pageParam = new ArrayList<>(1);
-    private List<T> currentItems;
-    private Stream<T> pagerStream = null;
+  private List<String> pageParam = new ArrayList<>(1);
+  private List<T> currentItems;
+  private Stream<T> pagerStream = null;
 
-    private AbstractApi api;
-    private MultivaluedMap<String, String> queryParams;
-    private Object[] pathArgs;
+  private final AbstractApi api;
+  private final MultivaluedMap<String, String> queryParams;
+  private final Object[] pathArgs;
 
-    private static JacksonJson jacksonJson = new JacksonJson();
-    private static ObjectMapper mapper = jacksonJson.getObjectMapper();
-    private JavaType javaType;
+  private static final JacksonJson jacksonJson = new JacksonJson();
+  private static final ObjectMapper mapper = jacksonJson.getObjectMapper();
+  private final JavaType javaType;
 
-    /**
-     * Creates a Pager instance to access the API through the specified path and query parameters.
-     *
-     * @param api the AbstractApi implementation to communicate through
-     * @param type the GitLab4J type that will be contained in the List
-     * @param itemsPerPage items per page
-     * @param queryParams HTTP query params
-     * @param pathArgs HTTP path arguments
-     * @throws GitLabApiException if any error occurs
-     */
-    Pager(AbstractApi api, Class<T> type, int itemsPerPage, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
+  /**
+   * Creates a Pager instance to access the API through the specified path and query parameters.
+   *
+   * @param api the AbstractApi implementation to communicate through
+   * @param type the GitLab4J type that will be contained in the List
+   * @param itemsPerPage items per page
+   * @param queryParams HTTP query params
+   * @param pathArgs HTTP path arguments
+   * @throws GitLabApiException if any error occurs
+   */
+  Pager(
+      final AbstractApi api,
+      final Class<T> type,
+      int itemsPerPage,
+      MultivaluedMap<String, String> queryParams,
+      final Object... pathArgs)
+      throws GitLabApiException {
 
-        javaType = mapper.getTypeFactory().constructCollectionType(List.class, type);
+    javaType = mapper.getTypeFactory().constructCollectionType(List.class, type);
 
-        if (itemsPerPage < 1) {
-            itemsPerPage = api.getDefaultPerPage();
-        }
-
-        // Make sure the per_page parameter is present
-        if (queryParams == null) {
-            queryParams = new GitLabApiForm().withParam(PER_PAGE_PARAM, itemsPerPage).asMap();
-        } else {
-            queryParams.remove(PER_PAGE_PARAM);
-            queryParams.add(PER_PAGE_PARAM, Integer.toString(itemsPerPage));
-        }
-
-        // Set the page param to 1
-        pageParam = new ArrayList<>();
-        pageParam.add("1");
-        queryParams.put(PAGE_PARAM, pageParam);
-        Response response = api.get(Response.Status.OK, queryParams, pathArgs);
-
-        try {
-            currentItems = mapper.readValue((InputStream) response.getEntity(), javaType);
-        } catch (Exception e) {
-            throw new GitLabApiException(e);
-        }
-
-        if (currentItems == null) {
-            throw new GitLabApiException("Invalid response from from GitLab server");
-        }
-
-        this.api = api;
-        this.queryParams = queryParams;
-        this.pathArgs = pathArgs;
-        this.itemsPerPage = getIntHeaderValue(response, PER_PAGE);
-
-        // Some API endpoints do not return the "X-Per-Page" header when there is only 1 page, check for that condition and act accordingly
-        if (this.itemsPerPage == -1) {
-            this.itemsPerPage = itemsPerPage;
-            totalPages = 1;
-            totalItems = currentItems.size();
-            return;
-        }
-
-        totalPages = getIntHeaderValue(response, TOTAL_PAGES_HEADER);
-        totalItems = getIntHeaderValue(response, TOTAL_HEADER);
-
-        // Since GitLab 11.8 and behind the api_kaminari_count_with_limit feature flag,
-        // if the number of resources is more than 10,000, the X-Total and X-Total-Page
-        // headers as well as the rel="last" Link are not present in the response headers.
-        if (totalPages == -1 || totalItems == -1) {
-
-            int nextPage = getIntHeaderValue(response, NEXT_PAGE_HEADER);
-            if (nextPage < 2) {
-                totalPages = 1;
-                totalItems = currentItems.size();
-            } else {
-                kaminariNextPage = 2;
-            }
-        }
-     }
-
-    /**
-     * Get the specified header value from the Response instance.
-     *
-     * @param response the Response instance to get the value from
-     * @param key the HTTP header key to get the value for
-     * @return the specified header value from the Response instance, or null if the header is not present
-     * @throws GitLabApiException if any error occurs
-     */
-    private String getHeaderValue(Response response, String key) throws GitLabApiException {
-
-        String value = response.getHeaderString(key);
-        value = (value != null ? value.trim() : null);
-        if (value == null || value.length() == 0) {
-            return (null);
-        }
-
-        return (value);
+    if (itemsPerPage < 1) {
+      itemsPerPage = api.getDefaultPerPage();
     }
 
-    /**
-     * Get the specified integer header value from the Response instance.
-     *
-     * @param response the Response instance to get the value from
-     * @param key the HTTP header key to get the value for
-     * @return the specified integer header value from the Response instance, or -1 if the header is not present
-     * @throws GitLabApiException if any error occurs
-     */
-    private int getIntHeaderValue(Response response, String key) throws GitLabApiException {
-
-        String value = getHeaderValue(response, key);
-        if (value == null) {
-            return -1;
-        }
-
-        try {
-            return (Integer.parseInt(value));
-        } catch (NumberFormatException nfe) {
-            throw new GitLabApiException("Invalid '" + key + "' header value (" + value + ") from server");
-        }
+    // Make sure the per_page parameter is present
+    if (queryParams == null) {
+      queryParams = new GitLabApiForm().withParam(PER_PAGE_PARAM, itemsPerPage).asMap();
+    } else {
+      queryParams.remove(PER_PAGE_PARAM);
+      queryParams.add(PER_PAGE_PARAM, Integer.toString(itemsPerPage));
     }
 
-    /**
-     * Sets the "page" query parameter.
-     *
-     * @param page the value for the "page" query parameter
-     */
-    private void setPageParam(int page) {
-        pageParam.set(0, Integer.toString(page));
-        queryParams.put(PAGE_PARAM, pageParam);
+    // Set the page param to 1
+    pageParam = new ArrayList<>();
+    pageParam.add("1");
+    queryParams.put(PAGE_PARAM, pageParam);
+    final Response response = api.get(Response.Status.OK, queryParams, pathArgs);
+
+    try {
+      currentItems = mapper.readValue((InputStream) response.getEntity(), javaType);
+    } catch (final Exception e) {
+      throw new GitLabApiException(e);
     }
 
-    /**
-     * Get the items per page value.
-     *
-     * @return the items per page value
-     */
-    public int getItemsPerPage() {
-        return (itemsPerPage);
+    if (currentItems == null) {
+      throw new GitLabApiException("Invalid response from from GitLab server");
     }
 
-    /**
-     * Get the total number of pages returned by the GitLab API.
-     *
-     * @return the total number of pages returned by the GitLab API, or -1 if the Kaminari limit of 10,000 has been exceeded
-     */
-    public int getTotalPages() {
-        return (totalPages);
+    this.api = api;
+    this.queryParams = queryParams;
+    this.pathArgs = pathArgs;
+    this.itemsPerPage = getIntHeaderValue(response, PER_PAGE);
+
+    // Some API endpoints do not return the "X-Per-Page" header when there is only 1 page, check for
+    // that condition and act accordingly
+    if (this.itemsPerPage == -1) {
+      this.itemsPerPage = itemsPerPage;
+      totalPages = 1;
+      totalItems = currentItems.size();
+      return;
     }
 
-    /**
-     * Get the total number of items (T instances) returned by the GitLab API.
-     *
-     * @return the total number of items (T instances) returned by the GitLab API, or -1 if the Kaminari limit of 10,000 has been exceeded
-     */
-    public int getTotalItems() {
-        return (totalItems);
+    totalPages = getIntHeaderValue(response, TOTAL_PAGES_HEADER);
+    totalItems = getIntHeaderValue(response, TOTAL_HEADER);
+
+    // Since GitLab 11.8 and behind the api_kaminari_count_with_limit feature flag,
+    // if the number of resources is more than 10,000, the X-Total and X-Total-Page
+    // headers as well as the rel="last" Link are not present in the response headers.
+    if (totalPages == -1 || totalItems == -1) {
+
+      final int nextPage = getIntHeaderValue(response, NEXT_PAGE_HEADER);
+      if (nextPage < 2) {
+        totalPages = 1;
+        totalItems = currentItems.size();
+      } else {
+        kaminariNextPage = 2;
+      }
+    }
+  }
+
+  /**
+   * Get the specified header value from the Response instance.
+   *
+   * @param response the Response instance to get the value from
+   * @param key the HTTP header key to get the value for
+   * @return the specified header value from the Response instance, or null if the header is not
+   *     present
+   * @throws GitLabApiException if any error occurs
+   */
+  private String getHeaderValue(final Response response, final String key)
+      throws GitLabApiException {
+
+    String value = response.getHeaderString(key);
+    value = (value != null ? value.trim() : null);
+    if (value == null || value.length() == 0) {
+      return (null);
     }
 
-    /**
-     * Get the current page of the iteration.
-     *
-     * @return the current page of the iteration
-     */
-    public int getCurrentPage() {
-        return (currentPage);
+    return (value);
+  }
+
+  /**
+   * Get the specified integer header value from the Response instance.
+   *
+   * @param response the Response instance to get the value from
+   * @param key the HTTP header key to get the value for
+   * @return the specified integer header value from the Response instance, or -1 if the header is
+   *     not present
+   * @throws GitLabApiException if any error occurs
+   */
+  private int getIntHeaderValue(final Response response, final String key)
+      throws GitLabApiException {
+
+    final String value = getHeaderValue(response, key);
+    if (value == null) {
+      return -1;
     }
 
-    /**
-     * Returns the true if there are additional pages to iterate over, otherwise returns false.
-     *
-     * @return true if there are additional pages to iterate over, otherwise returns false
-     */
-    @Override
-    public boolean hasNext() {
-        return (currentPage < totalPages || currentPage < kaminariNextPage);
+    try {
+      return (Integer.parseInt(value));
+    } catch (final NumberFormatException nfe) {
+      throw new GitLabApiException(
+          "Invalid '" + key + "' header value (" + value + ") from server");
+    }
+  }
+
+  /**
+   * Sets the "page" query parameter.
+   *
+   * @param page the value for the "page" query parameter
+   */
+  private void setPageParam(final int page) {
+    pageParam.set(0, Integer.toString(page));
+    queryParams.put(PAGE_PARAM, pageParam);
+  }
+
+  /**
+   * Get the items per page value.
+   *
+   * @return the items per page value
+   */
+  public int getItemsPerPage() {
+    return (itemsPerPage);
+  }
+
+  /**
+   * Get the total number of pages returned by the GitLab API.
+   *
+   * @return the total number of pages returned by the GitLab API, or -1 if the Kaminari limit of
+   *     10,000 has been exceeded
+   */
+  public int getTotalPages() {
+    return (totalPages);
+  }
+
+  /**
+   * Get the total number of items (T instances) returned by the GitLab API.
+   *
+   * @return the total number of items (T instances) returned by the GitLab API, or -1 if the
+   *     Kaminari limit of 10,000 has been exceeded
+   */
+  public int getTotalItems() {
+    return (totalItems);
+  }
+
+  /**
+   * Get the current page of the iteration.
+   *
+   * @return the current page of the iteration
+   */
+  public int getCurrentPage() {
+    return (currentPage);
+  }
+
+  /**
+   * Returns the true if there are additional pages to iterate over, otherwise returns false.
+   *
+   * @return true if there are additional pages to iterate over, otherwise returns false
+   */
+  @Override
+  public boolean hasNext() {
+    return (currentPage < totalPages || currentPage < kaminariNextPage);
+  }
+
+  /**
+   * Returns the next List in the iteration containing the next page of objects.
+   *
+   * @return the next List in the iteration
+   * @throws NoSuchElementException if the iteration has no more elements
+   * @throws RuntimeException if a GitLab API error occurs, will contain a wrapped
+   *     GitLabApiException with the details of the error
+   */
+  @Override
+  public List<T> next() {
+    return (page(currentPage + 1));
+  }
+
+  /**
+   * This method is not implemented and will throw an UnsupportedOperationException if called.
+   *
+   * @throws UnsupportedOperationException when invoked
+   */
+  @Override
+  public void remove() {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the first page of List. Will rewind the iterator.
+   *
+   * @return the first page of List
+   */
+  public List<T> first() {
+    return (page(1));
+  }
+
+  /**
+   * Returns the last page of List. Will set the iterator to the end.
+   *
+   * @return the last page of List
+   * @throws GitLabApiException if any error occurs
+   */
+  public List<T> last() throws GitLabApiException {
+
+    if (kaminariNextPage != 0) {
+      throw new GitLabApiException("Kaminari count limit exceeded, unable to fetch last page");
     }
 
-    /**
-     * Returns the next List in the iteration containing the next page of objects.
-     *
-     * @return the next List in the iteration
-     * @throws NoSuchElementException if the iteration has no more elements
-     * @throws RuntimeException if a GitLab API error occurs, will contain a wrapped GitLabApiException with the details of the error
-     */
-    @Override
-    public List<T> next() {
-        return (page(currentPage + 1));
+    return (page(totalPages));
+  }
+
+  /**
+   * Returns the previous page of List. Will set the iterator to the previous page.
+   *
+   * @return the previous page of List
+   */
+  public List<T> previous() {
+    return (page(currentPage - 1));
+  }
+
+  /**
+   * Returns the current page of List.
+   *
+   * @return the current page of List
+   */
+  public List<T> current() {
+    return (page(currentPage));
+  }
+
+  /**
+   * Returns the specified page of List.
+   *
+   * @param pageNumber the page to get
+   * @return the specified page of List
+   * @throws NoSuchElementException if the iteration has no more elements
+   * @throws RuntimeException if a GitLab API error occurs, will contain a wrapped
+   *     GitLabApiException with the details of the error
+   */
+  public List<T> page(final int pageNumber) {
+
+    if (currentPage == 0 && pageNumber == 1) {
+      currentPage = 1;
+      return (currentItems);
     }
 
-    /**
-     * This method is not implemented and will throw an UnsupportedOperationException if called.
-     *
-     * @throws UnsupportedOperationException when invoked
-     */
-    @Override
-    public void remove() {
-        throw new UnsupportedOperationException();
+    if (currentPage == pageNumber) {
+      return (currentItems);
     }
 
-    /**
-     * Returns the first page of List. Will rewind the iterator.
-     *
-     * @return the first page of List
-     */
-    public List<T> first() {
-        return (page(1));
+    if (pageNumber > totalPages && pageNumber > kaminariNextPage) {
+      throw new NoSuchElementException();
+    } else if (pageNumber < 1) {
+      throw new NoSuchElementException();
     }
 
-    /**
-     * Returns the last page of List. Will set the iterator to the end.
-     *
-     * @return the last page of List
-     * @throws GitLabApiException if any error occurs
-     */
-    public List<T> last() throws GitLabApiException {
+    try {
 
-        if (kaminariNextPage != 0) {
-            throw new GitLabApiException("Kaminari count limit exceeded, unable to fetch last page");
-        }
+      setPageParam(pageNumber);
+      final Response response = api.get(Response.Status.OK, queryParams, pathArgs);
+      currentItems = mapper.readValue((InputStream) response.getEntity(), javaType);
+      currentPage = pageNumber;
 
-        return (page(totalPages));
+      if (kaminariNextPage > 0) {
+        kaminariNextPage = getIntHeaderValue(response, NEXT_PAGE_HEADER);
+      }
+
+      return (currentItems);
+
+    } catch (final GitLabApiException | IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets all the items from each page as a single List instance.
+   *
+   * @return all the items from each page as a single List instance
+   * @throws GitLabApiException if any error occurs
+   */
+  public List<T> all() throws GitLabApiException {
+
+    // Make sure that current page is 0, this will ensure the whole list is fetched
+    // regardless of what page the instance is currently on.
+    currentPage = 0;
+    final List<T> allItems = new ArrayList<>(Math.max(totalItems, 0));
+
+    // Iterate through the pages and append each page of items to the list
+    while (hasNext()) {
+      allItems.addAll(next());
     }
 
-    /**
-     * Returns the previous page of List. Will set the iterator to the previous page.
-     *
-     * @return the previous page of List
-     */
-    public List<T> previous() {
-        return (page(currentPage - 1));
-    }
+    return (allItems);
+  }
 
-    /**
-     * Returns the current page of List.
-     *
-     * @return the current page of List
-     */
-    public List<T> current() {
-        return (page(currentPage));
-    }
+  /**
+   * Builds and returns a Stream instance which is pre-populated with all items from all pages.
+   *
+   * @return a Stream instance which is pre-populated with all items from all pages
+   * @throws IllegalStateException if Stream has already been issued
+   * @throws GitLabApiException if any other error occurs
+   */
+  public Stream<T> stream() throws GitLabApiException, IllegalStateException {
 
-    /**
-     * Returns the specified page of List.
-     *
-     * @param pageNumber the page to get
-     * @return the specified page of List
-     * @throws NoSuchElementException if the iteration has no more elements
-     * @throws RuntimeException if a GitLab API error occurs, will contain a wrapped GitLabApiException with the details of the error
-     */
-    public List<T> page(int pageNumber) {
-
-        if (currentPage == 0 && pageNumber == 1) {
-            currentPage = 1;
-            return (currentItems);
-        }
-
-        if (currentPage == pageNumber) {
-            return (currentItems);
-        }
-
-        if (pageNumber > totalPages && pageNumber > kaminariNextPage) {
-            throw new NoSuchElementException();
-        } else if (pageNumber < 1) {
-            throw new NoSuchElementException();
-        }
-
-        try {
-
-            setPageParam(pageNumber);
-            Response response = api.get(Response.Status.OK, queryParams, pathArgs);
-            currentItems = mapper.readValue((InputStream) response.getEntity(), javaType);
-            currentPage = pageNumber;
-
-            if (kaminariNextPage > 0) {
-                kaminariNextPage = getIntHeaderValue(response, NEXT_PAGE_HEADER);
-            }
-
-            return (currentItems);
-
-        } catch (GitLabApiException | IOException e) {
-            throw new RuntimeException(e);
-        }
-    }
-
-    /**
-     * Gets all the items from each page as a single List instance.
-     *
-     * @return all the items from each page as a single List instance
-     * @throws GitLabApiException if any error occurs
-     */
-    public List<T> all() throws GitLabApiException {
-
-        // Make sure that current page is 0, this will ensure the whole list is fetched
-        // regardless of what page the instance is currently on.
-        currentPage = 0;
-        List<T> allItems = new ArrayList<>(Math.max(totalItems, 0));
-
-        // Iterate through the pages and append each page of items to the list
-        while (hasNext()) {
-            allItems.addAll(next());
-        }
-
-        return (allItems);
-    }
-
-    /**
-     * Builds and returns a Stream instance which is pre-populated with all items from all pages.
-     *
-     * @return a Stream instance which is pre-populated with all items from all pages
-     * @throws IllegalStateException if Stream has already been issued
-     * @throws GitLabApiException if any other error occurs
-     */
-    public Stream<T> stream() throws GitLabApiException, IllegalStateException {
-
+    if (pagerStream == null) {
+      synchronized (this) {
         if (pagerStream == null) {
-            synchronized (this) {
-                if (pagerStream == null) {
 
-                    // Make sure that current page is 0, this will ensure the whole list is streamed
-                    // regardless of what page the instance is currently on.
-                    currentPage = 0;
+          // Make sure that current page is 0, this will ensure the whole list is streamed
+          // regardless of what page the instance is currently on.
+          currentPage = 0;
 
-                    // Create a Stream.Builder to contain all the items. This is more efficient than
-                    // getting a List with all() and streaming that List
-                    Stream.Builder<T> streamBuilder = Stream.builder();
+          // Create a Stream.Builder to contain all the items. This is more efficient than
+          // getting a List with all() and streaming that List
+          final Stream.Builder<T> streamBuilder = Stream.builder();
 
-                    // Iterate through the pages and append each page of items to the stream builder
-                    while (hasNext()) {
-                        next().forEach(streamBuilder);
-                    }
+          // Iterate through the pages and append each page of items to the stream builder
+          while (hasNext()) {
+            next().forEach(streamBuilder);
+          }
 
-                    pagerStream = streamBuilder.build();
-                    return (pagerStream);
-                }
-            }
+          pagerStream = streamBuilder.build();
+          return (pagerStream);
         }
-
-        throw new IllegalStateException("Stream already issued");
+      }
     }
 
-    /**
-     * Creates a Stream instance for lazily streaming items from the GitLab server.
-     *
-     * @return a Stream instance for lazily streaming items from the GitLab server
-     * @throws IllegalStateException if Stream has already been issued
-     */
-    public Stream<T> lazyStream() throws IllegalStateException {
+    throw new IllegalStateException("Stream already issued");
+  }
 
+  /**
+   * Creates a Stream instance for lazily streaming items from the GitLab server.
+   *
+   * @return a Stream instance for lazily streaming items from the GitLab server
+   * @throws IllegalStateException if Stream has already been issued
+   */
+  public Stream<T> lazyStream() throws IllegalStateException {
+
+    if (pagerStream == null) {
+      synchronized (this) {
         if (pagerStream == null) {
-            synchronized (this) {
-                if (pagerStream == null) {
 
-                    // Make sure that current page is 0, this will ensure the whole list is streamed
-                    // regardless of what page the instance is currently on.
-                    currentPage = 0;
+          // Make sure that current page is 0, this will ensure the whole list is streamed
+          // regardless of what page the instance is currently on.
+          currentPage = 0;
 
-                    pagerStream = StreamSupport.stream(new PagerSpliterator<T>(this), false);
-                    return (pagerStream);
-                }
-            }
+          pagerStream = StreamSupport.stream(new PagerSpliterator<T>(this), false);
+          return (pagerStream);
         }
-
-        throw new IllegalStateException("Stream already issued");
+      }
     }
+
+    throw new IllegalStateException("Stream already issued");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/PipelineApi.java
+++ b/src/main/java/org/gitlab4j/api/PipelineApi.java
@@ -4,11 +4,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Pipeline;
 import org.gitlab4j.api.models.PipelineFilter;
 import org.gitlab4j.api.models.PipelineSchedule;
@@ -17,843 +15,1244 @@ import org.gitlab4j.api.models.Trigger;
 import org.gitlab4j.api.models.Variable;
 
 /**
- * <p>This class provides an entry point to all the GitLab API pipeline related calls.
- * For more information on the Pipeline APIs see:</p>
- *
- * <a href="https://docs.gitlab.com/ee/api/pipelines.html">Pipelines API</a>
- * <a href="https://docs.gitlab.com/ee/api/pipeline_schedules.html">Pipeline Schedules API</a>
- * <a href="https://docs.gitlab.com/ee/api/pipeline_triggers.html">Pipeline Triggers API</a>
+ * This class provides an entry point to all the GitLab API pipeline related calls. For more
+ * information on the Pipeline APIs see: <a
+ * href="https://docs.gitlab.com/ee/api/pipelines.html">Pipelines API</a> <a
+ * href="https://docs.gitlab.com/ee/api/pipeline_schedules.html">Pipeline Schedules API</a> <a
+ * href="https://docs.gitlab.com/ee/api/pipeline_triggers.html">Pipeline Triggers API</a>
  */
 public class PipelineApi extends AbstractApi implements Constants {
 
-    public PipelineApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public PipelineApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getPipelines(final Object projectIdOrPath) throws GitLabApiException {
+    return (getPipelines(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of pipelines in a project in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of Pipeline instances per page
+   * @return a list containing the pipelines for the specified project ID in the specified page
+   *     range
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getPipelines(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines");
+    return (response.readEntity(new GenericType<List<Pipeline>>() {}));
+  }
+
+  /**
+   * Get a Pager of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Pipeline instances that will be fetched per page
+   * @return a Pager containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Pipeline> getPipelines(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Pipeline>(
+        this,
+        Pipeline.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines"));
+  }
+
+  /**
+   * Get a Stream of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Pipeline> getPipelinesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getPipelines(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of pipelines in a project filtered with the provided {@link
+   * org.gitlab4j.api.models.PipelineFilter}.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter a PipelineFilter instance used to filter the results
+   * @return a list containing the pipelines for the specified project ID and matching the provided
+   *     filter
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getPipelines(final Object projectIdOrPath, final PipelineFilter filter)
+      throws GitLabApiException {
+    return (getPipelines(projectIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of pipelines in a project filtered with the provided {@link
+   * org.gitlab4j.api.models.PipelineFilter}.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter a PipelineFilter instance used to filter the results
+   * @param itemsPerPage the number of Pipeline instances that will be fetched per page
+   * @return a Pager containing the pipelines for the specified project ID and matching the provided
+   *     filter
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Pipeline> getPipelines(
+      final Object projectIdOrPath, final PipelineFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
+    return (new Pager<Pipeline>(
+        this,
+        Pipeline.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines"));
+  }
+
+  /**
+   * Get a Stream of pipelines in a project filtered with the provided {@link
+   * org.gitlab4j.api.models.PipelineFilter}.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter a PipelineFilter instance used to filter the results
+   * @return a Stream containing the pipelines for the specified project ID and matching the
+   *     provided filter
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Pipeline> getPipelinesStream(
+      final Object projectIdOrPath, final PipelineFilter filter) throws GitLabApiException {
+    return (getPipelines(projectIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
+   * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED,
+   *     SKIPPED
+   * @param ref the ref of pipelines
+   * @param yamlErrors returns pipelines with invalid configurations
+   * @param name the name of the user who triggered pipelines
+   * @param username the username of the user who triggered pipelines
+   * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
+   * @param sort sort pipelines in ASC or DESC order (default: DESC)
+   * @return a list containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getPipelines(
+      final Object projectIdOrPath,
+      final PipelineScope scope,
+      final PipelineStatus status,
+      final String ref,
+      final boolean yamlErrors,
+      final String name,
+      final String username,
+      final PipelineOrderBy orderBy,
+      final SortOrder sort)
+      throws GitLabApiException {
+
+    return (getPipelines(
+            projectIdOrPath,
+            scope,
+            status,
+            ref,
+            yamlErrors,
+            name,
+            username,
+            orderBy,
+            sort,
+            getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of pipelines in a project in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
+   * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED,
+   *     SKIPPED
+   * @param ref the ref of pipelines
+   * @param yamlErrors returns pipelines with invalid configurations
+   * @param name the name of the user who triggered pipelines
+   * @param username the username of the user who triggered pipelines
+   * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
+   * @param sort sort pipelines in ASC or DESC order (default: DESC)
+   * @param page the page to get
+   * @param perPage the number of Pipeline instances per page
+   * @return a list containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public List<Pipeline> getPipelines(
+      final Object projectIdOrPath,
+      final PipelineScope scope,
+      final PipelineStatus status,
+      final String ref,
+      final boolean yamlErrors,
+      final String name,
+      final String username,
+      final PipelineOrderBy orderBy,
+      final SortOrder sort,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("scope", scope)
+            .withParam("status", status)
+            .withParam("ref", ref)
+            .withParam("yaml_errors", yamlErrors)
+            .withParam("name", name)
+            .withParam("username", username)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sort)
+            .withParam("page", page)
+            .withParam(PER_PAGE_PARAM, perPage);
+
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines");
+    return (response.readEntity(new GenericType<List<Pipeline>>() {}));
+  }
+
+  /**
+   * Get a Stream of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
+   * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED,
+   *     SKIPPED
+   * @param ref the ref of pipelines
+   * @param yamlErrors returns pipelines with invalid configurations
+   * @param name the name of the user who triggered pipelines
+   * @param username the username of the user who triggered pipelines
+   * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
+   * @param sort sort pipelines in ASC or DESC order (default: DESC)
+   * @return a Stream containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Stream<Pipeline> getPipelinesStream(
+      final Object projectIdOrPath,
+      final PipelineScope scope,
+      final PipelineStatus status,
+      final String ref,
+      final boolean yamlErrors,
+      final String name,
+      final String username,
+      final PipelineOrderBy orderBy,
+      final SortOrder sort)
+      throws GitLabApiException {
+
+    return (getPipelines(
+        projectIdOrPath,
+        scope,
+        status,
+        ref,
+        yamlErrors,
+        name,
+        username,
+        orderBy,
+        sort,
+        getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a Pager of pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
+   * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED,
+   *     SKIPPED
+   * @param ref the ref of pipelines
+   * @param yamlErrors returns pipelines with invalid configurations
+   * @param name the name of the user who triggered pipelines
+   * @param username the username of the user who triggered pipelines
+   * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
+   * @param sort sort pipelines in ASC or DESC order (default: DESC)
+   * @param itemsPerPage the number of Pipeline instances that will be fetched per page
+   * @return a list containing the pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pager<Pipeline> getPipelines(
+      final Object projectIdOrPath,
+      final PipelineScope scope,
+      final PipelineStatus status,
+      final String ref,
+      final boolean yamlErrors,
+      final String name,
+      final String username,
+      final PipelineOrderBy orderBy,
+      final SortOrder sort,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("scope", scope)
+            .withParam("status", status)
+            .withParam("ref", (ref != null ? urlEncode(ref) : null))
+            .withParam("yaml_errors", yamlErrors)
+            .withParam("name", name)
+            .withParam("username", username)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sort);
+
+    return (new Pager<Pipeline>(
+        this,
+        Pipeline.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines"));
+  }
+
+  /**
+   * Get single pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param pipelineId the pipeline ID to get
+   * @return a single pipelines for the specified project ID
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline getPipeline(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines",
+            pipelineId);
+    return (response.readEntity(Pipeline.class));
+  }
+
+  /**
+   * Create a pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref reference to commit
+   * @return a Pipeline instance with the newly created pipeline info
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline createPipeline(final Object projectIdOrPath, final String ref)
+      throws GitLabApiException {
+    return (createPipeline(projectIdOrPath, ref, Variable.convertMapToList(null)));
+  }
+
+  /**
+   * Create a pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref reference to commit
+   * @param variables a Map containing the variables available in the pipeline
+   * @return a Pipeline instance with the newly created pipeline info
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline createPipeline(
+      final Object projectIdOrPath, final String ref, final Map<String, String> variables)
+      throws GitLabApiException {
+    return (createPipeline(projectIdOrPath, ref, Variable.convertMapToList(variables)));
+  }
+
+  /**
+   * Create a pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref reference to commit
+   * @param variables a Map containing the variables available in the pipeline
+   * @return a Pipeline instance with the newly created pipeline info
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline createPipeline(
+      final Object projectIdOrPath, final String ref, final List<Variable> variables)
+      throws GitLabApiException {
+
+    if (ref == null || ref.trim().isEmpty()) {
+      throw new GitLabApiException("ref cannot be null or empty");
     }
 
-    /**
-     * Get a list of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getPipelines(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelines(projectIdOrPath, getDefaultPerPage()).all());
+    if (variables == null || variables.isEmpty()) {
+      final GitLabApiForm formData = new GitLabApiForm().withParam("ref", ref, true);
+      final Response response =
+          post(
+              Response.Status.CREATED,
+              formData,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "pipeline");
+      return (response.readEntity(Pipeline.class));
     }
 
-    /**
-     * Get a list of pipelines in a project in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of Pipeline instances per page
-     * @return a list containing the pipelines for the specified project ID in the specified page range
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getPipelines(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines");
-        return (response.readEntity(new GenericType<List<Pipeline>>() {}));
+    // The create pipeline REST API expects the variable data in an unusual format, this
+    // class is used to create the JSON for the POST data.
+    class CreatePipelineForm {
+      @SuppressWarnings("unused")
+      public final String ref;
+
+      @SuppressWarnings("unused")
+      public final List<Variable> variables;
+
+      CreatePipelineForm(final String ref, final List<Variable> variables) {
+        this.ref = ref;
+        this.variables = variables;
+      }
     }
 
-    /**
-     * Get a Pager of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Pipeline instances that will be fetched per page
-     * @return a Pager containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Pipeline> getPipelines(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Pipeline>(this, Pipeline.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines"));
+    final CreatePipelineForm pipelineForm = new CreatePipelineForm(ref, variables);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            pipelineForm,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline");
+    return (response.readEntity(Pipeline.class));
+  }
+
+  /**
+   * Delete a pipeline from a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/pipelines/:pipeline_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param pipelineId the pipeline ID to delete
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void deletePipeline(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.ACCEPTED,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines",
+        pipelineId);
+  }
+
+  /**
+   * Retry a job in specified pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/pipelines/:pipeline_id/retry</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param pipelineId the pipeline ID to retry a job from
+   * @return pipeline instance which just retried
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline retryPipelineJob(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines",
+            pipelineId,
+            "retry");
+    return (response.readEntity(Pipeline.class));
+  }
+
+  /**
+   * Cancel jobs of specified pipelines in a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/pipelines/:pipeline_id/cancel</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param pipelineId the pipeline ID to cancel jobs
+   * @return pipeline instance which just canceled
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Pipeline cancelPipelineJobs(final Object projectIdOrPath, final long pipelineId)
+      throws GitLabApiException {
+    final GitLabApiForm formData = null;
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipelines",
+            pipelineId,
+            "cancel");
+    return (response.readEntity(Pipeline.class));
+  }
+
+  /**
+   * Get a list of the project pipeline_schedules for the specified project.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedules</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @return a list of pipeline schedules for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<PipelineSchedule> getPipelineSchedules(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getPipelineSchedules(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get list of project pipeline schedules in the specified page range.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedules</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param page the page to get
+   * @param perPage the number of PipelineSchedule instances per page
+   * @return a list of project pipeline_schedules for the specified project in the specified page
+   *     range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<PipelineSchedule> getPipelineSchedules(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules");
+    return (response.readEntity(new GenericType<List<PipelineSchedule>>() {}));
+  }
+
+  /**
+   * Get Pager of project pipeline schedule.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param itemsPerPage the number of PipelineSchedule instances that will be fetched per page
+   * @return a Pager of project pipeline_schedules for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<PipelineSchedule> getPipelineSchedules(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<PipelineSchedule>(
+        this,
+        PipelineSchedule.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipeline_schedules"));
+  }
+
+  /**
+   * Get a Stream of the project pipeline schedule for the specified project.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @return a Stream of project pipeline schedules for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<PipelineSchedule> getPipelineSchedulesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getPipelineSchedules(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific pipeline schedule for project.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the ID of the pipeline schedule to get
+   * @return the project PipelineSchedule
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PipelineSchedule getPipelineSchedule(
+      final Object projectIdOrPath, final Long pipelineScheduleId) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules",
+            pipelineScheduleId);
+    return (response.readEntity(PipelineSchedule.class));
+  }
+
+  /**
+   * Get a specific pipeline schedule for project as an Optional instance.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the ID of the hook to get
+   * @return the project PipelineSchedule as an Optional instance
+   */
+  public Optional<PipelineSchedule> getOptionalPipelineSchedule(
+      final Object projectIdOrPath, final Long pipelineScheduleId) {
+    try {
+      return (Optional.ofNullable(getPipelineSchedule(projectIdOrPath, pipelineScheduleId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * create a pipeline schedule for a project.
+   *
+   * <pre><code>POST /projects/:id/pipeline_schedules</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineSchedule a PipelineSchedule instance to create
+   * @return the added PipelineSchedule instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PipelineSchedule createPipelineSchedule(
+      final Object projectIdOrPath, final PipelineSchedule pipelineSchedule)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("description", pipelineSchedule.getDescription(), true)
+            .withParam("ref", pipelineSchedule.getRef(), true)
+            .withParam("cron", pipelineSchedule.getCron(), true)
+            .withParam("cron_timezone", pipelineSchedule.getCronTimezone(), false)
+            .withParam("active", pipelineSchedule.getActive(), false);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules");
+    return (response.readEntity(PipelineSchedule.class));
+  }
+
+  /**
+   * Deletes a pipeline schedule from the project.
+   *
+   * <pre><code>DELETE /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the project schedule ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deletePipelineSchedule(final Object projectIdOrPath, final Long pipelineScheduleId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipeline_schedules",
+        pipelineScheduleId);
+  }
+
+  /**
+   * Modifies a pipeline schedule for project.
+   *
+   * <pre><code>PUT /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineSchedule the pipelineSchedule instance that contains the pipelineSchedule info
+   *     to modify
+   * @return the modified project schedule
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PipelineSchedule updatePipelineSchedule(
+      final Object projectIdOrPath, final PipelineSchedule pipelineSchedule)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("description", pipelineSchedule.getDescription(), false)
+            .withParam("ref", pipelineSchedule.getRef(), false)
+            .withParam("cron", pipelineSchedule.getCron(), false)
+            .withParam("cron_timezone", pipelineSchedule.getCronTimezone(), false)
+            .withParam("active", pipelineSchedule.getActive(), false);
+
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules",
+            pipelineSchedule.getId());
+    return (response.readEntity(PipelineSchedule.class));
+  }
+
+  /**
+   * Update the owner of the pipeline schedule of a project.
+   *
+   * <pre><code>POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/take_ownership</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the pipelineSchedule instance id that ownership has to be taken of
+   * @return the modified project schedule
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PipelineSchedule takeOwnershipPipelineSchedule(
+      final Object projectIdOrPath, final Long pipelineScheduleId) throws GitLabApiException {
+
+    final Response response =
+        post(
+            Response.Status.OK,
+            "",
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules",
+            pipelineScheduleId,
+            "take_ownership");
+    return (response.readEntity(PipelineSchedule.class));
+  }
+
+  /**
+   * Trigger a new scheduled pipeline, which runs immediately.
+   *
+   * <pre><code>POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/play</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the pipelineSchedule instance id which should run immediately
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public void playPipelineSchedule(final Object projectIdOrPath, final Long pipelineScheduleId)
+      throws GitLabApiException {
+    post(
+        Response.Status.CREATED,
+        (Form) null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipeline_schedules",
+        pipelineScheduleId,
+        "play");
+  }
+
+  /**
+   * Create a pipeline schedule variable.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the pipelineSchedule ID
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed
+   * @param value the value for the variable
+   * @return a Pipeline instance with the newly created pipeline schedule variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createPipelineScheduleVariable(
+      final Object projectIdOrPath,
+      final Long pipelineScheduleId,
+      final String key,
+      final String value)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("key", key, true).withParam("value", value, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules",
+            pipelineScheduleId,
+            "variables");
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Update a pipeline schedule variable.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PUT /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables/:key</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the pipelineSchedule ID
+   * @param key the key of an existing pipeline schedule variable
+   * @param value the new value for the variable
+   * @return a Pipeline instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updatePipelineScheduleVariable(
+      final Object projectIdOrPath,
+      final Long pipelineScheduleId,
+      final String key,
+      final String value)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData = new GitLabApiForm().withParam("value", value, true);
+    final Response response =
+        this.putWithFormData(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "pipeline_schedules",
+            pipelineScheduleId,
+            "variables",
+            key);
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Deletes a pipeline schedule variable.
+   *
+   * <pre><code>DELETE /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables/:key</code>
+   * </pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineScheduleId the pipeline schedule ID
+   * @param key the key of an existing pipeline schedule variable
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deletePipelineScheduleVariable(
+      final Object projectIdOrPath, final Long pipelineScheduleId, final String key)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipeline_schedules",
+        pipelineScheduleId,
+        "variables",
+        key);
+  }
+
+  /**
+   * Get a list of the project pipeline triggers for the specified project.
+   *
+   * <pre><code>GET /projects/:id/triggers</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @return a list of pipeline triggers for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Trigger> getPipelineTriggers(final Object projectIdOrPath) throws GitLabApiException {
+    return (getPipelineTriggers(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get list of project pipeline triggers in the specified page range.
+   *
+   * <pre><code>GET /projects/:id/triggers</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param page the page to get
+   * @param perPage the number of Trigger instances per page
+   * @return a list of project pipeline triggers for the specified project in the specified page
+   *     range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Trigger> getPipelineTriggers(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "triggers");
+    return (response.readEntity(new GenericType<List<Trigger>>() {}));
+  }
+
+  /**
+   * Get Pager of project pipeline triggers.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of project pipeline triggers for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Trigger> getPipelineTriggers(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Trigger>(
+        this,
+        Trigger.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "triggers"));
+  }
+
+  /**
+   * Get a Stream of the project pipeline triggers for the specified project.
+   *
+   * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @return a Stream of project pipeline triggers for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Trigger> getPipelineTriggersStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getPipelineTriggers(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific pipeline schedule for project.
+   *
+   * <pre><code>GET /projects/:id/triggers/:trigger_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param triggerId the ID of the trigger to get
+   * @return the project pipeline trigger
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Trigger getPipelineTrigger(final Object projectIdOrPath, final Long triggerId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "triggers",
+            triggerId);
+    return (response.readEntity(Trigger.class));
+  }
+
+  /**
+   * Get a specific pipeline trigger for project as an Optional instance.
+   *
+   * <pre><code>GET /projects/:id/triggers/:trigger_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param triggerId the ID of the trigger to get
+   * @return the project pipeline trigger as an Optional instance
+   */
+  public Optional<Trigger> getOptionalPipelineTrigger(
+      final Object projectIdOrPath, final Long triggerId) {
+    try {
+      return (Optional.ofNullable(getPipelineTrigger(projectIdOrPath, triggerId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Create a pipeline trigger for a project.
+   *
+   * <pre><code>POST /projects/:id/triggers</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param description the trigger description
+   * @return the created Trigger instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Trigger createPipelineTrigger(final Object projectIdOrPath, final String description)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("description", description, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "triggers");
+    return (response.readEntity(Trigger.class));
+  }
+
+  /**
+   * Updates a pipeline trigger for project.
+   *
+   * <pre><code>PUT /projects/:id/triggers/:trigger_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param triggerId the trigger ID to update
+   * @param description the new trigger description
+   * @return the updated Trigger instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Trigger updatePipelineTrigger(
+      final Object projectIdOrPath, final Long triggerId, final String description)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("description", description, false);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "triggers",
+            triggerId);
+    return (response.readEntity(Trigger.class));
+  }
+
+  /**
+   * Deletes a pipeline trigger from the project.
+   *
+   * <pre><code>DELETE /projects/:id/triggers/:trigger_id</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param triggerId the project trigger ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deletePipelineTrigger(final Object projectIdOrPath, final Long triggerId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "triggers",
+        triggerId);
+  }
+
+  /**
+   * Take ownership of a pipeline trigger for project.
+   *
+   * <pre><code>PUT /projects/:id/triggers/:trigger_id/take_ownership</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param triggerId the trigger ID to take opwnership of
+   * @return the updated Trigger instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Trigger takeOwnewrshipOfPipelineTrigger(final Object projectIdOrPath, final Long triggerId)
+      throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "triggers",
+            triggerId,
+            "take_ownership");
+    return (response.readEntity(Trigger.class));
+  }
+
+  /**
+   * Trigger a pipeline for a project.
+   *
+   * <pre><code>POST /projects/:id/trigger/pipeline</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param trigger the Trigger instance holding the trigger token
+   * @param ref the ref that the pipeline is to be triggered for
+   * @param variables a List of variables to be passed with the trigger
+   * @return a Pipeline instance holding information on the triggered pipeline
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pipeline triggerPipeline(
+      final Object projectIdOrPath,
+      final Trigger trigger,
+      final String ref,
+      final List<Variable> variables)
+      throws GitLabApiException {
+
+    if (trigger == null) {
+      throw new GitLabApiException("trigger cannot be null");
     }
 
-    /**
-     * Get a Stream of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Pipeline> getPipelinesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelines(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+    return (triggerPipeline(projectIdOrPath, trigger.getToken(), ref, variables));
+  }
 
-    /**
-     * Get a list of pipelines in a project filtered with the provided {@link org.gitlab4j.api.models.PipelineFilter}.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter a PipelineFilter instance used to filter the results
-     * @return a list containing the pipelines for the specified project ID and matching the provided filter
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getPipelines(Object projectIdOrPath, PipelineFilter filter) throws GitLabApiException {
-        return (getPipelines(projectIdOrPath, filter, getDefaultPerPage()).all());
-    }
+  /**
+   * Trigger a pipeline for a project.
+   *
+   * <pre><code>POST /projects/:id/trigger/pipeline</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param token the trigger token
+   * @param ref the ref that the pipeline is to be triggered for
+   * @param variables a List of variables to be passed with the trigger
+   * @return a Pipeline instance holding information on the triggered pipeline
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pipeline triggerPipeline(
+      final Object projectIdOrPath,
+      final String token,
+      final String ref,
+      final List<Variable> variables)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("token", token, true)
+            .withParam("ref", ref, true)
+            .withParam(variables);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "trigger",
+            "pipeline");
+    return (response.readEntity(Pipeline.class));
+  }
 
-    /**
-     * Get a Pager of pipelines in a project filtered with the provided {@link org.gitlab4j.api.models.PipelineFilter}.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter a PipelineFilter instance used to filter the results
-     * @param itemsPerPage the number of Pipeline instances that will be fetched per page
-     * @return a Pager containing the pipelines for the specified project ID and matching the provided filter
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Pipeline> getPipelines(Object projectIdOrPath, PipelineFilter filter, int itemsPerPage) throws GitLabApiException {
-	GitLabApiForm formData = (filter != null ? filter.getQueryParams() : new GitLabApiForm());
-	return (new Pager<Pipeline>(this, Pipeline.class, itemsPerPage, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines"));
-    }
+  /**
+   * Get List of variables of a pipeline.
+   *
+   * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineId the pipeline ID
+   * @return a List of pipeline variables
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Variable> getPipelineVariables(final Object projectIdOrPath, final Long pipelineId)
+      throws GitLabApiException {
+    return (getPipelineVariables(projectIdOrPath, pipelineId, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Stream of pipelines in a project filtered with the provided {@link org.gitlab4j.api.models.PipelineFilter}.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter a PipelineFilter instance used to filter the results
-     * @return a Stream containing the pipelines for the specified project ID and matching the provided filter
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Pipeline> getPipelinesStream(Object projectIdOrPath, PipelineFilter filter) throws GitLabApiException {
-        return (getPipelines(projectIdOrPath, filter, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Pager of variables of a pipeline.
+   *
+   * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineId the pipeline ID
+   * @param itemsPerPage the number of Pipeline instances that will be fetched per page
+   * @return a Pager of pipeline variables
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Variable> getPipelineVariables(
+      final Object projectIdOrPath, final Long pipelineId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Variable>(
+        this,
+        Variable.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "pipelines",
+        pipelineId,
+        "variables"));
+  }
 
-    /**
-     * Get a list of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
-     * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED
-     * @param ref the ref of pipelines
-     * @param yamlErrors returns pipelines with invalid configurations
-     * @param name the name of the user who triggered pipelines
-     * @param username the username of the user who triggered pipelines
-     * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
-     * @param sort sort pipelines in ASC or DESC order (default: DESC)
-     * @return a list containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getPipelines(Object projectIdOrPath, PipelineScope scope, PipelineStatus status, String ref, boolean yamlErrors,
-            String name, String username, PipelineOrderBy orderBy, SortOrder sort) throws GitLabApiException {
-
-        return(getPipelines(projectIdOrPath, scope, status, ref, yamlErrors,
-            name, username, orderBy, sort, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of pipelines in a project in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
-     * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED
-     * @param ref the ref of pipelines
-     * @param yamlErrors returns pipelines with invalid configurations
-     * @param name the name of the user who triggered pipelines
-     * @param username the username of the user who triggered pipelines
-     * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
-     * @param sort sort pipelines in ASC or DESC order (default: DESC)
-     * @param page the page to get
-     * @param perPage the number of Pipeline instances per page
-     * @return a list containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public List<Pipeline> getPipelines(Object projectIdOrPath, PipelineScope scope, PipelineStatus status, String ref, boolean yamlErrors,
-            String name, String username, PipelineOrderBy orderBy, SortOrder sort, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("scope", scope)
-                .withParam("status", status)
-                .withParam("ref", ref)
-                .withParam("yaml_errors", yamlErrors)
-                .withParam("name", name)
-                .withParam("username", username)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sort)
-                .withParam("page", page)
-                .withParam(PER_PAGE_PARAM, perPage);
-
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines");
-        return (response.readEntity(new GenericType<List<Pipeline>>() {}));
-    }
-
-    /**
-     * Get a Stream of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
-     * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED
-     * @param ref the ref of pipelines
-     * @param yamlErrors returns pipelines with invalid configurations
-     * @param name the name of the user who triggered pipelines
-     * @param username the username of the user who triggered pipelines
-     * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
-     * @param sort sort pipelines in ASC or DESC order (default: DESC)
-     * @return a Stream containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Stream<Pipeline> getPipelinesStream(Object projectIdOrPath, PipelineScope scope, PipelineStatus status,
-            String ref, boolean yamlErrors, String name, String username, PipelineOrderBy orderBy, SortOrder sort) throws GitLabApiException {
-
-        return(getPipelines(projectIdOrPath, scope, status, ref, yamlErrors,
-            name, username, orderBy, sort, getDefaultPerPage()).stream());
-   }
-
-    /**
-     * Get a Pager of pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param scope the scope of pipelines, one of: RUNNING, PENDING, FINISHED, BRANCHES, TAGS
-     * @param status the status of pipelines, one of: RUNNING, PENDING, SUCCESS, FAILED, CANCELED, SKIPPED
-     * @param ref the ref of pipelines
-     * @param yamlErrors returns pipelines with invalid configurations
-     * @param name the name of the user who triggered pipelines
-     * @param username the username of the user who triggered pipelines
-     * @param orderBy order pipelines by ID, STATUS, REF, USER_ID (default: ID)
-     * @param sort sort pipelines in ASC or DESC order (default: DESC)
-     * @param itemsPerPage the number of Pipeline instances that will be fetched per page
-     * @return a list containing the pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pager<Pipeline> getPipelines(Object projectIdOrPath, PipelineScope scope, PipelineStatus status, String ref, boolean yamlErrors,
-            String name, String username, PipelineOrderBy orderBy, SortOrder sort, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("scope", scope)
-                .withParam("status", status)
-                .withParam("ref", (ref != null ? urlEncode(ref) : null))
-                .withParam("yaml_errors", yamlErrors)
-                .withParam("name", name)
-                .withParam("username", username)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sort);
-
-        return (new Pager<Pipeline>(this, Pipeline.class, itemsPerPage, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipelines"));
-    }
-
-    /**
-     * Get single pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/pipelines/:pipeline_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param pipelineId the pipeline ID to get
-     * @return a single pipelines for the specified project ID
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline getPipeline(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId);
-        return (response.readEntity(Pipeline.class));
-    }
-
-    /**
-     * Create a pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref reference to commit
-     * @return a Pipeline instance with the newly created pipeline info
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline createPipeline(Object projectIdOrPath, String ref) throws GitLabApiException {
-        return (createPipeline(projectIdOrPath, ref, Variable.convertMapToList(null)));
-    }
-
-    /**
-     * Create a pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref reference to commit
-     * @param variables a Map containing the variables available in the pipeline
-     * @return a Pipeline instance with the newly created pipeline info
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline createPipeline(Object projectIdOrPath, String ref, Map<String, String> variables) throws GitLabApiException {
-        return (createPipeline(projectIdOrPath, ref, Variable.convertMapToList(variables)));
-    }
-
-    /**
-     * Create a pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref reference to commit
-     * @param variables a Map containing the variables available in the pipeline
-     * @return a Pipeline instance with the newly created pipeline info
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline createPipeline(Object projectIdOrPath, String ref, List<Variable> variables) throws GitLabApiException {
-
-        if (ref == null || ref.trim().isEmpty()) {
-            throw new GitLabApiException("ref cannot be null or empty");
-        }
-
-        if (variables == null || variables.isEmpty()) {
-            GitLabApiForm formData = new GitLabApiForm().withParam("ref", ref, true);
-            Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline");
-            return (response.readEntity(Pipeline.class));
-        }
-
-        // The create pipeline REST API expects the variable data in an unusual format, this
-        // class is used to create the JSON for the POST data.
-        class CreatePipelineForm {
-            @SuppressWarnings("unused")
-            public String ref;
-            @SuppressWarnings("unused")
-            public List<Variable> variables;
-            CreatePipelineForm(String ref, List<Variable> variables) {
-                this.ref = ref;
-                this.variables = variables;
-            }
-        }
-
-        CreatePipelineForm pipelineForm = new CreatePipelineForm(ref, variables);
-        Response response = post(Response.Status.CREATED, pipelineForm, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline");
-        return (response.readEntity(Pipeline.class));
-    }
-
-    /**
-     * Delete a pipeline from a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/pipelines/:pipeline_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param pipelineId the pipeline ID to delete
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void deletePipeline(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-       delete(Response.Status.ACCEPTED, null, "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId);
-    }
-
-    /**
-     * Retry a job in specified pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipelines/:pipeline_id/retry</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param pipelineId the pipeline ID to retry a job from
-     * @return pipeline instance which just retried
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline retryPipelineJob(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-        GitLabApiForm formData = null;
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "retry");
-        return (response.readEntity(Pipeline.class));
-    }
-
-    /**
-     * Cancel jobs of specified pipelines in a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipelines/:pipeline_id/cancel</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param pipelineId the pipeline ID to cancel jobs
-     * @return pipeline instance which just canceled
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Pipeline cancelPipelineJobs(Object projectIdOrPath, long pipelineId) throws GitLabApiException {
-        GitLabApiForm formData = null;
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "cancel");
-        return (response.readEntity(Pipeline.class));
-    }
-
-    /**
-     * Get a list of the project pipeline_schedules for the specified project.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedules</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of pipeline schedules for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<PipelineSchedule> getPipelineSchedules(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelineSchedules(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list of project pipeline schedules in the specified page range.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedules</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of PipelineSchedule instances per page
-     * @return a list of project pipeline_schedules for the specified project in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<PipelineSchedule> getPipelineSchedules(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules");
-        return (response.readEntity(new GenericType<List<PipelineSchedule>>() {}));
-    }
-
-    /**
-     * Get Pager of project pipeline schedule.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of PipelineSchedule instances that will be fetched per page
-     * @return a Pager of project pipeline_schedules for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<PipelineSchedule> getPipelineSchedules(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<PipelineSchedule>(this, PipelineSchedule.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules"));
-    }
-
-    /**
-     * Get a Stream of the project pipeline schedule for the specified project.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of project pipeline schedules for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<PipelineSchedule> getPipelineSchedulesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelineSchedules(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific pipeline schedule for project.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the ID of the pipeline schedule to get
-     * @return the project PipelineSchedule
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PipelineSchedule getPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules", pipelineScheduleId);
-        return (response.readEntity(PipelineSchedule.class));
-    }
-
-    /**
-     * Get a specific pipeline schedule for project as an Optional instance.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the ID of the hook to get
-     * @return the project PipelineSchedule as an Optional instance
-     */
-    public Optional<PipelineSchedule> getOptionalPipelineSchedule (Object projectIdOrPath, Long pipelineScheduleId) {
-        try {
-            return (Optional.ofNullable(getPipelineSchedule(projectIdOrPath, pipelineScheduleId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * create a pipeline schedule for a project.
-     *
-     * <pre><code>POST /projects/:id/pipeline_schedules</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineSchedule a PipelineSchedule instance to create
-     * @return the added PipelineSchedule instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PipelineSchedule createPipelineSchedule(Object projectIdOrPath, PipelineSchedule pipelineSchedule)
-            throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("description", pipelineSchedule.getDescription(), true)
-                .withParam("ref", pipelineSchedule.getRef(), true)
-                .withParam("cron", pipelineSchedule.getCron(), true)
-                .withParam("cron_timezone", pipelineSchedule.getCronTimezone(), false)
-                .withParam("active", pipelineSchedule.getActive(), false);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules");
-        return (response.readEntity(PipelineSchedule.class));
-    }
-
-    /**
-     * Deletes a pipeline schedule from the project.
-     *
-     * <pre><code>DELETE /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the project schedule ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deletePipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules", pipelineScheduleId);
-    }
-
-    /**
-     * Modifies a pipeline schedule for project.
-     *
-     * <pre><code>PUT /projects/:id/pipeline_schedules/:pipeline_schedule_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineSchedule the pipelineSchedule instance that contains the pipelineSchedule info to modify
-     * @return the modified project schedule
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PipelineSchedule updatePipelineSchedule(Object projectIdOrPath,PipelineSchedule pipelineSchedule) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("description", pipelineSchedule.getDescription(), false)
-                .withParam("ref", pipelineSchedule.getRef(), false)
-                .withParam("cron", pipelineSchedule.getCron(), false)
-                .withParam("cron_timezone", pipelineSchedule.getCronTimezone(), false)
-                .withParam("active", pipelineSchedule.getActive(), false);
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules", pipelineSchedule.getId());
-        return (response.readEntity(PipelineSchedule.class));
-    }
-
-    /**
-     * Update the owner of the pipeline schedule of a project.
-     *
-     * <pre><code>POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/take_ownership</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the pipelineSchedule instance id that ownership has to be taken of
-     * @return the modified project schedule
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PipelineSchedule takeOwnershipPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-
-        Response response = post(Response.Status.OK, "", "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "take_ownership");
-        return (response.readEntity(PipelineSchedule.class));
-    }
-
-    /**
-     * Trigger a new scheduled pipeline, which runs immediately.
-     *
-     * <pre><code>POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/play</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the pipelineSchedule instance id which should run immediately
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public void playPipelineSchedule(Object projectIdOrPath, Long pipelineScheduleId) throws GitLabApiException {
-        post(Response.Status.CREATED, (Form)null, "projects", getProjectIdOrPath(projectIdOrPath),  "pipeline_schedules", pipelineScheduleId, "play");
-    }
-
-    /**
-     * Create a pipeline schedule variable.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the pipelineSchedule ID
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed
-     * @param value the value for the variable
-     * @return a Pipeline instance with the newly created pipeline schedule variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createPipelineScheduleVariable(Object projectIdOrPath, Long pipelineScheduleId,
-            String key, String value) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("key", key, true)
-                .withParam("value", value, true);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules", pipelineScheduleId, "variables");
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Update a pipeline schedule variable.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the pipelineSchedule ID
-     * @param key the key of an existing pipeline schedule variable
-     * @param value the new value for the variable
-     * @return a Pipeline instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updatePipelineScheduleVariable(Object projectIdOrPath, Long pipelineScheduleId,
-            String key, String value) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("value", value, true);
-        Response response = this.putWithFormData(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "pipeline_schedules", pipelineScheduleId, "variables", key);
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Deletes a pipeline schedule variable.
-     *
-     * <pre><code>DELETE /projects/:id/pipeline_schedules/:pipeline_schedule_id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineScheduleId the pipeline schedule ID
-     * @param key the key of an existing pipeline schedule variable
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deletePipelineScheduleVariable(Object projectIdOrPath, Long pipelineScheduleId, String key) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(GitLabApi.ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "pipeline_schedules", pipelineScheduleId, "variables", key);
-    }
-
-    /**
-     * Get a list of the project pipeline triggers for the specified project.
-     *
-     * <pre><code>GET /projects/:id/triggers</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of pipeline triggers for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Trigger> getPipelineTriggers(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelineTriggers(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list of project pipeline triggers in the specified page range.
-     *
-     * <pre><code>GET /projects/:id/triggers</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of Trigger instances per page
-     * @return a list of project pipeline triggers for the specified project in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Trigger> getPipelineTriggers(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "triggers");
-        return (response.readEntity(new GenericType<List<Trigger>>() {}));
-    }
-
-    /**
-     * Get Pager of project pipeline triggers.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of project pipeline triggers for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Trigger> getPipelineTriggers(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Trigger>(this, Trigger.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "triggers"));
-    }
-
-    /**
-     * Get a Stream of the project pipeline triggers for the specified project.
-     *
-     * <pre><code>GET /projects/:id/pipeline_schedule</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of project pipeline triggers for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Trigger> getPipelineTriggersStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getPipelineTriggers(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific pipeline schedule for project.
-     *
-     * <pre><code>GET /projects/:id/triggers/:trigger_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param triggerId the ID of the trigger to get
-     * @return the project pipeline trigger
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Trigger getPipelineTrigger(Object projectIdOrPath, Long triggerId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "triggers", triggerId);
-        return (response.readEntity(Trigger.class));
-    }
-
-    /**
-     * Get a specific pipeline trigger for project as an Optional instance.
-     *
-     * <pre><code>GET /projects/:id/triggers/:trigger_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param triggerId the ID of the trigger to get
-     * @return the project pipeline trigger as an Optional instance
-     */
-    public Optional<Trigger> getOptionalPipelineTrigger(Object projectIdOrPath, Long triggerId) {
-        try {
-            return (Optional.ofNullable(getPipelineTrigger(projectIdOrPath, triggerId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create a pipeline trigger for a project.
-     *
-     * <pre><code>POST /projects/:id/triggers</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param description the trigger description
-     * @return the created Trigger instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Trigger createPipelineTrigger(Object projectIdOrPath, String description) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("description", description, true);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "triggers");
-        return (response.readEntity(Trigger.class));
-    }
-
-    /**
-     * Updates a pipeline trigger for project.
-     *
-     * <pre><code>PUT /projects/:id/triggers/:trigger_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param triggerId the trigger ID to update
-     * @param description the new trigger description
-     * @return the updated Trigger instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Trigger updatePipelineTrigger(Object projectIdOrPath, Long triggerId, String description) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("description", description, false);
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "triggers", triggerId);
-        return (response.readEntity(Trigger.class));
-    }
-
-    /**
-     * Deletes a pipeline trigger from the project.
-     *
-     * <pre><code>DELETE /projects/:id/triggers/:trigger_id</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param triggerId the project trigger ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deletePipelineTrigger(Object projectIdOrPath, Long triggerId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "triggers", triggerId);
-    }
-
-    /**
-     * Take ownership of a pipeline trigger for project.
-     *
-     * <pre><code>PUT /projects/:id/triggers/:trigger_id/take_ownership</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param triggerId the trigger ID to take opwnership of
-     * @return the updated Trigger instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Trigger takeOwnewrshipOfPipelineTrigger(Object projectIdOrPath, Long triggerId) throws GitLabApiException {
-        Response response = put(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "triggers", triggerId, "take_ownership");
-        return (response.readEntity(Trigger.class));
-    }
-
-    /**
-     * Trigger a pipeline for a project.
-     *
-     * <pre><code>POST /projects/:id/trigger/pipeline</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param trigger the Trigger instance holding the trigger token
-     * @param ref the ref that the pipeline is to be triggered for
-     * @param variables a List of variables to be passed with the trigger
-     * @return a Pipeline instance holding information on the triggered pipeline
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pipeline triggerPipeline(Object projectIdOrPath, Trigger trigger, String ref, List<Variable> variables) throws GitLabApiException {
-
-        if (trigger == null) {
-            throw new GitLabApiException("trigger cannot be null");
-        }
-
-        return (triggerPipeline(projectIdOrPath, trigger.getToken(), ref, variables));
-    }
-
-    /**
-     * Trigger a pipeline for a project.
-     *
-     * <pre><code>POST /projects/:id/trigger/pipeline</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param token the trigger token
-     * @param ref the ref that the pipeline is to be triggered for
-     * @param variables a List of variables to be passed with the trigger
-     * @return a Pipeline instance holding information on the triggered pipeline
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pipeline triggerPipeline(Object projectIdOrPath, String token, String ref, List<Variable> variables) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("token", token, true)
-                .withParam("ref",  ref, true)
-                .withParam(variables);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "trigger", "pipeline");
-        return (response.readEntity(Pipeline.class));
-    }
-
-    /**
-     * Get List of variables of a pipeline.
-     *
-     * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineId the pipeline ID
-     * @return a List of pipeline variables
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Variable> getPipelineVariables(Object projectIdOrPath, Long pipelineId) throws GitLabApiException {
-        return (getPipelineVariables(projectIdOrPath, pipelineId, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of variables of a pipeline.
-     *
-     * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineId the pipeline ID
-     * @param itemsPerPage the number of Pipeline instances that will be fetched per page
-     * @return a Pager of pipeline variables
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Variable> getPipelineVariables(Object projectIdOrPath, Long pipelineId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Variable>(this, Variable.class, itemsPerPage, null,
-                "projects",  getProjectIdOrPath(projectIdOrPath), "pipelines", pipelineId, "variables"));
-    }
-
-    /**
-     * Get a Stream of variables of a pipeline as a Stream.
-     *
-     * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pipelineId the pipeline ID
-     * @return a Stream of pipeline variables
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Variable> getPipelineVariablesStream(Object projectIdOrPath, Long pipelineId) throws GitLabApiException {
-        return (getPipelineVariables(projectIdOrPath, pipelineId, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of variables of a pipeline as a Stream.
+   *
+   * <pre><code>GET /projects/:id/pipelines/:pipeline_id/variables</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param pipelineId the pipeline ID
+   * @return a Stream of pipeline variables
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Variable> getPipelineVariablesStream(
+      final Object projectIdOrPath, final Long pipelineId) throws GitLabApiException {
+    return (getPipelineVariables(projectIdOrPath, pipelineId, getDefaultPerPage()).stream());
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -33,10 +33,10 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AccessRequest;
@@ -54,8 +54,8 @@ import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.ProjectApprovalsConfig;
 import org.gitlab4j.api.models.ProjectFetches;
 import org.gitlab4j.api.models.ProjectFilter;
-import org.gitlab4j.api.models.ProjectGroupsFilter;
 import org.gitlab4j.api.models.ProjectGroup;
+import org.gitlab4j.api.models.ProjectGroupsFilter;
 import org.gitlab4j.api.models.ProjectHook;
 import org.gitlab4j.api.models.ProjectUser;
 import org.gitlab4j.api.models.PushRules;
@@ -70,941 +70,1118 @@ import org.gitlab4j.api.utils.ISO8601;
  *
  * @see <a href="https://docs.gitlab.com/ce/api/projects.html">Projects API at GitLab</a>
  * @see <a href="https://docs.gitlab.com/ce/api/project_statistics.html">Project statistics API</a>
- * @see <a href="https://docs.gitlab.com/ce/api/members.html">Group and project members API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/access_requests.html#group-and-project-access-requests-api">Group and project access requests API</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/members.html">Group and project members API at
+ *     GitLab</a>
+ * @see <a
+ *     href="https://docs.gitlab.com/ce/api/access_requests.html#group-and-project-access-requests-api">Group
+ *     and project access requests API</a>
  * @see <a href="https://docs.gitlab.com/ee/api/project_badges.html">Project badges API</a>
- * @see <a href="https://docs.gitlab.com/ce/api/merge_request_approvals.html">Merge request approvals API (Project-level) at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/audit_events.html#retrieve-all-project-audit-events">Project audit events API</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/merge_request_approvals.html">Merge request
+ *     approvals API (Project-level) at GitLab</a>
+ * @see <a
+ *     href="https://docs.gitlab.com/ce/api/audit_events.html#retrieve-all-project-audit-events">Project
+ *     audit events API</a>
  * @see <a href="https://docs.gitlab.com/ce/api/custom_attributes.html">Custom Attributes API</a>
  * @see <a href="https://docs.gitlab.com/ce/api/remote_mirrors.html">Project remote mirrors API</a>
  */
 public class ProjectApi extends AbstractApi implements Constants {
 
-    public ProjectApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ProjectApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get the project fetch statistics for the last 30 days. Retrieving the statistics requires write
+   * access to the repository. Currently only HTTP fetches statistics are returned. Fetches
+   * statistics includes both clones and pulls count and are HTTP only, SSH fetches are not
+   * included.
+   *
+   * <pre><code>GitLab Endpoint: GET /project/:id/statistics</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a ProjectFetches instance with the project fetch statistics for the last 30 days
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public ProjectFetches getProjectStatistics(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "statistics");
+    return (response.readEntity(ProjectFetches.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for the project fetch statistics for the last 30 days.
+   *
+   * <pre><code>GitLab Endpoint: GET /project/:id/statistics</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return an Optional instance with the value for the project fetch statistics for the last 30
+   *     day
+   */
+  public Optional<ProjectFetches> getOptionalProjectStatistics(final Object projectIdOrPath) {
+    try {
+      return (Optional.ofNullable(getProjectStatistics(projectIdOrPath)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user. <strong>WARNING:</strong> Do not
+   * use this method to fetch projects from https://gitlab.com, gitlab.com has many 100,000's of
+   * public projects and it will take hours to fetch all of them. Instead use {@link
+   * #getProjects(int itemsPerPage)} which will return a Pager of Project instances.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @return a list of projects accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects() throws GitLabApiException {
+
+    final String url = this.gitLabApi.getGitLabServerUrl();
+    if (url.startsWith("https://gitlab.com")) {
+      GitLabApi.getLogger()
+          .warning(
+              "Fetching all projects from "
+                  + url
+                  + " may take many hours to complete, use Pager<Project> getProjects(int) instead.");
     }
 
-    /**
-     * Get the project fetch statistics for the last 30 days. Retrieving the statistics requires
-     * write access to the repository. Currently only HTTP fetches statistics are returned.
-     * Fetches statistics includes both clones and pulls count and are HTTP only,
-     * SSH fetches are not included.
-     *
-     * <pre><code>GitLab Endpoint: GET /project/:id/statistics</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a ProjectFetches instance with the project fetch statistics for the last 30 days
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public ProjectFetches getProjectStatistics(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "statistics");
-        return (response.readEntity(ProjectFetches.class));
+    return (getProjects(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user and in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, getPageQueryParams(page, perPage), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager instance of projects accessible by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager instance of projects accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<Project>(this, Project.class, itemsPerPage, null, "projects"));
+  }
+
+  /**
+   * Get a Stream of projects accessible by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @return a Stream of projects accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getProjectsStream() throws GitLabApiException {
+    return (getProjects(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user and matching the supplied filter
+   * parameters. All filter parameters are optional.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param archived limit by archived status
+   * @param visibility limit by visibility public, internal, or private
+   * @param orderBy return projects ordered by id, name, path, created_at, updated_at, or
+   *     last_activity_at fields, default is created_at
+   * @param sort return projects sorted in asc or desc order. Default is desc
+   * @param search return list of projects matching the search criteria
+   * @param simple return only the ID, URL, name, and path of each project
+   * @param owned limit by projects owned by the current user
+   * @param membership limit by projects that the current user is a member of
+   * @param starred limit by projects starred by the current user
+   * @param statistics include project statistics
+   * @return a list of projects accessible by the authenticated user and matching the supplied
+   *     parameters
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #getProjects(Boolean,
+   *     Visibility, Constants.ProjectOrderBy, Constants.SortOrder, String, Boolean, Boolean,
+   *     Boolean, Boolean, Boolean)}
+   */
+  @Deprecated
+  public List<Project> getProjects(
+      final Boolean archived,
+      final Visibility visibility,
+      final String orderBy,
+      final String sort,
+      final String search,
+      final Boolean simple,
+      final Boolean owned,
+      final Boolean membership,
+      final Boolean starred,
+      final Boolean statistics)
+      throws GitLabApiException {
+
+    final ProjectOrderBy projectOrderBy = ProjectOrderBy.valueOf(orderBy);
+    final SortOrder sortOrder = SortOrder.valueOf(sort);
+    return (getProjects(
+            archived,
+            visibility,
+            projectOrderBy,
+            sortOrder,
+            search,
+            simple,
+            owned,
+            membership,
+            starred,
+            statistics,
+            getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user and matching the supplied filter
+   * parameters. All filter parameters are optional.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param archived limit by archived status
+   * @param visibility limit by visibility public, internal, or private
+   * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
+   *     LAST_ACTIVITY_AT fields, default is CREATED_AT
+   * @param sort return projects sorted in asc or desc order. Default is desc
+   * @param search return list of projects matching the search criteria
+   * @param simple return only the ID, URL, name, and path of each project
+   * @param owned limit by projects owned by the current user
+   * @param membership limit by projects that the current user is a member of
+   * @param starred limit by projects starred by the current user
+   * @param statistics include project statistics
+   * @return a list of projects accessible by the authenticated user and matching the supplied
+   *     parameters
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(
+      final Boolean archived,
+      final Visibility visibility,
+      final ProjectOrderBy orderBy,
+      final SortOrder sort,
+      final String search,
+      final Boolean simple,
+      final Boolean owned,
+      final Boolean membership,
+      final Boolean starred,
+      final Boolean statistics)
+      throws GitLabApiException {
+
+    return (getProjects(
+            archived,
+            visibility,
+            orderBy,
+            sort,
+            search,
+            simple,
+            owned,
+            membership,
+            starred,
+            statistics,
+            getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user and matching the supplied filter
+   * parameters. All filter parameters are optional.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param archived limit by archived status
+   * @param visibility limit by visibility public, internal, or private
+   * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
+   *     LAST_ACTIVITY_AT fields, default is CREATED_AT
+   * @param sort return projects sorted in asc or desc order. Default is desc
+   * @param search return list of projects matching the search criteria
+   * @param simple return only the ID, URL, name, and path of each project
+   * @param owned limit by projects owned by the current user
+   * @param membership limit by projects that the current user is a member of
+   * @param starred limit by projects starred by the current user
+   * @param statistics include project statistics
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects accessible by the authenticated user and matching the supplied
+   *     parameters
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(
+      final Boolean archived,
+      final Visibility visibility,
+      final ProjectOrderBy orderBy,
+      final SortOrder sort,
+      final String search,
+      final Boolean simple,
+      final Boolean owned,
+      final Boolean membership,
+      final Boolean starred,
+      final Boolean statistics,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("archived", archived)
+            .withParam("visibility", visibility)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sort)
+            .withParam("search", search)
+            .withParam("simple", simple)
+            .withParam("owned", owned)
+            .withParam("membership", membership)
+            .withParam("starred", starred)
+            .withParam("statistics", statistics)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects accessible by the authenticated user and matching the supplied filter
+   * parameters. All filter parameters are optional.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param archived limit by archived status
+   * @param visibility limit by visibility public, internal, or private
+   * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
+   *     LAST_ACTIVITY_AT fields, default is CREATED_AT
+   * @param sort return projects sorted in asc or desc order. Default is desc
+   * @param search return list of projects matching the search criteria
+   * @param simple return only the ID, URL, name, and path of each project
+   * @param owned limit by projects owned by the current user
+   * @param membership limit by projects that the current user is a member of
+   * @param starred limit by projects starred by the current user
+   * @param statistics include project statistics
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of projects accessible by the authenticated user and matching the supplied
+   *     parameters
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(
+      final Boolean archived,
+      final Visibility visibility,
+      final ProjectOrderBy orderBy,
+      final SortOrder sort,
+      final String search,
+      final Boolean simple,
+      final Boolean owned,
+      final Boolean membership,
+      final Boolean starred,
+      final Boolean statistics,
+      final int itemsPerPage)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("archived", archived)
+            .withParam("visibility", visibility)
+            .withParam("order_by", orderBy)
+            .withParam("sort", sort)
+            .withParam("search", search)
+            .withParam("simple", simple)
+            .withParam("owned", owned)
+            .withParam("membership", membership)
+            .withParam("starred", starred)
+            .withParam("statistics", statistics);
+
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user that match the provided search
+   * string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
+   *
+   * @param search the project name search criteria
+   * @return a list of projects accessible by the authenticated user that match the provided search
+   *     string
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final String search) throws GitLabApiException {
+    return (getProjects(search, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects accessible by the authenticated user that match the provided search
+   * string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
+   *
+   * @param search the project name search criteria
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects accessible by the authenticated user that match the provided search
+   *     string
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final String search, final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("search", search)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects accessible by the authenticated user that match the provided search
+   * string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
+   *
+   * @param search the project name search criteria
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of projects accessible by the authenticated user that match the provided search
+   *     string
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(final String search, final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("search", search);
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a Stream of projects accessible by the authenticated user that match the provided search
+   * string.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
+   *
+   * @param search the project name search criteria
+   * @return a Stream of projects accessible by the authenticated user that match the provided
+   *     search string
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getProjectsStream(final String search) throws GitLabApiException {
+    return (getProjects(search, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects that the authenticated user is a member of.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
+   *
+   * @return a list of projects that the authenticated user is a member of
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getMemberProjects() throws GitLabApiException {
+    return (getMemberProjects(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects that the authenticated user is a member of in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects that the authenticated user is a member of
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getMemberProjects(final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("membership", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects that the authenticated user is a member of.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
+   *
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager o Project instances that the authenticated user is a member of
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getMemberProjects(final int itemsPerPage) throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("membership", true);
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a Stream of projects that the authenticated user is a member of.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
+   *
+   * @return a list of projects that the authenticated user is a member of
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getMemberProjectsStream() throws GitLabApiException {
+    return (getMemberProjects(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects owned by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
+   *
+   * @return a list of projects owned by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getOwnedProjects() throws GitLabApiException {
+    return (getOwnedProjects(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects owned by the authenticated user in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects owned by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getOwnedProjects(final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("owned", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects owned by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
+   *
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a list of projects owned by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getOwnedProjects(final int itemsPerPage) throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("owned", true);
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a Stream of projects owned by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
+   *
+   * @return a Stream of projects owned by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getOwnedProjectsStream() throws GitLabApiException {
+    return (getOwnedProjects(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of projects starred by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
+   *
+   * @return a list of projects starred by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getStarredProjects() throws GitLabApiException {
+    return (getStarredProjects(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects starred by the authenticated user in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of projects starred by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getStarredProjects(final int page, final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("starred", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects starred by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
+   *
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of projects starred by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getStarredProjects(final int itemsPerPage) throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("starred", true)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a Stream of projects starred by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
+   *
+   * @return a Stream of projects starred by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getStarredProjectsStream() throws GitLabApiException {
+    return (getStarredProjects(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of all visible projects across GitLab for the authenticated user using the provided
+   * filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @return a list of all visible projects across GitLab for the authenticated use
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final ProjectFilter filter) throws GitLabApiException {
+    return (getProjects(filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of all visible projects across GitLab for the authenticated user in the specified
+   * page range using the provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of all visible projects across GitLab for the authenticated use
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getProjects(final ProjectFilter filter, final int page, final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams(page, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of all visible projects across GitLab for the authenticated user using the provided
+   * filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of all visible projects across GitLab for the authenticated use
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getProjects(final ProjectFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+  }
+
+  /**
+   * Get a Stream of all visible projects across GitLab for the authenticated user using the
+   * provided filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects</code></pre>
+   *
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @return a Stream of all visible projects across GitLab for the authenticated use
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getProjectsStream(final ProjectFilter filter) throws GitLabApiException {
+    return (getProjects(filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of visible projects owned by the given user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
+   *
+   * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user
+   *     ID or username
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @return a list of visible projects owned by the given user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getUserProjects(final Object userIdOrUsername, final ProjectFilter filter)
+      throws GitLabApiException {
+    return (getUserProjects(userIdOrUsername, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of visible projects owned by the given user in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
+   *
+   * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user
+   *     ID or username
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a list of visible projects owned by the given user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getUserProjects(
+      final Object userIdOrUsername, final ProjectFilter filter, final int page, final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams(page, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "projects");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of visible projects owned by the given user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
+   *
+   * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user
+   *     ID or username
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of visible projects owned by the given user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getUserProjects(
+      final Object userIdOrUsername, final ProjectFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<Project>(
+        this,
+        Project.class,
+        itemsPerPage,
+        formData.asMap(),
+        "users",
+        getUserIdOrUsername(userIdOrUsername),
+        "projects"));
+  }
+
+  /**
+   * Get a Stream of visible projects owned by the given user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
+   *
+   * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user
+   *     ID or username
+   * @param filter the ProjectFilter instance holding the filter values for the query
+   * @return a Stream of visible projects owned by the given user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getUserProjectsStream(
+      final Object userIdOrUsername, final ProjectFilter filter) throws GitLabApiException {
+    return (getUserProjects(userIdOrUsername, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific project, which is owned by the authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project getProject(final Object projectIdOrPath) throws GitLabApiException {
+    return (getProject(projectIdOrPath, null, null, null));
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific project, which is owned by the
+   * authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return an Optional instance with the specified project as a value
+   */
+  public Optional<Project> getOptionalProject(final Object projectIdOrPath) {
+    try {
+      return (Optional.ofNullable(getProject(projectIdOrPath, null, null, null)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a specific project, which is owned by the authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param includeStatistics include project statistics
+   * @return the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project getProject(final Object projectIdOrPath, final Boolean includeStatistics)
+      throws GitLabApiException {
+    return (getProject(projectIdOrPath, includeStatistics, null, null));
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific project, which is owned by the
+   * authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param includeStatistics include project statistics
+   * @return an Optional instance with the specified project as a value
+   */
+  public Optional<Project> getOptionalProject(
+      final Object projectIdOrPath, final Boolean includeStatistics) {
+    try {
+      return (Optional.ofNullable(getProject(projectIdOrPath, includeStatistics, null, null)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a specific project, which is owned by the authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param includeStatistics include project statistics
+   * @param includeLicense include project license data
+   * @param withCustomAttributes include custom attributes in response (admins only)
+   * @return the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project getProject(
+      final Object projectIdOrPath,
+      final Boolean includeStatistics,
+      final Boolean includeLicense,
+      final Boolean withCustomAttributes)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("statistics", includeStatistics)
+            .withParam("license", includeLicense)
+            .withParam("with_custom_attributes", withCustomAttributes);
+    final Response response =
+        get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath));
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific project, which is owned by the
+   * authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param includeStatistics include project statistics
+   * @param includeLicense include project license data
+   * @param withCustomAttributes include custom attributes in response (admins only)
+   * @return an Optional instance with the specified project as a value
+   */
+  public Optional<Project> getOptionalProject(
+      final Object projectIdOrPath,
+      final Boolean includeStatistics,
+      final Boolean includeLicense,
+      final Boolean withCustomAttributes) {
+    try {
+      return (Optional.ofNullable(
+          getProject(projectIdOrPath, includeStatistics, includeLicense, withCustomAttributes)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a specific project, which is owned by the authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param namespace the name of the project namespace or group
+   * @param project the name of the project to get
+   * @return the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project getProject(final String namespace, final String project)
+      throws GitLabApiException {
+
+    if (namespace == null) {
+      throw new RuntimeException("namespace cannot be null");
     }
 
-    /**
-     * Get an Optional instance with the value for the project fetch statistics for the last 30 days.
-     *
-     * <pre><code>GitLab Endpoint: GET /project/:id/statistics</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return an Optional instance with the value for the project fetch statistics for the last 30 day
-     */
-    public Optional<ProjectFetches> getOptionalProjectStatistics(Object projectIdOrPath) {
-        try {
-            return (Optional.ofNullable(getProjectStatistics(projectIdOrPath)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+    if (project == null) {
+      throw new RuntimeException("project cannot be null");
     }
 
-    /**
-     * <p>Get a list of projects accessible by the authenticated user.</p>
-     *
-     * <strong>WARNING:</strong> Do not use this method to fetch projects from https://gitlab.com,
-     * gitlab.com has many 100,000's of public projects and it will take hours to fetch all of them.
-     * Instead use {@link #getProjects(int itemsPerPage)} which will return a Pager of Project instances.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @return a list of projects accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects() throws GitLabApiException {
-
-       String url = this.gitLabApi.getGitLabServerUrl();
-       if (url.startsWith("https://gitlab.com")) {
-           GitLabApi.getLogger().warning("Fetching all projects from " + url +
-                   " may take many hours to complete, use Pager<Project> getProjects(int) instead.");
-       }
-
-       return (getProjects(getDefaultPerPage()).all());
+    String projectPath = null;
+    try {
+      projectPath = URLEncoder.encode(namespace + "/" + project, "UTF-8");
+    } catch (final UnsupportedEncodingException uee) {
+      throw (new GitLabApiException(uee));
     }
 
-    /**
-     * Get a list of projects accessible by the authenticated user and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() { }));
+    final Response response = get(Response.Status.OK, null, "projects", projectPath);
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific project, which is owned by the
+   * authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param namespace the name of the project namespace or group
+   * @param project the name of the project
+   * @return an Optional instance with the specified project as a value
+   */
+  public Optional<Project> getOptionalProject(final String namespace, final String project) {
+    try {
+      return (Optional.ofNullable(getProject(namespace, project)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get a specific project, which is owned by the authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param namespace the name of the project namespace or group
+   * @param project the name of the project to get
+   * @param includeStatistics include project statistics
+   * @return the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project getProject(
+      final String namespace, final String project, final Boolean includeStatistics)
+      throws GitLabApiException {
+
+    if (namespace == null) {
+      throw new RuntimeException("namespace cannot be null");
     }
 
-    /**
-     * Get a Pager instance of projects accessible by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager instance of projects accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Project>(this, Project.class, itemsPerPage, null, "projects"));
+    if (project == null) {
+      throw new RuntimeException("project cannot be null");
     }
 
-    /**
-     * Get a Stream of projects accessible by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @return a Stream of projects accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getProjectsStream() throws GitLabApiException {
-       return (getProjects(getDefaultPerPage()).stream());
+    String projectPath = null;
+    try {
+      projectPath = URLEncoder.encode(namespace + "/" + project, "UTF-8");
+    } catch (final UnsupportedEncodingException uee) {
+      throw (new GitLabApiException(uee));
     }
 
-    /**
-     * Get a list of projects accessible by the authenticated user and matching the supplied filter parameters.
-     * All filter parameters are optional.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param archived limit by archived status
-     * @param visibility limit by visibility public, internal, or private
-     * @param orderBy return projects ordered by id, name, path, created_at, updated_at, or last_activity_at fields, default is created_at
-     * @param sort return projects sorted in asc or desc order. Default is desc
-     * @param search return list of projects matching the search criteria
-     * @param simple return only the ID, URL, name, and path of each project
-     * @param owned limit by projects owned by the current user
-     * @param membership limit by projects that the current user is a member of
-     * @param starred limit by projects starred by the current user
-     * @param statistics include project statistics
-     * @return a list of projects accessible by the authenticated user and matching the supplied parameters
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #getProjects(Boolean, Visibility,
-     *      Constants.ProjectOrderBy, Constants.SortOrder, String, Boolean, Boolean, Boolean, Boolean, Boolean)}
-     */
-    @Deprecated
-    public List<Project> getProjects(Boolean archived, Visibility visibility, String orderBy,
-            String sort, String search, Boolean simple, Boolean owned, Boolean membership,
-            Boolean starred, Boolean statistics) throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("statistics", includeStatistics);
+    final Response response = get(Response.Status.OK, formData.asMap(), "projects", projectPath);
+    return (response.readEntity(Project.class));
+  }
 
-        ProjectOrderBy projectOrderBy = ProjectOrderBy.valueOf(orderBy);
-        SortOrder sortOrder = SortOrder.valueOf(sort);
-        return (getProjects(archived, visibility, projectOrderBy, sortOrder, search, simple,
-                owned, membership, starred, statistics, getDefaultPerPage()).all());
+  /**
+   * Get an Optional instance with the value for the specific project, which is owned by the
+   * authentication user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
+   *
+   * @param namespace the name of the project namespace or group
+   * @param project the name of the project
+   * @param includeStatistics include project statistics
+   * @return an Optional instance with the specified project as a value
+   */
+  public Optional<Project> getOptionalProject(
+      final String namespace, final String project, final Boolean includeStatistics) {
+    try {
+      return (Optional.ofNullable(getProject(namespace, project, includeStatistics)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Create a new project belonging to the namespace ID. A namespace ID is either a user or group
+   * ID.
+   *
+   * @param namespaceId the namespace ID to create the project under
+   * @param projectName the name of the project top create
+   * @return the created project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final Long namespaceId, final String projectName)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("namespace_id", namespaceId)
+            .withParam("name", projectName, true);
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Create a new project belonging to the namespace ID and project configuration. A namespace ID is
+   * either a user or group ID.
+   *
+   * @param namespaceId the namespace ID to create the project under
+   * @param project the Project instance holding the new project configuration
+   * @return the created project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final Long namespaceId, final Project project)
+      throws GitLabApiException {
+
+    if (project == null) {
+      throw new RuntimeException("Project instance cannot be null.");
     }
 
-    /**
-     * Get a list of projects accessible by the authenticated user and matching the supplied filter parameters.
-     * All filter parameters are optional.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param archived limit by archived status
-     * @param visibility limit by visibility public, internal, or private
-     * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
-     *          LAST_ACTIVITY_AT fields, default is CREATED_AT
-     * @param sort return projects sorted in asc or desc order. Default is desc
-     * @param search return list of projects matching the search criteria
-     * @param simple return only the ID, URL, name, and path of each project
-     * @param owned limit by projects owned by the current user
-     * @param membership limit by projects that the current user is a member of
-     * @param starred limit by projects starred by the current user
-     * @param statistics include project statistics
-     * @return a list of projects accessible by the authenticated user and matching the supplied parameters
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(Boolean archived, Visibility visibility, ProjectOrderBy orderBy,
-            SortOrder sort, String search, Boolean simple, Boolean owned, Boolean membership,
-            Boolean starred, Boolean statistics) throws GitLabApiException {
+    final Namespace namespace = new Namespace().withId(namespaceId);
+    project.setNamespace(namespace);
+    return (createProject(project));
+  }
 
-        return (getProjects(archived, visibility, orderBy, sort, search, simple,
-                owned, membership, starred, statistics, getDefaultPerPage()).all());
+  /**
+   * Create a new project with the current user's namespace.
+   *
+   * @param projectName the name of the project top create
+   * @return the created project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final String projectName) throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("name", projectName, true);
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Creates a new project owned by the authenticated user.
+   *
+   * @param name the name of the project top create. Equals path if not provided.
+   * @param path repository name for new project. Generated based on name if not provided (generated
+   *     lowercased with dashes).
+   * @return the created project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final String name, final String path) throws GitLabApiException {
+
+    if ((name == null || name.trim().isEmpty()) && (path == null || path.trim().isEmpty())) {
+      throw new RuntimeException("Either name or path must be specified.");
     }
 
-    /**
-     * Get a list of projects accessible by the authenticated user and matching the supplied filter parameters.
-     * All filter parameters are optional.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param archived limit by archived status
-     * @param visibility limit by visibility public, internal, or private
-     * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
-     *          LAST_ACTIVITY_AT fields, default is CREATED_AT
-     * @param sort return projects sorted in asc or desc order. Default is desc
-     * @param search return list of projects matching the search criteria
-     * @param simple return only the ID, URL, name, and path of each project
-     * @param owned limit by projects owned by the current user
-     * @param membership limit by projects that the current user is a member of
-     * @param starred limit by projects starred by the current user
-     * @param statistics include project statistics
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects accessible by the authenticated user and matching the supplied parameters
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(Boolean archived, Visibility visibility, ProjectOrderBy orderBy,
-            SortOrder sort, String search, Boolean simple, Boolean owned, Boolean membership,
-            Boolean starred, Boolean statistics, int page, int perPage) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("name", name).withParam("path", path);
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("archived", archived)
-                .withParam("visibility", visibility)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sort)
-                .withParam("search", search)
-                .withParam("simple", simple)
-                .withParam("owned", owned)
-                .withParam("membership", membership)
-                .withParam("starred", starred)
-                .withParam("statistics", statistics)
-                .withParam(PAGE_PARAM,  page)
-                .withParam(PER_PAGE_PARAM, perPage);
+  /**
+   * Creates new project owned by the current user.
+   *
+   * @param project the Project instance with the configuration for the new project
+   * @return a Project instance with the newly created project info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final Project project) throws GitLabApiException {
+    return (createProject(project, null));
+  }
 
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
+  /**
+   * Creates new project owned by the current user. The following properties on the Project instance
+   * are utilized in the creation of the project:
+   *
+   * <p>name (name or path are required) - new project name path (name or path are required) - new
+   * project path defaultBranch (optional) - master by default description (optional) - short
+   * project description visibility (optional) - Limit by visibility public, internal, or private
+   * visibilityLevel (optional) issuesEnabled (optional) - Enable issues for this project
+   * mergeMethod (optional) - Set the merge method used mergeRequestsEnabled (optional) - Enable
+   * merge requests for this project wikiEnabled (optional) - Enable wiki for this project
+   * snippetsEnabled (optional) - Enable snippets for this project jobsEnabled (optional) - Enable
+   * jobs for this project containerRegistryEnabled (optional) - Enable container registry for this
+   * project sharedRunnersEnabled (optional) - Enable shared runners for this project publicJobs
+   * (optional) - If true, jobs can be viewed by non-project-members
+   * onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be merged
+   * with successful jobs onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge
+   * requests can only be merged when all the discussions are resolved lfsEnabled (optional) -
+   * Enable LFS requestAccessEnabled (optional) - Allow users to request member access
+   * repositoryStorage (optional) - Which storage shard the repository is on. Available only to
+   * admins approvalsBeforeMerge (optional) - How many approvers should approve merge request by
+   * default printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request
+   * when pushing from the command line resolveOutdatedDiffDiscussions (optional) - Automatically
+   * resolve merge request diffs discussions on lines changed with a push initialize_with_readme
+   * (optional) - Initialize project with README file packagesEnabled (optional) - Enable or disable
+   * mvn packages repository feature buildGitStrategy (optional) - set the build git strategy
+   * buildCoverageRegex (optional) - set build coverage regex ciConfigPath (optional) - Set path to
+   * CI configuration file squashOption (optional) - set squash option for merge requests
+   *
+   * @param project the Project instance with the configuration for the new project
+   * @param importUrl the URL to import the repository from
+   * @return a Project instance with the newly created project info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(final Project project, final String importUrl)
+      throws GitLabApiException {
+
+    if (project == null) {
+      return (null);
     }
 
-    /**
-     * Get a Pager of projects accessible by the authenticated user and matching the supplied filter parameters.
-     * All filter parameters are optional.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param archived limit by archived status
-     * @param visibility limit by visibility public, internal, or private
-     * @param orderBy return projects ordered by ID, NAME, PATH, CREATED_AT, UPDATED_AT, or
-     *          LAST_ACTIVITY_AT fields, default is CREATED_AT
-     * @param sort return projects sorted in asc or desc order. Default is desc
-     * @param search return list of projects matching the search criteria
-     * @param simple return only the ID, URL, name, and path of each project
-     * @param owned limit by projects owned by the current user
-     * @param membership limit by projects that the current user is a member of
-     * @param starred limit by projects starred by the current user
-     * @param statistics include project statistics
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of projects accessible by the authenticated user and matching the supplied parameters
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(Boolean archived, Visibility visibility, ProjectOrderBy orderBy,
-            SortOrder sort, String search, Boolean simple, Boolean owned, Boolean membership,
-            Boolean starred, Boolean statistics, int itemsPerPage) throws GitLabApiException {
+    final String name = project.getName();
+    final String path = project.getPath();
 
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("archived", archived)
-                .withParam("visibility", visibility)
-                .withParam("order_by", orderBy)
-                .withParam("sort", sort)
-                .withParam("search", search)
-                .withParam("simple", simple)
-                .withParam("owned", owned)
-                .withParam("membership", membership)
-                .withParam("starred", starred)
-                .withParam("statistics", statistics);
-
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
+    if ((name == null || name.trim().length() == 0)
+        && (path == null || path.trim().length() == 0)) {
+      return (null);
     }
 
-    /**
-     * Get a list of projects accessible by the authenticated user that match the provided search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
-     *
-     * @param search the project name search criteria
-     * @return a list of projects accessible by the authenticated user that match the provided search string
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(String search) throws GitLabApiException {
-        return (getProjects(search, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of projects accessible by the authenticated user that match the provided search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
-     *
-     * @param search the project name search criteria
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects accessible by the authenticated user that match the provided search string
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(String search, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of projects accessible by the authenticated user that match the provided search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
-     *
-     * @param search the project name search criteria
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of projects accessible by the authenticated user that match the provided search string
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(String search, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("search", search);
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects accessible by the authenticated user that match the provided search string.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?search=search</code></pre>
-     *
-     * @param search the project name search criteria
-     * @return a Stream of projects accessible by the authenticated user that match the provided search string
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getProjectsStream(String search) throws GitLabApiException {
-        return (getProjects(search, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of projects that the authenticated user is a member of.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
-     *
-     * @return a list of projects that the authenticated user is a member of
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getMemberProjects() throws GitLabApiException {
-        return (getMemberProjects(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of projects that the authenticated user is a member of in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects that the authenticated user is a member of
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getMemberProjects(int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("membership", true).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of projects that the authenticated user is a member of.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
-     *
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager o Project instances that the authenticated user is a member of
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getMemberProjects(int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("membership", true);
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects that the authenticated user is a member of.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?membership=true</code></pre>
-     *
-     * @return a list of projects that the authenticated user is a member of
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getMemberProjectsStream() throws GitLabApiException {
-        return (getMemberProjects(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of projects owned by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
-     *
-     * @return a list of projects owned by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getOwnedProjects() throws GitLabApiException {
-        return (getOwnedProjects(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of projects owned by the authenticated user in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects owned by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getOwnedProjects(int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("owned", true).withParam(PAGE_PARAM,  page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of projects owned by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
-     *
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a list of projects owned by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getOwnedProjects(int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("owned", true);
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects owned by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?owned=true</code></pre>
-     *
-     * @return a Stream of projects owned by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getOwnedProjectsStream() throws GitLabApiException {
-        return (getOwnedProjects(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of projects starred by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
-     *
-     * @return a list of projects starred by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getStarredProjects() throws GitLabApiException {
-        return (getStarredProjects(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of projects starred by the authenticated user in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of projects starred by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getStarredProjects(int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("starred", true).withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of projects starred by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
-     *
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of projects starred by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getStarredProjects(int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("starred", true).withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
-    }
-
-    /**
-     * Get a Stream of projects starred by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects?starred=true</code></pre>
-     *
-     * @return a Stream of projects starred by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getStarredProjectsStream() throws GitLabApiException {
-        return (getStarredProjects(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of all visible projects across GitLab for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @return a list of all visible projects across GitLab for the authenticated use
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(ProjectFilter filter) throws GitLabApiException {
-        return (getProjects(filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of all visible projects across GitLab for the authenticated user in the specified page range
-     * using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of all visible projects across GitLab for the authenticated use
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getProjects(ProjectFilter filter, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams(page, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of all visible projects across GitLab for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of all visible projects across GitLab for the authenticated use
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getProjects(ProjectFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(), "projects"));
-    }
-
-    /**
-     * Get a Stream of all visible projects across GitLab for the authenticated user using the provided filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects</code></pre>
-     *
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @return a Stream of all visible projects across GitLab for the authenticated use
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getProjectsStream(ProjectFilter filter) throws GitLabApiException {
-        return (getProjects(filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of visible projects owned by the given user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
-     *
-     * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user ID or username
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @return a list of visible projects owned by the given user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getUserProjects(Object userIdOrUsername, ProjectFilter filter) throws GitLabApiException {
-        return (getUserProjects(userIdOrUsername, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of visible projects owned by the given user in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
-     *
-     * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user ID or username
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a list of visible projects owned by the given user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getUserProjects(Object userIdOrUsername, ProjectFilter filter, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams(page, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "users", getUserIdOrUsername(userIdOrUsername), "projects");
-        return (response.readEntity(new GenericType<List<Project>>() {}));
-    }
-
-    /**
-     * Get a Pager of visible projects owned by the given user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
-     *
-     * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user ID or username
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of visible projects owned by the given user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getUserProjects(Object userIdOrUsername, ProjectFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<Project>(this, Project.class, itemsPerPage, formData.asMap(),
-                "users", getUserIdOrUsername(userIdOrUsername), "projects"));
-    }
-
-    /**
-     * Get a Stream of visible projects owned by the given user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/projects</code></pre>
-     *
-     * @param userIdOrUsername the user ID, username of the user, or a User instance holding the user ID or username
-     * @param filter the ProjectFilter instance holding the filter values for the query
-     * @return a Stream of visible projects owned by the given user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getUserProjectsStream(Object userIdOrUsername, ProjectFilter filter) throws GitLabApiException {
-        return (getUserProjects(userIdOrUsername, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project getProject(Object projectIdOrPath) throws GitLabApiException {
-	return (getProject(projectIdOrPath, null, null, null));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return an Optional instance with the specified project as a value
-     */
-    public Optional<Project> getOptionalProject(Object projectIdOrPath) {
-        try {
-            return (Optional.ofNullable(getProject(projectIdOrPath, null, null, null)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Get a specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param includeStatistics include project statistics
-     * @return the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project getProject(Object projectIdOrPath, Boolean includeStatistics) throws GitLabApiException {
-	return (getProject(projectIdOrPath, includeStatistics, null, null));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param includeStatistics include project statistics
-     * @return an Optional instance with the specified project as a value
-     */
-    public Optional<Project> getOptionalProject(Object projectIdOrPath, Boolean includeStatistics) {
-        try {
-            return (Optional.ofNullable(getProject(projectIdOrPath, includeStatistics, null, null)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Get a specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param includeStatistics include project statistics
-     * @param includeLicense include project license data
-     * @param withCustomAttributes include custom attributes in response (admins only)
-     * @return the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project getProject(Object projectIdOrPath, Boolean includeStatistics,
-	    Boolean includeLicense, Boolean withCustomAttributes) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-        	.withParam("statistics", includeStatistics)
-        	.withParam("license", includeLicense)
-        	.withParam("with_custom_attributes", withCustomAttributes);
-        Response response = get(Response.Status.OK, formData.asMap(),
-        	"projects", getProjectIdOrPath(projectIdOrPath));
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param includeStatistics include project statistics
-     * @param includeLicense include project license data
-     * @param withCustomAttributes include custom attributes in response (admins only)
-     * @return an Optional instance with the specified project as a value
-     */
-    public Optional<Project> getOptionalProject(Object projectIdOrPath, Boolean includeStatistics,
-	    Boolean includeLicense, Boolean withCustomAttributes) {
-        try {
-            return (Optional.ofNullable(getProject(projectIdOrPath,
-        	    includeStatistics, includeLicense, withCustomAttributes)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Get a specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param namespace the name of the project namespace or group
-     * @param project the name of the project to get
-     * @return the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project getProject(String namespace, String project) throws GitLabApiException {
-
-        if (namespace == null) {
-            throw new RuntimeException("namespace cannot be null");
-        }
-
-        if (project == null) {
-            throw new RuntimeException("project cannot be null");
-        }
-
-        String projectPath = null;
-        try {
-            projectPath = URLEncoder.encode(namespace + "/" + project, "UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            throw (new GitLabApiException(uee));
-        }
-
-        Response response = get(Response.Status.OK, null, "projects", projectPath);
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param namespace the name of the project namespace or group
-     * @param project the name of the project
-     * @return an Optional instance with the specified project as a value
-     */
-    public Optional<Project> getOptionalProject(String namespace, String project) {
-        try {
-            return (Optional.ofNullable(getProject(namespace, project)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Get a specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param namespace the name of the project namespace or group
-     * @param project the name of the project to get
-     * @param includeStatistics include project statistics
-     * @return the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project getProject(String namespace, String project, Boolean includeStatistics) throws GitLabApiException {
-
-        if (namespace == null) {
-            throw new RuntimeException("namespace cannot be null");
-        }
-
-        if (project == null) {
-            throw new RuntimeException("project cannot be null");
-        }
-
-        String projectPath = null;
-        try {
-            projectPath = URLEncoder.encode(namespace + "/" + project, "UTF-8");
-        } catch (UnsupportedEncodingException uee) {
-            throw (new GitLabApiException(uee));
-        }
-
-        Form formData = new GitLabApiForm().withParam("statistics", includeStatistics);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects", projectPath);
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific project, which is owned by the authentication user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id</code></pre>
-     *
-     * @param namespace the name of the project namespace or group
-     * @param project the name of the project
-     * @param includeStatistics include project statistics
-     * @return an Optional instance with the specified project as a value
-     */
-    public Optional<Project> getOptionalProject(String namespace, String project, Boolean includeStatistics) {
-        try {
-            return (Optional.ofNullable(getProject(namespace, project, includeStatistics)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create a new project belonging to the namespace ID.  A namespace ID is either a user or group ID.
-     *
-     * @param namespaceId the namespace ID to create the project under
-     * @param projectName the name of the project top create
-     * @return the created project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(Long namespaceId, String projectName) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("namespace_id", namespaceId).withParam("name", projectName, true);
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Create a new project belonging to the namespace ID and project configuration.  A namespace ID is either a user or group ID.
-     *
-     * @param namespaceId the namespace ID to create the project under
-     * @param project the Project instance holding the new project configuration
-     * @return the created project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(Long namespaceId, Project project) throws GitLabApiException {
-
-        if (project == null) {
-            throw new RuntimeException("Project instance cannot be null.");
-        }
-
-        Namespace namespace = new Namespace().withId(namespaceId);
-        project.setNamespace(namespace);
-        return (createProject(project));
-    }
-
-    /**
-     * Create a new project with the current user's namespace.
-     *
-     * @param projectName the name of the project top create
-     * @return the created project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(String projectName) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("name", projectName, true);
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Creates a new project owned by the authenticated user.
-     *
-     * @param name the name of the project top create.  Equals path if not provided.
-     * @param path repository name for new project. Generated based on name if not provided (generated lowercased with dashes).
-     * @return the created project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(String name, String path) throws GitLabApiException {
-
-	if ((name == null || name.trim().isEmpty()) && (path == null || path.trim().isEmpty())) {
-	    throw new RuntimeException("Either name or path must be specified.");
-	}
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("name", name).withParam("path", path);
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
-    }
-
-    /**
-     * Creates new project owned by the current user.
-     *
-     * @param project the Project instance with the configuration for the new project
-     * @return a Project instance with the newly created project info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(Project project) throws GitLabApiException {
-        return (createProject(project, null));
-    }
-
-    /**
-     * Creates new project owned by the current user. The following properties on the Project instance
-     * are utilized in the creation of the project:
-     *
-     * name (name or path are required) - new project name
-     * path (name or path are required) - new project path
-     * defaultBranch (optional) - master by default
-     * description (optional) - short project description
-     * visibility (optional) - Limit by visibility public, internal, or private
-     * visibilityLevel (optional)
-     * issuesEnabled (optional) - Enable issues for this project
-     * mergeMethod (optional) - Set the merge method used
-     * mergeRequestsEnabled (optional) - Enable merge requests for this project
-     * wikiEnabled (optional) - Enable wiki for this project
-     * snippetsEnabled (optional) - Enable snippets for this project
-     * jobsEnabled (optional) - Enable jobs for this project
-     * containerRegistryEnabled (optional) - Enable container registry for this project
-     * sharedRunnersEnabled (optional) - Enable shared runners for this project
-     * publicJobs (optional) - If true, jobs can be viewed by non-project-members
-     * onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be merged with successful jobs
-     * onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge requests can only be merged when all the discussions are resolved
-     * lfsEnabled (optional) - Enable LFS
-     * requestAccessEnabled (optional) - Allow users to request member access
-     * repositoryStorage (optional) - Which storage shard the repository is on. Available only to admins
-     * approvalsBeforeMerge (optional) - How many approvers should approve merge request by default
-     * printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line
-     * resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push
-     * initialize_with_readme (optional) - Initialize project with README file
-     * packagesEnabled (optional) - Enable or disable mvn packages repository feature
-     * buildGitStrategy (optional) - set the build git strategy
-     * buildCoverageRegex (optional) - set build coverage regex
-     * ciConfigPath (optional) - Set path to CI configuration file
-     * squashOption (optional) - set squash option for merge requests
-     *
-     * @param project the Project instance with the configuration for the new project
-     * @param importUrl the URL to import the repository from
-     * @return a Project instance with the newly created project info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(Project project, String importUrl) throws GitLabApiException {
-
-        if (project == null) {
-            return (null);
-        }
-
-        String name = project.getName();
-        String path = project.getPath();
-
-        if ((name == null || name.trim().length() == 0) && (path == null || path.trim().length() == 0)) {
-            return (null);
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("name", name)
             .withParam("path", path)
             .withParam("default_branch", project.getDefaultBranch())
             .withParam("description", project.getDescription())
             .withParam("issues_enabled", project.getIssuesEnabled())
-            .withParam("merge_method",  project.getMergeMethod())
+            .withParam("merge_method", project.getMergeMethod())
             .withParam("merge_requests_enabled", project.getMergeRequestsEnabled())
             .withParam("jobs_enabled", project.getJobsEnabled())
             .withParam("wiki_enabled", project.getWikiEnabled())
@@ -1013,274 +1190,359 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("shared_runners_enabled", project.getSharedRunnersEnabled())
             .withParam("public_jobs", project.getPublicJobs())
             .withParam("visibility_level", project.getVisibilityLevel())
-            .withParam("only_allow_merge_if_pipeline_succeeds", project.getOnlyAllowMergeIfPipelineSucceeds())
-            .withParam("only_allow_merge_if_all_discussions_are_resolved", project.getOnlyAllowMergeIfAllDiscussionsAreResolved())
+            .withParam(
+                "only_allow_merge_if_pipeline_succeeds",
+                project.getOnlyAllowMergeIfPipelineSucceeds())
+            .withParam(
+                "only_allow_merge_if_all_discussions_are_resolved",
+                project.getOnlyAllowMergeIfAllDiscussionsAreResolved())
             .withParam("lfs_enabled", project.getLfsEnabled())
             .withParam("request_access_enabled", project.getRequestAccessEnabled())
             .withParam("repository_storage", project.getRepositoryStorage())
             .withParam("approvals_before_merge", project.getApprovalsBeforeMerge())
             .withParam("import_url", importUrl)
-            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
-            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
+            .withParam(
+                "printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
+            .withParam(
+                "resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
             .withParam("initialize_with_readme", project.getInitializeWithReadme())
             .withParam("packages_enabled", project.getPackagesEnabled())
             .withParam("build_git_strategy", project.getBuildGitStrategy())
             .withParam("build_coverage_regex", project.getBuildCoverageRegex())
             .withParam("ci_config_path", project.getCiConfigPath())
             .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
-            .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())
+            .withParam(
+                "remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())
             .withParam("squash_option", project.getSquashOption());
 
-        Namespace namespace = project.getNamespace();
-        if (namespace != null && namespace.getId() != null) {
-            formData.withParam("namespace_id", namespace.getId());
-        }
-
-        if (isApiVersion(ApiVersion.V3)) {
-            boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
-            formData.withParam("public", isPublic);
-
-            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
-                throw new IllegalArgumentException("GitLab API v3 does not support tag lists when creating projects");
-            }
-        } else {
-            Visibility visibility = (project.getVisibility() != null ? project.getVisibility() :
-                project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
-            formData.withParam("visibility", visibility);
-
-            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
-                formData.withParam("tag_list", String.join(",", project.getTagList()));
-            }
-        }
-
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
+    final Namespace namespace = project.getNamespace();
+    if (namespace != null && namespace.getId() != null) {
+      formData.withParam("namespace_id", namespace.getId());
     }
 
-    /**
-     * Creates a Project
-     *
-     * @param name The name of the project
-     * @param namespaceId The Namespace for the new project, otherwise null indicates to use the GitLab default (user)
-     * @param description A description for the project, null otherwise
-     * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab default
-     * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates to use GitLab default
-     * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab default
-     * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use GitLab default
-     * @param visibility The visibility of the project, otherwise null indicates to use GitLab default
-     * @param visibilityLevel The visibility level of the project, otherwise null indicates to use GitLab default
-     * @param importUrl The Import URL for the project, otherwise null
-     * @return the GitLab Project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(String name, Long namespaceId, String description, Boolean issuesEnabled, Boolean mergeRequestsEnabled,
-            Boolean wikiEnabled, Boolean snippetsEnabled, Visibility visibility, Integer visibilityLevel, String importUrl) throws GitLabApiException {
+    if (isApiVersion(ApiVersion.V3)) {
+      final boolean isPublic =
+          (project.getPublic() != null
+              ? project.getPublic()
+              : project.getVisibility() == Visibility.PUBLIC);
+      formData.withParam("public", isPublic);
 
-        if (isApiVersion(ApiVersion.V3)) {
-            Boolean isPublic = Visibility.PUBLIC == visibility;
-            return (createProject(name, namespaceId, description, issuesEnabled, mergeRequestsEnabled,
-                    wikiEnabled, snippetsEnabled, isPublic, visibilityLevel, importUrl));
-        }
+      if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+        throw new IllegalArgumentException(
+            "GitLab API v3 does not support tag lists when creating projects");
+      }
+    } else {
+      final Visibility visibility =
+          (project.getVisibility() != null
+              ? project.getVisibility()
+              : project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
+      formData.withParam("visibility", visibility);
 
-        if (name == null || name.trim().length() == 0) {
-            return (null);
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("namespace_id", namespaceId)
-                .withParam("description", description)
-                .withParam("issues_enabled", issuesEnabled)
-                .withParam("merge_requests_enabled", mergeRequestsEnabled)
-                .withParam("wiki_enabled", wikiEnabled)
-                .withParam("snippets_enabled", snippetsEnabled)
-                .withParam("visibility_level", visibilityLevel)
-                .withParam("visibility", visibility)
-                .withParam("import_url", importUrl);
-
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
+      if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+        formData.withParam("tag_list", String.join(",", project.getTagList()));
+      }
     }
 
-    /**
-     * Creates a Project
-     *
-     * @param name The name of the project
-     * @param namespaceId The Namespace for the new project, otherwise null indicates to use the GitLab default (user)
-     * @param description A description for the project, null otherwise
-     * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab default
-     * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates to use GitLab default
-     * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab default
-     * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use GitLab default
-     * @param visibility The visibility of the project, otherwise null indicates to use GitLab default
-     * @param visibilityLevel The visibility level of the project, otherwise null indicates to use GitLab default
-     * @param printingMergeRequestLinkEnabled Show link to create/view merge request when pushing from the command line
-     * @param importUrl The Import URL for the project, otherwise null
-     * @return the GitLab Project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProject(String name, Long namespaceId, String description, Boolean issuesEnabled, Boolean mergeRequestsEnabled,
-            Boolean wikiEnabled, Boolean snippetsEnabled, Visibility visibility, Integer visibilityLevel,
-            Boolean printingMergeRequestLinkEnabled, String importUrl) throws GitLabApiException {
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
 
-        if (isApiVersion(ApiVersion.V3)) {
-            Boolean isPublic = Visibility.PUBLIC == visibility;
-            return (createProject(name, namespaceId, description, issuesEnabled, mergeRequestsEnabled,
-                    wikiEnabled, snippetsEnabled, isPublic, visibilityLevel, importUrl));
-        }
+  /**
+   * Creates a Project
+   *
+   * @param name The name of the project
+   * @param namespaceId The Namespace for the new project, otherwise null indicates to use the
+   *     GitLab default (user)
+   * @param description A description for the project, null otherwise
+   * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates
+   *     to use GitLab default
+   * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use
+   *     GitLab default
+   * @param visibility The visibility of the project, otherwise null indicates to use GitLab default
+   * @param visibilityLevel The visibility level of the project, otherwise null indicates to use
+   *     GitLab default
+   * @param importUrl The Import URL for the project, otherwise null
+   * @return the GitLab Project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(
+      final String name,
+      final Long namespaceId,
+      final String description,
+      final Boolean issuesEnabled,
+      final Boolean mergeRequestsEnabled,
+      final Boolean wikiEnabled,
+      final Boolean snippetsEnabled,
+      final Visibility visibility,
+      final Integer visibilityLevel,
+      final String importUrl)
+      throws GitLabApiException {
 
-        if (name == null || name.trim().length() == 0) {
-            return (null);
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("namespace_id", namespaceId)
-                .withParam("description", description)
-                .withParam("issues_enabled", issuesEnabled)
-                .withParam("merge_requests_enabled", mergeRequestsEnabled)
-                .withParam("wiki_enabled", wikiEnabled)
-                .withParam("snippets_enabled", snippetsEnabled)
-                .withParam("visibility_level", visibilityLevel)
-                .withParam("visibility", visibility)
-                .withParam("printing_merge_request_link_enabled", printingMergeRequestLinkEnabled)
-                .withParam("import_url", importUrl);
-
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
+    if (isApiVersion(ApiVersion.V3)) {
+      final Boolean isPublic = Visibility.PUBLIC == visibility;
+      return (createProject(
+          name,
+          namespaceId,
+          description,
+          issuesEnabled,
+          mergeRequestsEnabled,
+          wikiEnabled,
+          snippetsEnabled,
+          isPublic,
+          visibilityLevel,
+          importUrl));
     }
 
-    /**
-     * Creates a Project
-     *
-     * @param name The name of the project
-     * @param namespaceId The Namespace for the new project, otherwise null indicates to use the GitLab default (user)
-     * @param description A description for the project, null otherwise
-     * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab default
-     * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates to use GitLab default
-     * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab default
-     * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use GitLab default
-     * @param isPublic Whether the project is public or private, if true same as setting visibilityLevel = 20, otherwise null indicates to use GitLab default
-     * @param visibilityLevel The visibility level of the project, otherwise null indicates to use GitLab default
-     * @param importUrl The Import URL for the project, otherwise null
-     * @return the GitLab Project
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated As of release 4.2.0, replaced by {@link #createProject(String, Long, String, Boolean, Boolean,
-     *      Boolean, Boolean, Visibility, Integer, String)}
-     */
-    @Deprecated
-    public Project createProject(String name, Long namespaceId, String description, Boolean issuesEnabled, Boolean mergeRequestsEnabled,
-            Boolean wikiEnabled, Boolean snippetsEnabled, Boolean isPublic, Integer visibilityLevel, String importUrl) throws GitLabApiException {
-
-        if (name == null || name.trim().length() == 0) {
-            return (null);
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("namespace_id", namespaceId)
-                .withParam("description", description)
-                .withParam("issues_enabled", issuesEnabled)
-                .withParam("merge_requests_enabled", mergeRequestsEnabled)
-                .withParam("wiki_enabled", wikiEnabled)
-                .withParam("snippets_enabled", snippetsEnabled)
-                .withParam("visibility_level", visibilityLevel)
-                .withParam("import_url", importUrl);
-
-        if (isApiVersion(ApiVersion.V3)) {
-            formData.withParam("public", isPublic);
-        } else if (isPublic) {
-            formData.withParam("visibility", Visibility.PUBLIC);
-        }
-
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
+    if (name == null || name.trim().length() == 0) {
+      return (null);
     }
 
-    /**
-     * Create a new project from a template, belonging to the namespace ID.  A namespace ID is either a user or group ID.
-     *
-     * @param namespaceId the namespace ID to create the project under
-     * @param projectName the name of the project top create
-     * @param groupWithProjectTemplatesId Id of the Gitlab Group, which contains the relevant templates.
-     * @param templateName name of the template to use
-     * @param visibility Visibility of the new create project
-     * @return the created project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createProjectFromTemplate(Integer namespaceId, String projectName, Integer groupWithProjectTemplatesId, String templateName, Visibility visibility) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("namespace_id", namespaceId)
+            .withParam("description", description)
+            .withParam("issues_enabled", issuesEnabled)
+            .withParam("merge_requests_enabled", mergeRequestsEnabled)
+            .withParam("wiki_enabled", wikiEnabled)
+            .withParam("snippets_enabled", snippetsEnabled)
+            .withParam("visibility_level", visibilityLevel)
+            .withParam("visibility", visibility)
+            .withParam("import_url", importUrl);
+
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Creates a Project
+   *
+   * @param name The name of the project
+   * @param namespaceId The Namespace for the new project, otherwise null indicates to use the
+   *     GitLab default (user)
+   * @param description A description for the project, null otherwise
+   * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates
+   *     to use GitLab default
+   * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use
+   *     GitLab default
+   * @param visibility The visibility of the project, otherwise null indicates to use GitLab default
+   * @param visibilityLevel The visibility level of the project, otherwise null indicates to use
+   *     GitLab default
+   * @param printingMergeRequestLinkEnabled Show link to create/view merge request when pushing from
+   *     the command line
+   * @param importUrl The Import URL for the project, otherwise null
+   * @return the GitLab Project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProject(
+      final String name,
+      final Long namespaceId,
+      final String description,
+      final Boolean issuesEnabled,
+      final Boolean mergeRequestsEnabled,
+      final Boolean wikiEnabled,
+      final Boolean snippetsEnabled,
+      final Visibility visibility,
+      final Integer visibilityLevel,
+      final Boolean printingMergeRequestLinkEnabled,
+      final String importUrl)
+      throws GitLabApiException {
+
+    if (isApiVersion(ApiVersion.V3)) {
+      final Boolean isPublic = Visibility.PUBLIC == visibility;
+      return (createProject(
+          name,
+          namespaceId,
+          description,
+          issuesEnabled,
+          mergeRequestsEnabled,
+          wikiEnabled,
+          snippetsEnabled,
+          isPublic,
+          visibilityLevel,
+          importUrl));
+    }
+
+    if (name == null || name.trim().length() == 0) {
+      return (null);
+    }
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("namespace_id", namespaceId)
+            .withParam("description", description)
+            .withParam("issues_enabled", issuesEnabled)
+            .withParam("merge_requests_enabled", mergeRequestsEnabled)
+            .withParam("wiki_enabled", wikiEnabled)
+            .withParam("snippets_enabled", snippetsEnabled)
+            .withParam("visibility_level", visibilityLevel)
+            .withParam("visibility", visibility)
+            .withParam("printing_merge_request_link_enabled", printingMergeRequestLinkEnabled)
+            .withParam("import_url", importUrl);
+
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Creates a Project
+   *
+   * @param name The name of the project
+   * @param namespaceId The Namespace for the new project, otherwise null indicates to use the
+   *     GitLab default (user)
+   * @param description A description for the project, null otherwise
+   * @param issuesEnabled Whether Issues should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param mergeRequestsEnabled Whether Merge Requests should be enabled, otherwise null indicates
+   *     to use GitLab default
+   * @param wikiEnabled Whether a Wiki should be enabled, otherwise null indicates to use GitLab
+   *     default
+   * @param snippetsEnabled Whether Snippets should be enabled, otherwise null indicates to use
+   *     GitLab default
+   * @param isPublic Whether the project is public or private, if true same as setting
+   *     visibilityLevel = 20, otherwise null indicates to use GitLab default
+   * @param visibilityLevel The visibility level of the project, otherwise null indicates to use
+   *     GitLab default
+   * @param importUrl The Import URL for the project, otherwise null
+   * @return the GitLab Project
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated As of release 4.2.0, replaced by {@link #createProject(String, Long, String,
+   *     Boolean, Boolean, Boolean, Boolean, Visibility, Integer, String)}
+   */
+  @Deprecated
+  public Project createProject(
+      final String name,
+      final Long namespaceId,
+      final String description,
+      final Boolean issuesEnabled,
+      final Boolean mergeRequestsEnabled,
+      final Boolean wikiEnabled,
+      final Boolean snippetsEnabled,
+      final Boolean isPublic,
+      final Integer visibilityLevel,
+      final String importUrl)
+      throws GitLabApiException {
+
+    if (name == null || name.trim().length() == 0) {
+      return (null);
+    }
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("namespace_id", namespaceId)
+            .withParam("description", description)
+            .withParam("issues_enabled", issuesEnabled)
+            .withParam("merge_requests_enabled", mergeRequestsEnabled)
+            .withParam("wiki_enabled", wikiEnabled)
+            .withParam("snippets_enabled", snippetsEnabled)
+            .withParam("visibility_level", visibilityLevel)
+            .withParam("import_url", importUrl);
+
+    if (isApiVersion(ApiVersion.V3)) {
+      formData.withParam("public", isPublic);
+    } else if (isPublic) {
+      formData.withParam("visibility", Visibility.PUBLIC);
+    }
+
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Create a new project from a template, belonging to the namespace ID. A namespace ID is either a
+   * user or group ID.
+   *
+   * @param namespaceId the namespace ID to create the project under
+   * @param projectName the name of the project top create
+   * @param groupWithProjectTemplatesId Id of the Gitlab Group, which contains the relevant
+   *     templates.
+   * @param templateName name of the template to use
+   * @param visibility Visibility of the new create project
+   * @return the created project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createProjectFromTemplate(
+      final Integer namespaceId,
+      final String projectName,
+      final Integer groupWithProjectTemplatesId,
+      final String templateName,
+      final Visibility visibility)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("namespace_id", namespaceId)
             .withParam("name", projectName, true)
             .withParam("use_custom_template", true)
             .withParam("group_with_project_templates_id", groupWithProjectTemplatesId, true)
             .withParam("template_name", templateName, true)
-            .withParam("visibility", visibility)
-            ;
-        Response response = post(Response.Status.CREATED, formData, "projects");
-        return (response.readEntity(Project.class));
+            .withParam("visibility", visibility);
+    final Response response = post(Response.Status.CREATED, formData, "projects");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Updates a project. The following properties on the Project instance are utilized in the edit of
+   * the project, null values are not updated:
+   *
+   * <p>id (required) - existing project id, either id or path must be provided name (optional) -
+   * project name path (optional) - project path, either id or path must be provided defaultBranch
+   * (optional) - master by default description (optional) - short project description visibility
+   * (optional) - Limit by visibility public, internal, or private issuesEnabled (optional) - Enable
+   * issues for this project mergeMethod (optional) - Set the merge method used mergeRequestsEnabled
+   * (optional) - Enable merge requests for this project wikiEnabled (optional) - Enable wiki for
+   * this project snippetsEnabled (optional) - Enable snippets for this project jobsEnabled
+   * (optional) - Enable jobs for this project containerRegistryEnabled (optional) - Enable
+   * container registry for this project sharedRunnersEnabled (optional) - Enable shared runners for
+   * this project publicJobs (optional) - If true, jobs can be viewed by non-project-members
+   * onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be merged
+   * with successful jobs onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge
+   * requests can only be merged when all the discussions are resolved lfsEnabled (optional) -
+   * Enable LFS requestAccessEnabled (optional) - Allow users to request member access
+   * repositoryStorage (optional) - Which storage shard the repository is on. Available only to
+   * admins approvalsBeforeMerge (optional) - How many approvers should approve merge request by
+   * default printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request
+   * when pushing from the command line resolveOutdatedDiffDiscussions (optional) - Automatically
+   * resolve merge request diffs discussions on lines changed with a push packagesEnabled (optional)
+   * - Enable or disable mvn packages repository feature buildGitStrategy (optional) - set the build
+   * git strategy buildCoverageRegex (optional) - set build coverage regex ciConfigPath (optional) -
+   * Set path to CI configuration file ciForwardDeploymentEnabled (optional) - When a new deployment
+   * job starts, skip older deployment jobs that are still pending squashOption (optional) - set
+   * squash option for merge requests
+   *
+   * <p>NOTE: The following parameters specified by the GitLab API edit project are not supported:
+   * import_url tag_list array avatar initialize_with_readme
+   *
+   * @param project the Project instance with the configuration for the new project
+   * @return a Project instance with the newly updated project info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project updateProject(final Project project) throws GitLabApiException {
+
+    if (project == null) {
+      throw new RuntimeException("Project instance cannot be null.");
     }
 
-    /**
-     * Updates a project. The following properties on the Project instance
-     * are utilized in the edit of the project, null values are not updated:
-     *
-     * id (required) - existing project id, either id or path must be provided
-     * name (optional) - project name
-     * path (optional) - project path, either id or path must be provided
-     * defaultBranch (optional) - master by default
-     * description (optional) - short project description
-     * visibility (optional) - Limit by visibility public, internal, or private
-     * issuesEnabled (optional) - Enable issues for this project
-     * mergeMethod (optional) - Set the merge method used
-     * mergeRequestsEnabled (optional) - Enable merge requests for this project
-     * wikiEnabled (optional) - Enable wiki for this project
-     * snippetsEnabled (optional) - Enable snippets for this project
-     * jobsEnabled (optional) - Enable jobs for this project
-     * containerRegistryEnabled (optional) - Enable container registry for this project
-     * sharedRunnersEnabled (optional) - Enable shared runners for this project
-     * publicJobs (optional) - If true, jobs can be viewed by non-project-members
-     * onlyAllowMergeIfPipelineSucceeds (optional) - Set whether merge requests can only be merged with successful jobs
-     * onlyAllowMergeIfAllDiscussionsAreResolved (optional) - Set whether merge requests can only be merged when all the discussions are resolved
-     * lfsEnabled (optional) - Enable LFS
-     * requestAccessEnabled (optional) - Allow users to request member access
-     * repositoryStorage (optional) - Which storage shard the repository is on. Available only to admins
-     * approvalsBeforeMerge (optional) - How many approvers should approve merge request by default
-     * printingMergeRequestLinkEnabled (optional) - Show link to create/view merge request when pushing from the command line
-     * resolveOutdatedDiffDiscussions (optional) - Automatically resolve merge request diffs discussions on lines changed with a push
-     * packagesEnabled (optional) - Enable or disable mvn packages repository feature
-     * buildGitStrategy (optional) - set the build git strategy
-     * buildCoverageRegex (optional) - set build coverage regex
-     * ciConfigPath (optional) - Set path to CI configuration file
-     * ciForwardDeploymentEnabled (optional) - When a new deployment job starts, skip older deployment jobs that are still pending
-     * squashOption (optional) - set squash option for merge requests
-     *
-     * NOTE: The following parameters specified by the GitLab API edit project are not supported:
-     *     import_url
-     *     tag_list array
-     *     avatar
-     *     initialize_with_readme
-     *
-     * @param project the Project instance with the configuration for the new project
-     * @return a Project instance with the newly updated project info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project updateProject(Project project) throws GitLabApiException {
+    // This will throw an exception if both id and path are not present
+    final Object projectIdentifier = getProjectIdOrPath(project);
 
-        if (project == null) {
-            throw new RuntimeException("Project instance cannot be null.");
-        }
-
-        // This will throw an exception if both id and path are not present
-        Object projectIdentifier = getProjectIdOrPath(project);
-
-        GitLabApiForm formData = new GitLabApiForm()
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("name", project.getName())
             .withParam("path", project.getPath())
             .withParam("default_branch", project.getDefaultBranch())
             .withParam("description", project.getDescription())
             .withParam("issues_enabled", project.getIssuesEnabled())
-            .withParam("merge_method",  project.getMergeMethod())
+            .withParam("merge_method", project.getMergeMethod())
             .withParam("merge_requests_enabled", project.getMergeRequestsEnabled())
             .withParam("jobs_enabled", project.getJobsEnabled())
             .withParam("wiki_enabled", project.getWikiEnabled())
@@ -1288,14 +1550,20 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("container_registry_enabled", project.getContainerRegistryEnabled())
             .withParam("shared_runners_enabled", project.getSharedRunnersEnabled())
             .withParam("public_jobs", project.getPublicJobs())
-            .withParam("only_allow_merge_if_pipeline_succeeds", project.getOnlyAllowMergeIfPipelineSucceeds())
-            .withParam("only_allow_merge_if_all_discussions_are_resolved", project.getOnlyAllowMergeIfAllDiscussionsAreResolved())
+            .withParam(
+                "only_allow_merge_if_pipeline_succeeds",
+                project.getOnlyAllowMergeIfPipelineSucceeds())
+            .withParam(
+                "only_allow_merge_if_all_discussions_are_resolved",
+                project.getOnlyAllowMergeIfAllDiscussionsAreResolved())
             .withParam("lfs_enabled", project.getLfsEnabled())
             .withParam("request_access_enabled", project.getRequestAccessEnabled())
             .withParam("repository_storage", project.getRepositoryStorage())
             .withParam("approvals_before_merge", project.getApprovalsBeforeMerge())
-            .withParam("printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
-            .withParam("resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
+            .withParam(
+                "printing_merge_request_link_enabled", project.getPrintingMergeRequestLinkEnabled())
+            .withParam(
+                "resolve_outdated_diff_discussions", project.getResolveOutdatedDiffDiscussions())
             .withParam("packages_enabled", project.getPackagesEnabled())
             .withParam("build_git_strategy", project.getBuildGitStrategy())
             .withParam("build_coverage_regex", project.getBuildCoverageRegex())
@@ -1303,962 +1571,1249 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("ci_forward_deployment_enabled", project.getCiForwardDeploymentEnabled())
             .withParam("merge_method", project.getMergeMethod())
             .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
-            .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())
+            .withParam(
+                "remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())
             .withParam("squash_option", project.getSquashOption());
 
-        if (isApiVersion(ApiVersion.V3)) {
-            formData.withParam("visibility_level", project.getVisibilityLevel());
-            boolean isPublic = (project.getPublic() != null ? project.getPublic() : project.getVisibility() == Visibility.PUBLIC);
-            formData.withParam("public", isPublic);
+    if (isApiVersion(ApiVersion.V3)) {
+      formData.withParam("visibility_level", project.getVisibilityLevel());
+      final boolean isPublic =
+          (project.getPublic() != null
+              ? project.getPublic()
+              : project.getVisibility() == Visibility.PUBLIC);
+      formData.withParam("public", isPublic);
 
-            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
-                throw new IllegalArgumentException("GitLab API v3 does not support tag lists when updating projects");
-            }
-        } else {
-            Visibility visibility = (project.getVisibility() != null ? project.getVisibility() :
-                project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
-            formData.withParam("visibility", visibility);
+      if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+        throw new IllegalArgumentException(
+            "GitLab API v3 does not support tag lists when updating projects");
+      }
+    } else {
+      final Visibility visibility =
+          (project.getVisibility() != null
+              ? project.getVisibility()
+              : project.getPublic() == Boolean.TRUE ? Visibility.PUBLIC : null);
+      formData.withParam("visibility", visibility);
 
-            if (project.getTagList() != null && !project.getTagList().isEmpty()) {
-                formData.withParam("tag_list", String.join(",", project.getTagList()));
-            }
-        }
-
-        Response response = putWithFormData(Response.Status.OK, formData, "projects", projectIdentifier);
-        return (response.readEntity(Project.class));
+      if (project.getTagList() != null && !project.getTagList().isEmpty()) {
+        formData.withParam("tag_list", String.join(",", project.getTagList()));
+      }
     }
 
-    /**
-     * Removes project with all resources(issues, merge requests etc).
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteProject(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.ACCEPTED);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath));
+    final Response response =
+        putWithFormData(Response.Status.OK, formData, "projects", projectIdentifier);
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Removes project with all resources(issues, merge requests etc).
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteProject(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.ACCEPTED);
+    delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath));
+  }
+
+  /**
+   * Forks a project into the user namespace of the authenticated user or the one provided. The
+   * forking operation for a project is asynchronous and is completed in a background job. The
+   * request will return immediately.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param namespace path of the namespace that the project will be forked to
+   * @return the newly forked Project instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project forkProject(final Object projectIdOrPath, final String namespace)
+      throws GitLabApiException {
+    return forkProject(projectIdOrPath, namespace, null, null);
+  }
+
+  /**
+   * Forks a project into the user namespace of the authenticated user or the one provided. The
+   * forking operation for a project is asynchronous and is completed in a background job. The
+   * request will return immediately.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param namespaceId ID of the namespace that the project will be forked to
+   * @return the newly forked Project instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project forkProject(final Object projectIdOrPath, final Long namespaceId)
+      throws GitLabApiException {
+    return forkProject(projectIdOrPath, Long.toString(namespaceId));
+  }
+
+  /**
+   * Forks a project into the user namespace of the authenticated user or the one provided. The
+   * forking operation for a project is asynchronous and is completed in a background job. The
+   * request will return immediately.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param namespace path of the namespace that the project will be forked to
+   * @param path the path that will be assigned to the resultant project after forking
+   * @param name the name that will be assigned to the resultant project after forking
+   * @return the newly forked Project instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project forkProject(
+      final Object projectIdOrPath, final String namespace, final String path, final String name)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("namespace", namespace, true)
+            .withParam("path", path)
+            .withParam("name", name);
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
+    final Response response =
+        post(expectedStatus, formData, "projects", getProjectIdOrPath(projectIdOrPath), "fork");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Create a forked from/to relation between existing projects.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/fork/:forkFromId</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param forkedFromId the ID of the project that was forked from
+   * @return the updated Project instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project createForkedFromRelationship(final Object projectIdOrPath, final Long forkedFromId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
+    final Response response =
+        post(
+            expectedStatus,
+            (Form) null,
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "fork",
+            forkedFromId);
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Delete an existing forked from relationship.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/fork</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteForkedFromRelationship(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.ACCEPTED);
+    delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "fork");
+  }
+
+  /**
+   * Get a list of project team members.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the members belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getMembers(final Object projectIdOrPath) throws GitLabApiException {
+    return (getMembers(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project team members in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of Member instances per page
+   * @return the members belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getMembers(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "members");
+    return (response.readEntity(new GenericType<List<Member>>() {}));
+  }
+
+  /**
+   * Get a Pager of project team members.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the members belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getMembers(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Member>(
+        this,
+        Member.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "members"));
+  }
+
+  /**
+   * Get a Stream of project team members.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of the members belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getMembersStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getMembers(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Gets a list of project members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the project members viewable by the authenticated user, including inherited members
+   *     through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getAllMembers(final Object projectIdOrPath) throws GitLabApiException {
+    return (getAllMembers(projectIdOrPath, null, null));
+  }
+
+  /**
+   * Gets a list of project members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of Member instances per page
+   * @return the project members viewable by the authenticated user, including inherited members
+   *     through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0
+   */
+  @Deprecated
+  public List<Member> getAllMembers(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "members",
+            "all");
+    return (response.readEntity(new GenericType<List<Member>>() {}));
+  }
+
+  /**
+   * Gets a Pager of project members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the project members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getAllMembers(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getAllMembers(projectIdOrPath, null, null, itemsPerPage));
+  }
+
+  /**
+   * Gets a Stream of project members viewable by the authenticated user, including inherited
+   * members through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of the project members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getAllMembersStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getAllMembersStream(projectIdOrPath, null, null));
+  }
+
+  /**
+   * Gets a list of project members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @return the project members viewable by the authenticated user, including inherited members
+   *     through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Member> getAllMembers(
+      final Object projectIdOrPath, final String query, final List<Long> userIds)
+      throws GitLabApiException {
+    return (getAllMembers(projectIdOrPath, query, userIds, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a Pager of project members viewable by the authenticated user, including inherited members
+   * through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the project members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Member> getAllMembers(
+      final Object projectIdOrPath,
+      final String query,
+      final List<Long> userIds,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm form =
+        new GitLabApiForm().withParam("query", query).withParam("user_ids", userIds);
+    return (new Pager<Member>(
+        this,
+        Member.class,
+        itemsPerPage,
+        form.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "members",
+        "all"));
+  }
+
+  /**
+   * Gets a Stream of project members viewable by the authenticated user, including inherited
+   * members through ancestor groups. Returns multiple times the same user (with different member
+   * attributes) when the user is a member of the project/group and of one or more ancestor group.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param query a query string to search for members
+   * @param userIds filter the results on the given user IDs
+   * @return a Stream of the project members viewable by the authenticated user, including inherited
+   *     members through ancestor groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Member> getAllMembersStream(
+      final Object projectIdOrPath, final String query, final List<Long> userIds)
+      throws GitLabApiException {
+    return (getAllMembers(projectIdOrPath, query, userIds, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Gets a project team member.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member
+   * @return the member specified by the project ID/user ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member getMember(final Object projectIdOrPath, final Long userId)
+      throws GitLabApiException {
+    return (getMember(projectIdOrPath, userId, false));
+  }
+
+  /**
+   * Gets a project team member.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member
+   * @return the member specified by the project ID/user ID pair
+   */
+  public Optional<Member> getOptionalMember(final Object projectIdOrPath, final Long userId) {
+    try {
+      return (Optional.ofNullable(getMember(projectIdOrPath, userId, false)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Forks a project into the user namespace of the authenticated user or the one provided.
-     * The forking operation for a project is asynchronous and is completed in a background job.
-     * The request will return immediately.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param namespace       path of the namespace that the project will be forked to
-     * @return the newly forked Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project forkProject(Object projectIdOrPath, String namespace) throws GitLabApiException {
-        return forkProject(projectIdOrPath, namespace, null, null);
+  /**
+   * Gets a project team member, optionally including inherited member.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member
+   * @param includeInherited if true will the member even if inherited thru an ancestor group
+   * @return the member specified by the project ID/user ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member getMember(
+      final Object projectIdOrPath, final Long userId, final Boolean includeInherited)
+      throws GitLabApiException {
+    final Response response;
+    if (includeInherited) {
+      response =
+          get(
+              Response.Status.OK,
+              null,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "members",
+              "all",
+              userId);
+    } else {
+      response =
+          get(
+              Response.Status.OK,
+              null,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "members",
+              userId);
     }
+    return (response.readEntity(Member.class));
+  }
 
-    /**
-     * Forks a project into the user namespace of the authenticated user or the one provided.
-     * The forking operation for a project is asynchronous and is completed in a background job.
-     * The request will return immediately.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param namespaceId     ID of the namespace that the project will be forked to
-     * @return the newly forked Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project forkProject(Object projectIdOrPath, Long namespaceId) throws GitLabApiException {
-        return forkProject(projectIdOrPath, Long.toString(namespaceId));
+  /**
+   * Gets a project team member, optionally including inherited member.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/members/all/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member
+   * @param includeInherited if true will the member even if inherited thru an ancestor group
+   * @return the member specified by the project ID/user ID pair as the value of an Optional
+   */
+  public Optional<Member> getOptionalMember(
+      final Object projectIdOrPath, final Long userId, final Boolean includeInherited) {
+    try {
+      return (Optional.ofNullable(getMember(projectIdOrPath, userId, includeInherited)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Forks a project into the user namespace of the authenticated user or the one provided.
-     * The forking operation for a project is asynchronous and is completed in a background job.
-     * The request will return immediately.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/fork</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param namespace       path of the namespace that the project will be forked to
-     * @param path            the path that will be assigned to the resultant project after forking
-     * @param name            the name that will be assigned to the resultant project after forking
-     * @return the newly forked Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project forkProject(Object projectIdOrPath, String namespace, String path, String name) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("namespace", namespace, true)
-                .withParam("path", path)
-                .withParam("name", name);
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
-        Response response = post(expectedStatus, formData, "projects", getProjectIdOrPath(projectIdOrPath), "fork");
-        return (response.readEntity(Project.class));
+  /**
+   * Adds a user to a project team. This is an idempotent method and can be called multiple times
+   * with the same parameters. Adding team membership to a user that is already a member does not
+   * affect the existing membership.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @return the added member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object projectIdOrPath, final Long userId, final Integer accessLevel)
+      throws GitLabApiException {
+    return (addMember(projectIdOrPath, userId, accessLevel, null));
+  }
+
+  /**
+   * Adds a user to a project team. This is an idempotent method and can be called multiple times
+   * with the same parameters. Adding team membership to a user that is already a member does not
+   * affect the existing membership.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to add, required
+   * @param accessLevel the access level for the new member, required
+   * @return the added member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object projectIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    return (addMember(projectIdOrPath, userId, accessLevel.toValue(), null));
+  }
+
+  /**
+   * Adds a user to a project team. This is an idempotent method and can be called multiple times
+   * with the same parameters. Adding team membership to a user that is already a member does not
+   * affect the existing membership.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to add
+   * @param accessLevel the access level for the new member
+   * @param expiresAt the date the membership in the group will expire
+   * @return the added member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object projectIdOrPath,
+      final Long userId,
+      final AccessLevel accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    return (addMember(projectIdOrPath, userId, accessLevel.toValue(), expiresAt));
+  }
+
+  /**
+   * Adds a user to a project team. This is an idempotent method and can be called multiple times
+   * with the same parameters. Adding team membership to a user that is already a member does not
+   * affect the existing membership.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to add
+   * @param accessLevel the access level for the new member
+   * @param expiresAt the date the membership in the group will expire
+   * @return the added member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member addMember(
+      final Object projectIdOrPath,
+      final Long userId,
+      final Integer accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("user_id", userId, true)
+            .withParam("access_level", accessLevel, true)
+            .withParam("expires_at", expiresAt, false);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "members");
+    return (response.readEntity(Member.class));
+  }
+
+  /**
+   * Updates a member of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object projectIdOrPath, final Long userId, final Integer accessLevel)
+      throws GitLabApiException {
+    return (updateMember(projectIdOrPath, userId, accessLevel, null));
+  }
+
+  /**
+   * Updates a member of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object projectIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    return (updateMember(projectIdOrPath, userId, accessLevel.toValue(), null));
+  }
+
+  /**
+   * Updates a member of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object projectIdOrPath,
+      final Long userId,
+      final AccessLevel accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    return (updateMember(projectIdOrPath, userId, accessLevel.toValue(), expiresAt));
+  }
+
+  /**
+   * Updates a member of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param userId the user ID of the member to update, required
+   * @param accessLevel the new access level for the member, required
+   * @param expiresAt the date the membership in the group will expire, optional
+   * @return the updated member
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Member updateMember(
+      final Object projectIdOrPath,
+      final Long userId,
+      final Integer accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("access_level", accessLevel, true)
+            .withParam("expires_at", expiresAt, false);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "members",
+            userId);
+    return (response.readEntity(Member.class));
+  }
+
+  /**
+   * Removes user from project team.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/members/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param userId the user ID of the member to remove
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void removeMember(final Object projectIdOrPath, final Long userId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "members", userId);
+  }
+
+  /**
+   * Get a list of project users. This list includes all project members and all users assigned to
+   * project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the users belonging to the specified project and its parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectUser> getProjectUsers(final Object projectIdOrPath) throws GitLabApiException {
+    return (getProjectUsers(projectIdOrPath, null, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of project users. This Pager includes all project members and all users assigned to
+   * project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the users matching the search string and belonging to the specified project
+   *     and its parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProjectUser> getProjectUsers(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getProjectUsers(projectIdOrPath, null, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of project users. This Stream includes all project members and all users assigned
+   * to project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of the users belonging to the specified project and its parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProjectUser> getProjectUsersStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectUsers(projectIdOrPath, null, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of project users matching the specified search string. This list includes all
+   * project members and all users assigned to project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param search the string to match specific users
+   * @return the users matching the search string and belonging to the specified project and its
+   *     parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectUser> getProjectUsers(final Object projectIdOrPath, final String search)
+      throws GitLabApiException {
+    return (getProjectUsers(projectIdOrPath, search, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of project users matching the specified search string. This Pager includes all
+   * project members and all users assigned to project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param search the string to match specific users
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the users matching the search string and belonging to the specified project
+   *     and its parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProjectUser> getProjectUsers(
+      final Object projectIdOrPath, final String search, final int itemsPerPage)
+      throws GitLabApiException {
+    final MultivaluedMap<String, String> params =
+        (search != null ? new GitLabApiForm().withParam("search", search).asMap() : null);
+    return (new Pager<ProjectUser>(
+        this,
+        ProjectUser.class,
+        itemsPerPage,
+        params,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "users"));
+  }
+
+  /**
+   * Get a Stream of project users matching the specified search string. This Stream includes all
+   * project members and all users assigned to project parent groups.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param search the string to match specific users
+   * @return a Stream of the users matching the search string and belonging to the specified project
+   *     and its parent groups
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProjectUser> getProjectUsersStream(
+      final Object projectIdOrPath, final String search) throws GitLabApiException {
+    return (getProjectUsers(projectIdOrPath, search, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of the ancestor groups for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectGroup> getProjectGroups(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a Pager of the ancestor groups for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProjectGroup> getProjectGroups(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of the ancestor groups for a given project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProjectGroup> getProjectGroupsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a list of the ancestor groups for a given project matching the specified filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param filter the ProjectGroupsFilter to match against
+   * @return the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectGroup> getProjectGroups(
+      final Object projectIdOrPath, final ProjectGroupsFilter filter) throws GitLabApiException {
+    return (getProjectGroups(projectIdOrPath, filter, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of the ancestor groups for a given project matching the specified filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filter the ProjectGroupsFilter to match against
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProjectGroup> getProjectGroups(
+      final Object projectIdOrPath, final ProjectGroupsFilter filter, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = filter.getQueryParams();
+    return (new Pager<ProjectGroup>(
+        this,
+        ProjectGroup.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "groups"));
+  }
+
+  /**
+   * Get a Stream of the ancestor groups for a given project matching the specified filter.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param filter the ProjectGroupsFilter to match against
+   * @return a Stream of the ancestor groups for a given project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProjectGroup> getProjectGroupsStream(
+      final Object projectIdOrPath, final ProjectGroupsFilter filter) throws GitLabApiException {
+    return (getProjectGroups(projectIdOrPath, filter, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the project events for specific project. Sorted from newest to latest.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the project events for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Event> getProjectEvents(final Object projectIdOrPath) throws GitLabApiException {
+    return (getProjectEvents(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get the project events for specific project. Sorted from newest to latest in the specified page
+   * range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of Event instances per page
+   * @return the project events for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Event> getProjectEvents(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "events");
+    return (response.readEntity(new GenericType<List<Event>>() {}));
+  }
+
+  /**
+   * Get a Pager of project events for specific project. Sorted from newest to latest.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of project events for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Event> getProjectEvents(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Event>(
+        this,
+        Event.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "events"));
+  }
+
+  /**
+   * Get a Stream of the project events for specific project. Sorted from newest to latest.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of the project events for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Event> getProjectEventsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProjectEvents(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of the project hooks for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a list of project hooks for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectHook> getHooks(final Object projectIdOrPath) throws GitLabApiException {
+    return (getHooks(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get list of project hooks in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of ProjectHook instances per page
+   * @return a list of project hooks for the specified project in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProjectHook> getHooks(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "hooks");
+    return (response.readEntity(new GenericType<List<ProjectHook>>() {}));
+  }
+
+  /**
+   * Get Pager of project hooks.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of project hooks for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProjectHook> getHooks(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<ProjectHook>(
+        this,
+        ProjectHook.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "hooks"));
+  }
+
+  /**
+   * Get a Stream of the project hooks for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of project hooks for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProjectHook> getHooksStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getHooks(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific hook for project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks/:hook_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param hookId the ID of the hook to get
+   * @return the project hook for the specified project ID/hook ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectHook getHook(final Object projectIdOrPath, final Long hookId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "hooks",
+            hookId);
+    return (response.readEntity(ProjectHook.class));
+  }
+
+  /**
+   * Get a specific hook for project as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/hooks/:hook_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param hookId the ID of the hook to get
+   * @return the project hook for the specified project ID/hook ID pair as an Optional instance
+   */
+  public Optional<ProjectHook> getOptionalHook(final Object projectIdOrPath, final Long hookId) {
+    try {
+      return (Optional.ofNullable(getHook(projectIdOrPath, hookId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Create a forked from/to relation between existing projects.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/fork/:forkFromId</code></pre>
-     *
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param forkedFromId the ID of the project that was forked from
-     * @return the updated Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project createForkedFromRelationship(Object projectIdOrPath, Long forkedFromId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
-        Response response = post(expectedStatus, (Form)null, "projects", this.getProjectIdOrPath(projectIdOrPath), "fork", forkedFromId);
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Adds a hook to project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param url the callback URL for the hook
+   * @param enabledHooks a ProjectHook instance specifying which hooks to enable
+   * @param enableSslVerification enable SSL verification
+   * @param secretToken the secret token to pass back to the hook
+   * @return the added ProjectHook instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectHook addHook(
+      final Object projectIdOrPath,
+      final String url,
+      final ProjectHook enabledHooks,
+      final boolean enableSslVerification,
+      final String secretToken)
+      throws GitLabApiException {
 
-    /**
-     * Delete an existing forked from relationship.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/fork</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteForkedFromRelationship(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.ACCEPTED);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "fork");
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("url", url, true)
+            .withParam("push_events", enabledHooks.getPushEvents(), false)
+            .withParam("push_events_branch_filter", enabledHooks.getPushEventsBranchFilter(), false)
+            .withParam("issues_events", enabledHooks.getIssuesEvents(), false)
+            .withParam(
+                "confidential_issues_events", enabledHooks.getConfidentialIssuesEvents(), false)
+            .withParam("merge_requests_events", enabledHooks.getMergeRequestsEvents(), false)
+            .withParam("tag_push_events", enabledHooks.getTagPushEvents(), false)
+            .withParam("note_events", enabledHooks.getNoteEvents(), false)
+            .withParam("confidential_note_events", enabledHooks.getConfidentialNoteEvents(), false)
+            .withParam("job_events", enabledHooks.getJobEvents(), false)
+            .withParam("pipeline_events", enabledHooks.getPipelineEvents(), false)
+            .withParam("wiki_page_events", enabledHooks.getWikiPageEvents(), false)
+            .withParam("enable_ssl_verification", enableSslVerification, false)
+            .withParam("repository_update_events", enabledHooks.getRepositoryUpdateEvents(), false)
+            .withParam("deployment_events", enabledHooks.getDeploymentEvents(), false)
+            .withParam("releases_events", enabledHooks.getReleasesEvents(), false)
+            .withParam("deployment_events", enabledHooks.getDeploymentEvents(), false)
+            .withParam("token", secretToken, false);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "hooks");
+    return (response.readEntity(ProjectHook.class));
+  }
 
-    /**
-     * Get a list of project team members.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the members belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getMembers(Object projectIdOrPath) throws GitLabApiException {
-        return (getMembers(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Adds a hook to project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/hooks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param url the callback URL for the hook
+   * @param doPushEvents flag specifying whether to do push events
+   * @param doIssuesEvents flag specifying whether to do issues events
+   * @param doMergeRequestsEvents flag specifying whether to do merge requests events
+   * @return the added ProjectHook instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectHook addHook(
+      final Object projectIdOrPath,
+      final String url,
+      final boolean doPushEvents,
+      final boolean doIssuesEvents,
+      final boolean doMergeRequestsEvents)
+      throws GitLabApiException {
 
-    /**
-     * Get a list of project team members in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of Member instances per page
-     * @return the members belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getMembers(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "members");
-        return (response.readEntity(new GenericType<List<Member>>() {}));
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("url", url)
+            .withParam("push_events", doPushEvents)
+            .withParam("issues_events", doIssuesEvents)
+            .withParam("merge_requests_events", doMergeRequestsEvents);
 
-    /**
-     * Get a Pager of project team members.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the members belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getMembers(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Member>(this, Member.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "members"));
-    }
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "hooks");
+    return (response.readEntity(ProjectHook.class));
+  }
 
-    /**
-     * Get a Stream of project team members.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of the members belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getMembersStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getMembers(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Deletes a hook from the project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/hooks/:hook_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param hookId the project hook ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteHook(final Object projectIdOrPath, final Long hookId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "hooks", hookId);
+  }
 
-    /**
-     * Gets a list of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the project members viewable by the authenticated user, including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getAllMembers(Object projectIdOrPath) throws GitLabApiException {
-        return (getAllMembers(projectIdOrPath, null, null));
-    }
+  /**
+   * Deletes a hook from the project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/hooks/:hook_id</code></pre>
+   *
+   * @param hook the ProjectHook instance to remove
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteHook(final ProjectHook hook) throws GitLabApiException {
+    deleteHook(hook.getProjectId(), hook.getId());
+  }
 
-    /**
-     * Gets a list of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of Member instances per page
-     * @return the project members viewable by the authenticated user, including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0
-     */
-    @Deprecated
-    public List<Member> getAllMembers(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "members", "all");
-        return (response.readEntity(new GenericType<List<Member>>() {}));
-    }
+  /**
+   * Modifies a hook for project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/hooks/:hook_id</code></pre>
+   *
+   * @param hook the ProjectHook instance that contains the project hook info to modify
+   * @return the modified project hook
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectHook modifyHook(final ProjectHook hook) throws GitLabApiException {
 
-    /**
-     * Gets a Pager of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the project members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getAllMembers(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getAllMembers(projectIdOrPath, null, null, itemsPerPage));
-    }
-
-    /**
-     * Gets a Stream of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of the project members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getAllMembersStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getAllMembersStream(projectIdOrPath, null, null));
-    }
-
-    /**
-     * Gets a list of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @return the project members viewable by the authenticated user, including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Member> getAllMembers(Object projectIdOrPath, String query, List<Long> userIds) throws GitLabApiException {
-        return (getAllMembers(projectIdOrPath, query, userIds, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a Pager of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the project members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Member> getAllMembers(Object projectIdOrPath, String query, List<Long> userIds, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm form = new GitLabApiForm().withParam("query", query).withParam("user_ids", userIds);
-        return (new Pager<Member>(this, Member.class, itemsPerPage, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "members", "all"));
-    }
-
-    /**
-     * Gets a Stream of project members viewable by the authenticated user,
-     * including inherited members through ancestor groups. Returns multiple
-     * times the same user (with different member attributes) when the user is
-     * a member of the project/group and of one or more ancestor group.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param query a query string to search for members
-     * @param userIds filter the results on the given user IDs
-     * @return a Stream of the project members viewable by the authenticated user,
-     * including inherited members through ancestor groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Member> getAllMembersStream(Object projectIdOrPath, String query, List<Long> userIds) throws GitLabApiException {
-        return (getAllMembers(projectIdOrPath, query, userIds, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Gets a project team member.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member
-     * @return the member specified by the project ID/user ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member getMember(Object projectIdOrPath, Long userId) throws GitLabApiException {
-        return (getMember(projectIdOrPath, userId, false));
-    }
-
-    /**
-     * Gets a project team member.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member
-     * @return the member specified by the project ID/user ID pair
-     */
-    public Optional<Member> getOptionalMember(Object projectIdOrPath, Long userId)  {
-        try {
-            return (Optional.ofNullable(getMember(projectIdOrPath, userId, false)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Gets a project team member, optionally including inherited member.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member
-     * @param includeInherited if true will the member even if inherited thru an ancestor group
-     * @return the member specified by the project ID/user ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member getMember(Object projectIdOrPath, Long userId, Boolean includeInherited) throws GitLabApiException {
-        Response response;
-        if (includeInherited) {
-            response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "members", "all", userId);
-        } else {
-            response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "members", userId);
-        }
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Gets a project team member, optionally including inherited member.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/members/all/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member
-     * @param includeInherited if true will the member even if inherited thru an ancestor group
-     * @return the member specified by the project ID/user ID pair as the value of an Optional
-     */
-    public Optional<Member> getOptionalMember(Object projectIdOrPath, Long userId, Boolean includeInherited)  {
-        try {
-            return (Optional.ofNullable(getMember(projectIdOrPath, userId, includeInherited)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Adds a user to a project team. This is an idempotent method and can be called multiple times
-     * with the same parameters. Adding team membership to a user that is already a member does not
-     * affect the existing membership.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @return the added member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object projectIdOrPath, Long userId, Integer accessLevel) throws GitLabApiException {
-        return (addMember(projectIdOrPath, userId, accessLevel, null));
-    }
-
-    /**
-     * Adds a user to a project team. This is an idempotent method and can be called multiple times
-     * with the same parameters. Adding team membership to a user that is already a member does not
-     * affect the existing membership.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to add, required
-     * @param accessLevel the access level for the new member, required
-     * @return the added member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object projectIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        return (addMember(projectIdOrPath, userId, accessLevel.toValue(), null));
-    }
-
-    /**
-     * Adds a user to a project team. This is an idempotent method and can be called multiple times
-     * with the same parameters. Adding team membership to a user that is already a member does not
-     * affect the existing membership.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to add
-     * @param accessLevel the access level for the new member
-     * @param expiresAt the date the membership in the group will expire
-     * @return the added member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object projectIdOrPath, Long userId, AccessLevel accessLevel, Date expiresAt) throws GitLabApiException {
-        return (addMember(projectIdOrPath, userId, accessLevel.toValue(), expiresAt));
-    }
-
-    /**
-     * Adds a user to a project team. This is an idempotent method and can be called multiple times
-     * with the same parameters. Adding team membership to a user that is already a member does not
-     * affect the existing membership.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/members</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to add
-     * @param accessLevel the access level for the new member
-     * @param expiresAt the date the membership in the group will expire
-     * @return the added member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member addMember(Object projectIdOrPath, Long userId, Integer accessLevel, Date expiresAt) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("user_id", userId, true)
-                .withParam("access_level", accessLevel, true)
-                .withParam("expires_at",  expiresAt, false);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "members");
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Updates a member of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object projectIdOrPath, Long userId, Integer accessLevel) throws GitLabApiException {
-        return (updateMember(projectIdOrPath, userId, accessLevel, null));
-    }
-
-    /**
-     * Updates a member of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object projectIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        return (updateMember(projectIdOrPath, userId, accessLevel.toValue(), null));
-    }
-
-    /**
-     * Updates a member of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object projectIdOrPath, Long userId, AccessLevel accessLevel, Date expiresAt) throws GitLabApiException {
-        return (updateMember(projectIdOrPath, userId, accessLevel.toValue(), expiresAt));
-    }
-
-    /**
-     * Updates a member of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:projectId/members/:userId</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param userId the user ID of the member to update, required
-     * @param accessLevel the new access level for the member, required
-     * @param expiresAt the date the membership in the group will expire, optional
-     * @return the updated member
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Member updateMember(Object projectIdOrPath, Long userId, Integer accessLevel, Date expiresAt) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("access_level", accessLevel, true)
-                .withParam("expires_at",  expiresAt, false);
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "members", userId);
-        return (response.readEntity(Member.class));
-    }
-
-    /**
-     * Removes user from project team.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/members/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param userId the user ID of the member to remove
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void removeMember(Object projectIdOrPath, Long userId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "members", userId);
-    }
-
-    /**
-     * Get a list of project users. This list includes all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the users belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectUser> getProjectUsers(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectUsers(projectIdOrPath, null, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of project users. This Pager includes all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the users matching the search string and belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProjectUser> getProjectUsers(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getProjectUsers(projectIdOrPath, null, itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of project users. This Stream includes all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of the users belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProjectUser> getProjectUsersStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectUsers(projectIdOrPath, null, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of project users matching the specified search string. This list
-     * includes all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param search the string to match specific users
-     * @return the users matching the search string and belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectUser> getProjectUsers(Object projectIdOrPath, String search) throws GitLabApiException {
-        return (getProjectUsers(projectIdOrPath, search, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of project users matching the specified search string. This Pager includes
-     * all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param search the string to match specific users
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the users matching the search string and belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProjectUser> getProjectUsers(Object projectIdOrPath, String search, int itemsPerPage) throws GitLabApiException {
-        MultivaluedMap<String, String> params = (search != null ? new GitLabApiForm().withParam("search", search).asMap() : null);
-        return (new Pager<ProjectUser>(this, ProjectUser.class, itemsPerPage, params,
-                "projects", getProjectIdOrPath(projectIdOrPath), "users"));
-    }
-
-    /**
-     * Get a Stream of project users matching the specified search string. This Stream
-     * includes all project members and all users assigned to project parent groups.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/users</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param search the string to match specific users
-     * @return a Stream of the users matching the search string and belonging to the specified project and its parent groups
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProjectUser> getProjectUsersStream(Object projectIdOrPath, String search) throws GitLabApiException {
-        return (getProjectUsers(projectIdOrPath, search, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of the ancestor groups for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectGroup> getProjectGroups(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the ancestor groups for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProjectGroup> getProjectGroups(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of the ancestor groups for a given project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProjectGroup> getProjectGroupsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectGroups(projectIdOrPath, new ProjectGroupsFilter(), getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of the ancestor groups for a given project matching the specified filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param filter the ProjectGroupsFilter to match against
-     * @return the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectGroup> getProjectGroups(Object projectIdOrPath, ProjectGroupsFilter filter) throws GitLabApiException {
-        return (getProjectGroups(projectIdOrPath, filter, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the ancestor groups for a given project matching the specified filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filter the ProjectGroupsFilter to match against
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProjectGroup> getProjectGroups(Object projectIdOrPath, ProjectGroupsFilter filter, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = filter.getQueryParams();
-        return (new Pager<ProjectGroup>(this, ProjectGroup.class, itemsPerPage, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "groups"));
-    }
-
-    /**
-     * Get a Stream of the ancestor groups for a given project matching the specified filter.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/groups</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param filter the ProjectGroupsFilter to match against
-     * @return a Stream of the ancestor groups for a given project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProjectGroup> getProjectGroupsStream(Object projectIdOrPath, ProjectGroupsFilter filter) throws GitLabApiException {
-        return (getProjectGroups(projectIdOrPath, filter, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the project events for specific project. Sorted from newest to latest.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the project events for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Event> getProjectEvents(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectEvents(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get the project events for specific project. Sorted from newest to latest in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of Event instances per page
-     * @return the project events for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Event> getProjectEvents(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "events");
-        return (response.readEntity(new GenericType<List<Event>>() {}));
-    }
-
-    /**
-     * Get a Pager of project events for specific project. Sorted from newest to latest.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of project events for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Event> getProjectEvents(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Event>(this, Event.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "events"));
-    }
-
-    /**
-     * Get a Stream of the project events for specific project. Sorted from newest to latest.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/events</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of the project events for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Event> getProjectEventsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProjectEvents(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of the project hooks for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of project hooks for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectHook> getHooks(Object projectIdOrPath) throws GitLabApiException {
-        return (getHooks(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get list of project hooks in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of ProjectHook instances per page
-     * @return a list of project hooks for the specified project in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProjectHook> getHooks(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "hooks");
-        return (response.readEntity(new GenericType<List<ProjectHook>>() {}));
-    }
-
-    /**
-     * Get Pager of project hooks.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of project hooks for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProjectHook> getHooks(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<ProjectHook>(this, ProjectHook.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "hooks"));
-    }
-
-    /**
-     * Get a Stream of the project hooks for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of project hooks for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProjectHook> getHooksStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getHooks(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific hook for project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks/:hook_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param hookId the ID of the hook to get
-     * @return the project hook for the specified project ID/hook ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectHook getHook(Object projectIdOrPath, Long hookId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "hooks", hookId);
-        return (response.readEntity(ProjectHook.class));
-    }
-
-    /**
-     * Get a specific hook for project as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/hooks/:hook_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param hookId the ID of the hook to get
-     * @return the project hook for the specified project ID/hook ID pair as an Optional instance
-     */
-    public Optional<ProjectHook> getOptionalHook(Object projectIdOrPath, Long hookId) {
-        try {
-            return (Optional.ofNullable(getHook(projectIdOrPath, hookId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Adds a hook to project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param url the callback URL for the hook
-     * @param enabledHooks a ProjectHook instance specifying which hooks to enable
-     * @param enableSslVerification enable SSL verification
-     * @param secretToken the secret token to pass back to the hook
-     * @return the added ProjectHook instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectHook addHook(Object projectIdOrPath, String url, ProjectHook enabledHooks,
-            boolean enableSslVerification, String secretToken) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("url", url, true)
-                .withParam("push_events", enabledHooks.getPushEvents(), false)
-                .withParam("push_events_branch_filter", enabledHooks.getPushEventsBranchFilter(), false)
-                .withParam("issues_events", enabledHooks.getIssuesEvents(), false)
-                .withParam("confidential_issues_events", enabledHooks.getConfidentialIssuesEvents(), false)
-                .withParam("merge_requests_events", enabledHooks.getMergeRequestsEvents(), false)
-                .withParam("tag_push_events", enabledHooks.getTagPushEvents(), false)
-                .withParam("note_events", enabledHooks.getNoteEvents(), false)
-                .withParam("confidential_note_events", enabledHooks.getConfidentialNoteEvents(), false)
-                .withParam("job_events", enabledHooks.getJobEvents(), false)
-                .withParam("pipeline_events", enabledHooks.getPipelineEvents(), false)
-                .withParam("wiki_page_events", enabledHooks.getWikiPageEvents(), false)
-                .withParam("enable_ssl_verification", enableSslVerification, false)
-                .withParam("repository_update_events", enabledHooks.getRepositoryUpdateEvents(), false)
-                .withParam("deployment_events", enabledHooks.getDeploymentEvents(), false)
-                .withParam("releases_events", enabledHooks.getReleasesEvents(), false)
-                .withParam("deployment_events", enabledHooks.getDeploymentEvents(), false)
-                .withParam("token", secretToken, false);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "hooks");
-        return (response.readEntity(ProjectHook.class));
-    }
-
-    /**
-     * Adds a hook to project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/hooks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param url the callback URL for the hook
-     * @param doPushEvents flag specifying whether to do push events
-     * @param doIssuesEvents flag specifying whether to do issues events
-     * @param doMergeRequestsEvents flag specifying whether to do merge requests events
-     * @return the added ProjectHook instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectHook addHook(Object projectIdOrPath, String url, boolean doPushEvents,
-            boolean doIssuesEvents, boolean doMergeRequestsEvents) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("url", url)
-                .withParam("push_events", doPushEvents)
-                .withParam("issues_events", doIssuesEvents)
-                .withParam("merge_requests_events", doMergeRequestsEvents);
-
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "hooks");
-        return (response.readEntity(ProjectHook.class));
-    }
-
-    /**
-     * Deletes a hook from the project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/hooks/:hook_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param hookId the project hook ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteHook(Object projectIdOrPath, Long hookId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "hooks", hookId);
-    }
-
-    /**
-     * Deletes a hook from the project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/hooks/:hook_id</code></pre>
-     *
-     * @param hook the ProjectHook instance to remove
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteHook(ProjectHook hook) throws GitLabApiException {
-        deleteHook(hook.getProjectId(), hook.getId());
-    }
-
-    /**
-     * Modifies a hook for project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/hooks/:hook_id</code></pre>
-     *
-     * @param hook the ProjectHook instance that contains the project hook info to modify
-     * @return the modified project hook
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectHook modifyHook(ProjectHook hook) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("url", hook.getUrl(), true)
             .withParam("push_events", hook.getPushEvents(), false)
             .withParam("push_events_branch_filter", hook.getPushEventsBranchFilter(), false)
@@ -2277,472 +2832,666 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("deployment_events", hook.getDeploymentEvents(), false)
             .withParam("token", hook.getToken(), false);
 
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", hook.getProjectId(), "hooks", hook.getId());
-        return (response.readEntity(ProjectHook.class));
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            hook.getProjectId(),
+            "hooks",
+            hook.getId());
+    return (response.readEntity(ProjectHook.class));
+  }
+
+  /**
+   * Get a list of the project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a list of project's issues
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object)}
+   */
+  @Deprecated
+  public List<Issue> getIssues(final Object projectIdOrPath) throws GitLabApiException {
+    return (getIssues(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project's issues using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of issues per page
+   * @return the list of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object, int,
+   *     int)}
+   */
+  @Deprecated
+  public List<Issue> getIssues(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues");
+    return (response.readEntity(new GenericType<List<Issue>>() {}));
+  }
+
+  /**
+   * Get a Pager of project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of issues per page
+   * @return the list of issues in the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object,
+   *     int)}
+   */
+  @Deprecated
+  public Pager<Issue> getIssues(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Issue>(
+        this,
+        Issue.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues"));
+  }
+
+  /**
+   * Get a Stream of the project's issues.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of the project's issues
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object)}
+   */
+  @Deprecated
+  public Stream<Issue> getIssuesStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getIssues(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single project issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueId the internal ID of a project's issue
+   * @return the specified Issue instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssue(Object,
+   *     Long)}
+   */
+  @Deprecated
+  public Issue getIssue(final Object projectIdOrPath, final Long issueId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getDefaultPerPageParam(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueId);
+    return (response.readEntity(Issue.class));
+  }
+
+  /**
+   * Delete a project issue.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param issueId the internal ID of a project's issue
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#deleteIssue(Object,
+   *     Long)}
+   */
+  @Deprecated
+  public void deleteIssue(final Object projectIdOrPath, final Long issueId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        getDefaultPerPageParam(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueId);
+  }
+
+  /**
+   * Get a list of the project snippets.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a list of the project's snippets
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Snippet> getSnippets(final Object projectIdOrPath) throws GitLabApiException {
+    return (getSnippets(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of project snippets.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of snippets per page
+   * @return a list of project's snippets for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Snippet> getSnippets(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets");
+    return (response.readEntity(new GenericType<List<Snippet>>() {}));
+  }
+
+  /**
+   * Get a Pager of project's snippets.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of snippets per page
+   * @return the Pager of snippets
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Snippet> getSnippets(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Snippet>(
+        this,
+        Snippet.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "snippets"));
+  }
+
+  /**
+   * Get a Stream of the project snippets.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of the project's snippets
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Snippet> getSnippetsStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getSnippets(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single of project snippet.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param snippetId the ID of the project's snippet
+   * @return the specified project Snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Snippet getSnippet(final Object projectIdOrPath, final Long snippetId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId);
+    return (response.readEntity(Snippet.class));
+  }
+
+  /**
+   * Get a single of project snippet as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param snippetId the ID of the project's snippet
+   * @return the specified project Snippet as an Optional instance
+   */
+  public Optional<Snippet> getOptionalSnippet(final Object projectIdOrPath, final Long snippetId) {
+    try {
+      return (Optional.ofNullable(getSnippet(projectIdOrPath, snippetId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get a list of the project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of project's issues
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object)}
-     */
-    @Deprecated
-    public List<Issue> getIssues(Object projectIdOrPath) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, getDefaultPerPage()).all());
+  /**
+   * Creates a new project snippet. The user must have permission to create new snippets.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/snippets</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param title the title of a snippet, required
+   * @param filename the name of a snippet file, required
+   * @param description the description of a snippet, optional
+   * @param content the content of a snippet, required
+   * @param visibility the snippet's visibility, required
+   * @return a Snippet instance with info on the created snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Snippet createSnippet(
+      final Object projectIdOrPath,
+      final String title,
+      final String filename,
+      final String description,
+      final String content,
+      final Visibility visibility)
+      throws GitLabApiException {
+
+    try {
+
+      final GitLabApiForm form =
+          new GitLabApiForm()
+              .withParam("title", title, true)
+              .withParam("file_name", filename, true)
+              .withParam("description", description)
+              .withParam("content", content, true)
+              .withParam("visibility", visibility, true);
+
+      final Response response =
+          post(
+              Response.Status.CREATED,
+              form,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "snippets");
+      return (response.readEntity(Snippet.class));
+
+    } catch (final GitLabApiException glae) {
+
+      // GitLab 12.8 and older will return HTTP status 400 if called with content instead of code
+      if (glae.getHttpStatus() != Response.Status.BAD_REQUEST.getStatusCode()) {
+        throw glae;
+      }
+
+      final GitLabApiForm form =
+          new GitLabApiForm()
+              .withParam("title", title, true)
+              .withParam("file_name", filename, true)
+              .withParam("description", description)
+              .withParam("code", content, true)
+              .withParam("visibility", visibility, true);
+
+      final Response response =
+          post(
+              Response.Status.CREATED,
+              form,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "snippets");
+      return (response.readEntity(Snippet.class));
     }
+  }
 
-    /**
-     * Get a list of project's issues using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of issues per page
-     * @return the list of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object, int, int)}
-     */
-    @Deprecated
-    public List<Issue> getIssues(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "issues");
-        return (response.readEntity(new GenericType<List<Issue>>() {}));
+  /**
+   * Updates an existing project snippet. The user must have permission to change an existing
+   * snippet.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/snippets/:snippet_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param snippetId the ID of a project's snippet, required
+   * @param title the title of a snippet, optional
+   * @param filename the name of a snippet file, optional
+   * @param description the description of a snippet, optioptionalonal
+   * @param code the content of a snippet, optional
+   * @param visibility the snippet's visibility, reqoptionaluired
+   * @return a Snippet instance with info on the updated snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Snippet updateSnippet(
+      final Object projectIdOrPath,
+      final Long snippetId,
+      final String title,
+      final String filename,
+      final String description,
+      final String code,
+      final Visibility visibility)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title)
+            .withParam("file_name", filename)
+            .withParam("description", description)
+            .withParam("code", code)
+            .withParam("visibility", visibility);
+
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId);
+    return (response.readEntity(Snippet.class));
+  }
+
+  /*
+   * Deletes an existing project snippet. This is an idempotent function and deleting a
+   * non-existent snippet does not cause an error.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/snippets/:snippet_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
+   * @param snippetId the ID of the project's snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteSnippet(final Object projectIdOrPath, final Long snippetId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "snippets",
+        snippetId);
+  }
+
+  /**
+   * Get the raw project snippet as plain text.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/raw</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param snippetId the ID of the project's snippet
+   * @return the raw project snippet plain text as an Optional instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public String getRawSnippetContent(final Object projectIdOrPath, final Long snippetId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "snippets",
+            snippetId,
+            "raw");
+    return (response.readEntity(String.class));
+  }
+
+  /**
+   * Get the raw project snippet plain text as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/raw</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param snippetId the ID of the project's snippet
+   * @return the raw project snippet plain text as an Optional instance
+   */
+  public Optional<String> getOptionalRawSnippetContent(
+      final Object projectIdOrPath, final Long snippetId) {
+    try {
+      return (Optional.ofNullable(getRawSnippetContent(projectIdOrPath, snippetId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get a Pager of project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of issues per page
-     * @return the list of issues in the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object, int)}
-     */
-    @Deprecated
-    public Pager<Issue> getIssues(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "issues"));
-    }
-
-    /**
-     * Get a Stream of the project's issues.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of the project's issues
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link IssuesApi#getIssues(Object)}
-     */
-    @Deprecated
-    public Stream<Issue> getIssuesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getIssues(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single project issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueId the internal ID of a project's issue
-     * @return the specified Issue instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link IssuesApi#getIssue(Object, Long)}
-     */
-    @Deprecated
-    public Issue getIssue(Object projectIdOrPath, Long issueId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueId);
-        return (response.readEntity(Issue.class));
-    }
-
-    /**
-     * Delete a project issue.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param issueId the internal ID of a project's issue
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link IssuesApi#deleteIssue(Object, Long)}
-     */
-    @Deprecated
-    public void deleteIssue(Object projectIdOrPath, Long issueId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, getDefaultPerPageParam(), "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueId);
-    }
-
-    /**
-     * Get a list of the project snippets.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of the project's snippets
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Snippet> getSnippets(Object projectIdOrPath) throws GitLabApiException {
-        return (getSnippets(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of project snippets.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of snippets per page
-     * @return a list of project's snippets for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Snippet> getSnippets(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "snippets");
-        return (response.readEntity(new GenericType<List<Snippet>>() {}));
-    }
-
-    /**
-     * Get a Pager of project's snippets.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of snippets per page
-     * @return the Pager of snippets
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Snippet> getSnippets(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Snippet>(this, Snippet.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "snippets"));
-    }
-
-    /**
-     * Get a Stream of the project snippets.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of the project's snippets
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Snippet> getSnippetsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getSnippets(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single of project snippet.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of the project's snippet
-     * @return the specified project Snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Snippet getSnippet(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId);
-        return (response.readEntity(Snippet.class));
-    }
-
-    /**
-     * Get a single of project snippet as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of the project's snippet
-     * @return the specified project Snippet as an Optional instance
-     */
-    public Optional<Snippet> getOptionalSnippet(Object projectIdOrPath, Long snippetId) {
-        try {
-            return (Optional.ofNullable(getSnippet(projectIdOrPath, snippetId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new project snippet. The user must have permission to create new snippets.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/snippets</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param title the title of a snippet, required
-     * @param filename the name of a snippet file, required
-     * @param description the description of a snippet, optional
-     * @param content the content of a snippet, required
-     * @param visibility the snippet's visibility, required
-     * @return a Snippet instance with info on the created snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Snippet createSnippet(Object projectIdOrPath, String title, String filename, String description,
-            String content, Visibility visibility) throws GitLabApiException {
-
-        try {
-
-            GitLabApiForm form = new GitLabApiForm()
-                    .withParam("title", title, true)
-                    .withParam("file_name", filename, true)
-                    .withParam("description", description)
-                    .withParam("content", content, true)
-                    .withParam("visibility", visibility, true);
-
-            Response response = post(Response.Status.CREATED, form, "projects", getProjectIdOrPath(projectIdOrPath), "snippets");
-            return (response.readEntity(Snippet.class));
-
-        } catch (GitLabApiException glae) {
-
-            // GitLab 12.8 and older will return HTTP status 400 if called with content instead of code
-            if (glae.getHttpStatus() != Response.Status.BAD_REQUEST.getStatusCode()) {
-                throw glae;
-            }
-
-            GitLabApiForm form = new GitLabApiForm()
-                    .withParam("title", title, true)
-                    .withParam("file_name", filename, true)
-                    .withParam("description", description)
-                    .withParam("code", content, true)
-                    .withParam("visibility", visibility, true);
-
-            Response response = post(Response.Status.CREATED, form, "projects", getProjectIdOrPath(projectIdOrPath), "snippets");
-            return (response.readEntity(Snippet.class));
-        }
-    }
-
-    /**
-     * Updates an existing project snippet. The user must have permission to change an existing snippet.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/snippets/:snippet_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of a project's snippet, required
-     * @param title the title of a snippet, optional
-     * @param filename the name of a snippet file, optional
-     * @param description the description of a snippet, optioptionalonal
-     * @param code the content of a snippet, optional
-     * @param visibility the snippet's visibility, reqoptionaluired
-     * @return a Snippet instance with info on the updated snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Snippet updateSnippet(Object projectIdOrPath, Long snippetId, String title, String filename, String description,
-            String code, Visibility visibility) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title)
-                .withParam("file_name", filename)
-                .withParam("description", description)
-                .withParam("code", code)
-                .withParam("visibility", visibility);
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId);
-        return (response.readEntity(Snippet.class));
-    }
-
-    /*
-     * Deletes an existing project snippet. This is an idempotent function and deleting a
-     * non-existent snippet does not cause an error.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/snippets/:snippet_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of the project's snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteSnippet(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId);
-    }
-
-    /**
-     * Get the raw project snippet as plain text.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/raw</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of the project's snippet
-     * @return the raw project snippet plain text as an Optional instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public String getRawSnippetContent(Object projectIdOrPath, Long snippetId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "snippets", snippetId, "raw");
-        return (response.readEntity(String.class));
-    }
-
-    /**
-     * Get the raw project snippet plain text as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/snippets/:snippet_id/raw</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param snippetId the ID of the project's snippet
-     * @return the raw project snippet plain text as an Optional instance
-     */
-    public Optional<String> getOptionalRawSnippetContent(Object projectIdOrPath, Long snippetId) {
-        try {
-            return (Optional.ofNullable(getRawSnippetContent(projectIdOrPath, snippetId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Share a project with the specified group.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/share</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param groupId the ID of the group to share with, required
-     * @param accessLevel the permissions level to grant the group, required
-     * @param expiresAt the share expiration date, optional
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void shareProject(Object projectIdOrPath, Long groupId, AccessLevel accessLevel, Date expiresAt)
-            throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+  /**
+   * Share a project with the specified group.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/share</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param groupId the ID of the group to share with, required
+   * @param accessLevel the permissions level to grant the group, required
+   * @param expiresAt the share expiration date, optional
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void shareProject(
+      final Object projectIdOrPath,
+      final Long groupId,
+      final AccessLevel accessLevel,
+      final Date expiresAt)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("group_id", groupId, true)
             .withParam("group_access", accessLevel, true)
             .withParam("expires_at", expiresAt);
-        post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "share");
-    }
+    post(
+        Response.Status.CREATED,
+        formData,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "share");
+  }
 
-    /**
-     * Unshare the project from the group.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/share/:group_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param groupId the ID of the group to unshare, required
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void unshareProject(Object projectIdOrPath, Long groupId) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "share", groupId);
-    }
+  /**
+   * Unshare the project from the group.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/share/:group_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param groupId the ID of the group to unshare, required
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void unshareProject(final Object projectIdOrPath, final Long groupId)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "share", groupId);
+  }
 
-    /**
-     * Archive a project
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the archived GitLab Project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project archiveProject(Object projectIdOrPath)
-            throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (new GitLabApiForm()), "projects", getProjectIdOrPath(projectIdOrPath), "archive");
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Archive a project
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the archived GitLab Project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project archiveProject(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (new GitLabApiForm()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "archive");
+    return (response.readEntity(Project.class));
+  }
 
-    /**
-     * Unarchive a project
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/unarchive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the unarchived GitLab Project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project unarchiveProject(Object projectIdOrPath)
-            throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (new GitLabApiForm()), "projects", getProjectIdOrPath(projectIdOrPath), "unarchive");
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Unarchive a project
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/unarchive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the unarchived GitLab Project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project unarchiveProject(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (new GitLabApiForm()),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "unarchive");
+    return (response.readEntity(Project.class));
+  }
 
-    /**
-     * Uploads a file to the specified project to be used in an issue or merge request description, or a comment.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param fileToUpload the File instance of the file to upload, required
-     * @return a FileUpload instance with information on the just uploaded file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public FileUpload uploadFile(Object projectIdOrPath, File fileToUpload) throws GitLabApiException {
-        return (uploadFile(projectIdOrPath, fileToUpload, null));
-    }
+  /**
+   * Uploads a file to the specified project to be used in an issue or merge request description, or
+   * a comment.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param fileToUpload the File instance of the file to upload, required
+   * @return a FileUpload instance with information on the just uploaded file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public FileUpload uploadFile(final Object projectIdOrPath, final File fileToUpload)
+      throws GitLabApiException {
+    return (uploadFile(projectIdOrPath, fileToUpload, null));
+  }
 
-    /**
-     * Uploads a file to the specified project to be used in an issue or merge request description, or a comment.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param fileToUpload the File instance of the file to upload, required
-     * @param mediaType unused; will be removed in the next major version
-     * @return a FileUpload instance with information on the just uploaded file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public FileUpload uploadFile(Object projectIdOrPath, File fileToUpload, String mediaType) throws GitLabApiException {
-        Response response = upload(Response.Status.CREATED, "file", fileToUpload, mediaType, "projects", getProjectIdOrPath(projectIdOrPath), "uploads");
-        return (response.readEntity(FileUpload.class));
-    }
+  /**
+   * Uploads a file to the specified project to be used in an issue or merge request description, or
+   * a comment.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param fileToUpload the File instance of the file to upload, required
+   * @param mediaType unused; will be removed in the next major version
+   * @return a FileUpload instance with information on the just uploaded file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public FileUpload uploadFile(
+      final Object projectIdOrPath, final File fileToUpload, final String mediaType)
+      throws GitLabApiException {
+    final Response response =
+        upload(
+            Response.Status.CREATED,
+            "file",
+            fileToUpload,
+            mediaType,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "uploads");
+    return (response.readEntity(FileUpload.class));
+  }
 
-    /**
-     * Uploads some data in an {@link InputStream} to the specified project,
-     * to be used in an issue or merge request description, or a comment.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project instance, required
-     * @param inputStream the data to upload, required
-     * @param filename The filename of the file to upload
-     * @param mediaType unused; will be removed in the next major version
-     * @return a FileUpload instance with information on the just uploaded file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public FileUpload uploadFile(Object projectIdOrPath, InputStream inputStream, String filename, String mediaType) throws GitLabApiException {
-        Response response = upload(Response.Status.CREATED, "file", inputStream, filename, mediaType, "projects", getProjectIdOrPath(projectIdOrPath), "uploads");
-        return (response.readEntity(FileUpload.class));
-    }
+  /**
+   * Uploads some data in an {@link InputStream} to the specified project, to be used in an issue or
+   * merge request description, or a comment.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/uploads</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Integer(ID), String(path), or Project
+   *     instance, required
+   * @param inputStream the data to upload, required
+   * @param filename The filename of the file to upload
+   * @param mediaType unused; will be removed in the next major version
+   * @return a FileUpload instance with information on the just uploaded file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public FileUpload uploadFile(
+      final Object projectIdOrPath,
+      final InputStream inputStream,
+      final String filename,
+      final String mediaType)
+      throws GitLabApiException {
+    final Response response =
+        upload(
+            Response.Status.CREATED,
+            "file",
+            inputStream,
+            filename,
+            mediaType,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "uploads");
+    return (response.readEntity(FileUpload.class));
+  }
 
-    /**
-     * Get the project's push rules.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/push_rule</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return the push rules for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PushRules getPushRules(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
-        return (response.readEntity(PushRules.class));
-    }
+  /**
+   * Get the project's push rules.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/push_rule</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return the push rules for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PushRules getPushRules(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
+    return (response.readEntity(PushRules.class));
+  }
 
-    /**
-     * Adds a push rule to a specified project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/push_rule</code></pre>
-     *
-     * The following properties on the PushRules instance are utilized in the creation of the push rule:
-     *
-     *<code>
-     * denyDeleteTag (optional) - Deny deleting a tag
-     * memberCheck (optional) - Restrict commits by author (email) to existing GitLab users
-     * preventSecrets (optional) - GitLab will reject any files that are likely to contain secrets
-     * commitMessageRegex (optional) - All commit messages must match this, e.g. Fixed \d+\..*
-     * commitMessageNegativeRegex (optional) - No commit message is allowed to match this, e.g. ssh\:\/\/
-     * branchNameRegex (optional) - All branch names must match this, e.g. `(feature
-     * authorEmailRegex (optional) - All commit author emails must match this, e.g. @my-company.com$
-     * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
-     * maxFileSize (optional) - Maximum file size (MB)
-     * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
-     * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
-     *</code>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pushRule the PushRule instance containing the push rule configuration to add
-     * @return a PushRules instance with the newly created push rule info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PushRules createPushRules(Object projectIdOrPath, PushRules pushRule) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+  /**
+   * Adds a push rule to a specified project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/push_rule</code></pre>
+   *
+   * The following properties on the PushRules instance are utilized in the creation of the push
+   * rule: <code>
+   * denyDeleteTag (optional) - Deny deleting a tag
+   * memberCheck (optional) - Restrict commits by author (email) to existing GitLab users
+   * preventSecrets (optional) - GitLab will reject any files that are likely to contain secrets
+   * commitMessageRegex (optional) - All commit messages must match this, e.g. Fixed \d+\..*
+   * commitMessageNegativeRegex (optional) - No commit message is allowed to match this, e.g. ssh\:\/\/
+   * branchNameRegex (optional) - All branch names must match this, e.g. `(feature
+   * authorEmailRegex (optional) - All commit author emails must match this, e.g. @my-company.com$
+   * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
+   * maxFileSize (optional) - Maximum file size (MB)
+   * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
+   * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
+   * </code>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param pushRule the PushRule instance containing the push rule configuration to add
+   * @return a PushRules instance with the newly created push rule info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PushRules createPushRules(final Object projectIdOrPath, final PushRules pushRule)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("deny_delete_tag", pushRule.getDenyDeleteTag())
             .withParam("member_check", pushRule.getMemberCheck())
             .withParam("prevent_secrets", pushRule.getPreventSecrets())
@@ -2755,38 +3504,46 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
             .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits());
 
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
-        return (response.readEntity(PushRules.class));
-    }
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "push_rule");
+    return (response.readEntity(PushRules.class));
+  }
 
-    /**
-     * Updates a push rule for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/push_rule/:push_rule_id</code></pre>
-     *
-     * The following properties on the PushRules instance are utilized when updating the push rule:
-     *
-     *<code>
-     * denyDeleteTag (optional) - Deny deleting a tag
-     * memberCheck (optional) - Restrict commits by author (email) to existing GitLab users
-     * preventSecrets (optional) - GitLab will reject any files that are likely to contain secrets
-     * commitMessageRegex (optional) - All commit messages must match this, e.g. Fixed \d+\..*
-     * commitMessageNegativeRegex (optional) - No commit message is allowed to match this, e.g. ssh\:\/\/
-     * branchNameRegex (optional) - All branch names must match this, e.g. `(feature
-     * authorEmailRegex (optional) - All commit author emails must match this, e.g. @my-company.com$
-     * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
-     * maxFileSize (optional) - Maximum file size (MB)
-     * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
-     * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
-     *</code>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param pushRule the PushRules instance containing the push rule configuration to update
-     * @return a PushRules instance with the newly created push rule info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public PushRules updatePushRules(Object projectIdOrPath, PushRules pushRule) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+  /**
+   * Updates a push rule for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/push_rule/:push_rule_id</code></pre>
+   *
+   * The following properties on the PushRules instance are utilized when updating the push rule:
+   * <code>
+   * denyDeleteTag (optional) - Deny deleting a tag
+   * memberCheck (optional) - Restrict commits by author (email) to existing GitLab users
+   * preventSecrets (optional) - GitLab will reject any files that are likely to contain secrets
+   * commitMessageRegex (optional) - All commit messages must match this, e.g. Fixed \d+\..*
+   * commitMessageNegativeRegex (optional) - No commit message is allowed to match this, e.g. ssh\:\/\/
+   * branchNameRegex (optional) - All branch names must match this, e.g. `(feature
+   * authorEmailRegex (optional) - All commit author emails must match this, e.g. @my-company.com$
+   * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
+   * maxFileSize (optional) - Maximum file size (MB)
+   * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
+   * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
+   * </code>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param pushRule the PushRules instance containing the push rule configuration to update
+   * @return a PushRules instance with the newly created push rule info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public PushRules updatePushRules(final Object projectIdOrPath, final PushRules pushRule)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("deny_delete_tag", pushRule.getDenyDeleteTag())
             .withParam("member_check", pushRule.getMemberCheck())
             .withParam("prevent_secrets", pushRule.getPreventSecrets())
@@ -2799,1106 +3556,1530 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
             .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits());
 
-        final Response response = putWithFormData(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
-        return (response.readEntity(PushRules.class));
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "push_rule");
+    return (response.readEntity(PushRules.class));
+  }
+
+  /**
+   * Removes a push rule from a project. This is an idempotent method and can be called multiple
+   * times. Either the push rule is available or not.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/push_rule</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deletePushRules(final Object projectIdOrPath) throws GitLabApiException {
+    delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
+  }
+
+  /**
+   * Get a list of projects that were forked from the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a List of forked projects
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getForks(final Object projectIdOrPath) throws GitLabApiException {
+    return (getForks(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of projects that were forked from the specified project and in the specified page
+   * range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a List of forked projects
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Project> getForks(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "forks");
+    return (response.readEntity(new GenericType<List<Project>>() {}));
+  }
+
+  /**
+   * Get a Pager of projects that were forked from the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of projects
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Project> getForks(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Project>(
+        this,
+        Project.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "forks");
+  }
+
+  /**
+   * Get a Stream of projects that were forked from the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of forked projects
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Project> getForksStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getForks(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Star a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/star</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Project instance with the new project info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project starProject(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
+    final Response response =
+        post(expectedStatus, (Form) null, "projects", getProjectIdOrPath(projectIdOrPath), "star");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Unstar a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/unstar</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Project instance with the new project info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project unstarProject(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
+    final Response response =
+        post(
+            expectedStatus, (Form) null, "projects", getProjectIdOrPath(projectIdOrPath), "unstar");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Get languages used in a project with percentage value.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/languages</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Map instance with the language as the key and the percentage as the value
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 10.8
+   */
+  public Map<String, Float> getProjectLanguages(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "languages");
+    return (response.readEntity(new GenericType<Map<String, Float>>() {}));
+  }
+
+  /**
+   * Transfer a project to a new namespace. This was added in GitLab 11.1
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/transfer.</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param namespace the namespace to transfer the project to
+   * @return the updated Project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project transferProject(final Object projectIdOrPath, final String namespace)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("namespace", namespace, true);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "transfer");
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Uploads and sets the project avatar for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param avatarFile the File instance of the avatar file to upload
+   * @return the updated Project instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Project setProjectAvatar(final Object projectIdOrPath, final File avatarFile)
+      throws GitLabApiException {
+    final Response response =
+        putUpload(
+            Response.Status.OK,
+            "avatar",
+            avatarFile,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath));
+    return (response.readEntity(Project.class));
+  }
+
+  /**
+   * Get a List of the project audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /projects/:id/audit_events</code></pre>
+   *
+   * @param projectIdOrPath the project ID, path of the project, or a project instance holding the
+   *     project ID or path
+   * @param created_after Project audit events created on or after the given time.
+   * @param created_before Project audit events created on or before the given time.
+   * @return a List of project Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AuditEvent> getAuditEvents(
+      final Object projectIdOrPath, final Date created_after, final Date created_before)
+      throws GitLabApiException {
+    return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Get a Pager of the group audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /projects/:id/audit_events</code></pre>
+   *
+   * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the
+   *     project ID or path
+   * @param created_after Project audit events created on or after the given time.
+   * @param created_before Project audit events created on or before the given time.
+   * @param itemsPerPage the number of Audit Event instances that will be fetched per page
+   * @return a Pager of project Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<AuditEvent> getAuditEvents(
+      final Object projectIdOrPath,
+      final Date created_after,
+      final Date created_before,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form form =
+        new GitLabApiForm()
+            .withParam("created_before", ISO8601.toString(created_before, false))
+            .withParam("created_after", ISO8601.toString(created_after, false));
+    return (new Pager<AuditEvent>(
+        this,
+        AuditEvent.class,
+        itemsPerPage,
+        form.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "audit_events"));
+  }
+
+  /**
+   * Get a Stream of the group audit events viewable by Maintainer or an Owner of the group.
+   *
+   * <pre><code>GET /projects/:id/audit_events</code></pre>
+   *
+   * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the
+   *     project ID or path
+   * @param created_after Project audit events created on or after the given time.
+   * @param created_before Project audit events created on or before the given time.
+   * @return a Stream of project Audit events
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<AuditEvent> getAuditEventsStream(
+      final Object projectIdOrPath, final Date created_after, final Date created_before)
+      throws GitLabApiException {
+    return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a specific audit event of a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/audit_events/:id_audit_event</code></pre>
+   *
+   * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the
+   *     project ID or path
+   * @param auditEventId the auditEventId, required
+   * @return the project Audit event
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AuditEvent getAuditEvent(final Object projectIdOrPath, final Long auditEventId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "audit_events",
+            auditEventId);
+    return (response.readEntity(AuditEvent.class));
+  }
+
+  /**
+   * Get list of a project's variables.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a list of variables belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Variable> getVariables(final Object projectIdOrPath) throws GitLabApiException {
+    return (getVariables(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of variables for the specified project in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param page the page to get
+   * @param perPage the number of Variable instances per page
+   * @return a list of variables belonging to the specified project in the specified page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Variable> getVariables(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "variables");
+    return (response.readEntity(new GenericType<List<Variable>>() {}));
+  }
+
+  /**
+   * Get a Pager of variables belonging to the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param itemsPerPage the number of Variable instances that will be fetched per page
+   * @return a Pager of variables belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Variable> getVariables(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Variable>(
+        this,
+        Variable.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "variables"));
+  }
+
+  /**
+   * Get a Stream of variables belonging to the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @return a Stream of variables belonging to the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Variable> getVariablesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getVariables(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the details of a project variable.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @return the Variable instance for the specified variable
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Variable getVariable(final Object projectIdOrPath, final String key)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "variables",
+            key);
+    return (response.readEntity(Variable.class));
+  }
+
+  /**
+   * Get the details of a variable as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @return the Variable for the specified variable as an Optional instance
+   */
+  public Optional<Variable> getOptionalVariable(final Object projectIdOrPath, final String key) {
+    try {
+      return (Optional.ofNullable(getVariable(projectIdOrPath, key)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Removes a push rule from a project. This is an idempotent method and can be
-     * called multiple times. Either the push rule is available or not.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/push_rule</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deletePushRules(Object projectIdOrPath) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
-    }
+  /**
+   * Create a new project variable.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object projectIdOrPath, final String key, final String value, final Boolean isProtected)
+      throws GitLabApiException {
+    return (createVariable(projectIdOrPath, key, value, isProtected, (String) null));
+  }
 
-    /**
-     * Get a list of projects that were forked from the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a List of forked projects
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getForks(Object projectIdOrPath) throws GitLabApiException {
-        return (getForks(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Create a new project variable.
+   *
+   * <p>NOTE: Setting the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @param environmentScope the environment_scope of the variable, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Boolean isProtected,
+      final String environmentScope)
+      throws GitLabApiException {
+    return createVariable(projectIdOrPath, key, value, null, isProtected, null, environmentScope);
+  }
 
-    /**
-     * Get a list of projects that were forked from the specified project and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a List of forked projects
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Project> getForks(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),"projects", getProjectIdOrPath(projectIdOrPath), "forks");
-        return (response.readEntity(new GenericType<List<Project>>() { }));
-    }
+  /**
+   * Create a new project variable.
+   *
+   * <p>NOTE: Setting the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param variableType the type of variable. Available types are: env_var (default) and file
+   * @param isProtected whether the variable is protected, optional
+   * @param isMasked whether the variable is masked, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Variable.Type variableType,
+      final Boolean isProtected,
+      final Boolean isMasked)
+      throws GitLabApiException {
+    return createVariable(projectIdOrPath, key, value, variableType, isProtected, isMasked, null);
+  }
 
-    /**
-     * Get a Pager of projects that were forked from the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of projects
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Project> getForks(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Project>(this, Project.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "forks");
-    }
+  /**
+   * Create a new project variable.
+   *
+   * <p>NOTE: Setting the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9,
+   *     and _ are allowed, required
+   * @param value the value for the variable, required
+   * @param variableType the type of variable. Available types are: env_var (default) and file
+   * @param isProtected whether the variable is protected, optional
+   * @param isMasked whether the variable is masked, optional
+   * @param environmentScope the environment_scope of the variable, optional
+   * @return a Variable instance with the newly created variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable createVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Variable.Type variableType,
+      final Boolean isProtected,
+      final Boolean isMasked,
+      final String environmentScope)
+      throws GitLabApiException {
 
-    /**
-     * Get a Stream of projects that were forked from the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/forks</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of forked projects
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Project> getForksStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getForks(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("key", key, true)
+            .withParam("value", value, true)
+            .withParam("variable_type", variableType)
+            .withParam("protected", isProtected)
+            .withParam("masked", isMasked)
+            .withParam("environment_scope", environmentScope);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "variables");
+    return (response.readEntity(Variable.class));
+  }
 
-    /**
-     * Star a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/star</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Project instance with the new project info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project starProject(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
-        Response response = post(expectedStatus, (Form) null, "projects", getProjectIdOrPath(projectIdOrPath), "star");
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Update a project variable.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object projectIdOrPath, final String key, final String value, final Boolean isProtected)
+      throws GitLabApiException {
+    return (updateVariable(projectIdOrPath, key, value, null, isProtected, null, null));
+  }
 
-    /**
-     * Unstar a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/unstar</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Project instance with the new project info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project unstarProject(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.CREATED);
-        Response response = post(expectedStatus, (Form) null, "projects", getProjectIdOrPath(projectIdOrPath), "unstar");
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Update a project variable.
+   *
+   * <p>NOTE: Updating the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param isProtected whether the variable is protected, optional
+   * @param environmentScope the environment_scope of the variable, optional.
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Boolean isProtected,
+      final String environmentScope)
+      throws GitLabApiException {
+    return updateVariable(projectIdOrPath, key, value, null, isProtected, null, environmentScope);
+  }
 
-    /**
-     * Get languages used in a project with percentage value.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/languages</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Map instance with the language as the key and the percentage as the value
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 10.8
-     */
-    public Map<String, Float> getProjectLanguages(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "languages");
-        return (response.readEntity(new GenericType<Map<String, Float>>() {}));
-    }
+  /**
+   * Update a project variable.
+   *
+   * <p>NOTE: Updating the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param variableType the type of variable. Available types are: env_var (default) and file
+   * @param isProtected whether the variable is protected, optional
+   * @param masked whether the variable is masked, optional
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Variable.Type variableType,
+      final Boolean isProtected,
+      final Boolean masked)
+      throws GitLabApiException {
+    return updateVariable(projectIdOrPath, key, value, variableType, isProtected, masked, null);
+  }
 
-    /**
-     * Transfer a project to a new namespace.  This was added in GitLab 11.1
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/transfer.</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param namespace the namespace to transfer the project to
-     * @return the updated Project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project transferProject(Object projectIdOrPath, String namespace) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("namespace", namespace, true);
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "transfer");
-        return (response.readEntity(Project.class));
-    }
+  /**
+   * Update a project variable.
+   *
+   * <p>NOTE: Updating the environmentScope is only available on GitLab EE.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @param value the value for the variable, required
+   * @param variableType the type of variable. Available types are: env_var (default) and file
+   * @param isProtected whether the variable is protected, optional
+   * @param masked whether the variable is masked, optional
+   * @param environmentScope the environment_scope of the variable, optional.
+   * @return a Variable instance with the updated variable
+   * @throws GitLabApiException if any exception occurs during execution
+   */
+  public Variable updateVariable(
+      final Object projectIdOrPath,
+      final String key,
+      final String value,
+      final Variable.Type variableType,
+      final Boolean isProtected,
+      final Boolean masked,
+      final String environmentScope)
+      throws GitLabApiException {
 
-    /**
-     * Uploads and sets the project avatar for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param avatarFile the File instance of the avatar file to upload
-     * @return the updated Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Project setProjectAvatar(Object projectIdOrPath, File avatarFile) throws GitLabApiException {
-        Response response = putUpload(Response.Status.OK,
-                "avatar", avatarFile, "projects", getProjectIdOrPath(projectIdOrPath));
-        return (response.readEntity(Project.class));
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("value", value, true)
+            .withParam("variable_type", variableType)
+            .withParam("protected", isProtected)
+            .withParam("masked", masked)
+            .withParam("environment_scope", environmentScope);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "variables",
+            key);
+    return (response.readEntity(Variable.class));
+  }
 
-    /**
-     * Get a List of the project audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /projects/:id/audit_events</code></pre>
-     *
-     * @param projectIdOrPath the project ID, path of the project, or a project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
-     * @return a List of project Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AuditEvent> getAuditEvents(Object projectIdOrPath, Date created_after, Date created_before) throws GitLabApiException {
-        return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage()).all());
-    }
+  /**
+   * Deletes a project variable.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/variables/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key of an existing variable, required
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteVariable(final Object projectIdOrPath, final String key)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "variables",
+        key);
+  }
 
-    /**
-     * Get a Pager of the group audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /projects/:id/audit_events</code></pre>
-     *
-     * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
-     * @param itemsPerPage the number of Audit Event instances that will be fetched per page
-     * @return a Pager of project Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<AuditEvent> getAuditEvents(Object projectIdOrPath, Date created_after, Date created_before, int itemsPerPage) throws GitLabApiException {
-        Form form = new GitLabApiForm()
-                .withParam("created_before", ISO8601.toString(created_before, false))
-                .withParam("created_after", ISO8601.toString(created_after, false));
-        return (new Pager<AuditEvent>(this, AuditEvent.class, itemsPerPage, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "audit_events"));
-    }
+  /**
+   * Get a List of the project access requests viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a List of project AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<AccessRequest> getAccessRequests(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getAccessRequests(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Stream of the group audit events viewable by Maintainer or an Owner of the group.
-     *
-     * <pre><code>GET /projects/:id/audit_events</code></pre>
-     *
-     * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
-     * @return a Stream of project Audit events
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<AuditEvent> getAuditEventsStream(Object projectIdOrPath, Date created_after, Date created_before) throws GitLabApiException {
-        return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Pager of the project access requests viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of AccessRequest instances that will be fetched per page
+   * @return a Pager of project AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<AccessRequest> getAccessRequests(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<AccessRequest>(
+        this,
+        AccessRequest.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "access_requests"));
+  }
 
-    /**
-     * Get a specific audit event of a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/audit_events/:id_audit_event</code></pre>
-     *
-     * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the project ID or path
-     * @param auditEventId the auditEventId, required
-     * @return the project Audit event
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AuditEvent getAuditEvent(Object projectIdOrPath, Long auditEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "audit_events", auditEventId);
-        return (response.readEntity(AuditEvent.class));
-    }
+  /**
+   * Get a Stream of the project access requests viewable by the authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project AccessRequest instances accessible by the authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<AccessRequest> getAccessRequestsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getAccessRequests(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get list of a project's variables.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a list of variables belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Variable> getVariables(Object projectIdOrPath) throws GitLabApiException {
-        return (getVariables(projectIdOrPath, getDefaultPerPage()).all());
-    }
+  /**
+   * Requests access for the authenticated user to the specified project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/access_requests</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the created AccessRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AccessRequest requestAccess(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            (Form) null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "access_requests");
+    return (response.readEntity(AccessRequest.class));
+  }
 
-    /**
-     * Get a list of variables for the specified project in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param page the page to get
-     * @param perPage the number of Variable instances per page
-     * @return a list of variables belonging to the specified project in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Variable> getVariables(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects", getProjectIdOrPath(projectIdOrPath), "variables");
-        return (response.readEntity(new GenericType<List<Variable>>() {}));
-    }
+  /**
+   * Approve access for the specified user to the specified project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/access_requests/:user_id/approve</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID to approve access for
+   * @param accessLevel the access level the user is approved for, if null will be developer (30)
+   * @return the approved AccessRequest instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public AccessRequest approveAccessRequest(
+      final Object projectIdOrPath, final Long userId, final AccessLevel accessLevel)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("access_level", accessLevel);
+    final Response response =
+        this.putWithFormData(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "access_requests",
+            userId,
+            "approve");
+    return (response.readEntity(AccessRequest.class));
+  }
 
-    /**
-     * Get a Pager of variables belonging to the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param itemsPerPage the number of Variable instances that will be fetched per page
-     * @return a Pager of variables belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Variable> getVariables(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Variable>(this, Variable.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "variables"));
-    }
+  /**
+   * Deny access for the specified user to the specified project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/access_requests/:user_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param userId the user ID to deny access for
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void denyAccessRequest(final Object projectIdOrPath, final Long userId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "access_requests",
+        userId);
+  }
 
-    /**
-     * Get a Stream of variables belonging to the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @return a Stream of variables belonging to the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Variable> getVariablesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getVariables(projectIdOrPath, getDefaultPerPage()).stream());
-    }
+  /**
+   * Start the Housekeeping task for a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/housekeeping</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void triggerHousekeeping(final Object projectIdOrPath) throws GitLabApiException {
+    post(
+        Response.Status.OK,
+        (Form) null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "housekeeping");
+  }
 
-    /**
-     * Get the details of a project variable.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @return the Variable instance for the specified variable
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Variable getVariable(Object projectIdOrPath, String key) throws GitLabApiException {
-      Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "variables", key);
-      return (response.readEntity(Variable.class));
-    }
+  /**
+   * Gets a list of a project’s badges and its group badges.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/badges</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a List of Badge instances for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Badge> getBadges(final Object projectIdOrPath) throws GitLabApiException {
+    return getBadges(projectIdOrPath, null);
+  }
 
-    /**
-     * Get the details of a variable as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @return the Variable for the specified variable as an Optional instance
-     */
-    public Optional<Variable> getOptionalVariable(Object projectIdOrPath, String key) {
-        try {
-            return (Optional.ofNullable(getVariable(projectIdOrPath, key)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create a new project variable.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object projectIdOrPath, String key, String value, Boolean isProtected) throws GitLabApiException {
-        return (createVariable(projectIdOrPath, key, value, isProtected, (String) null));
-    }
-
-    /**
-     * Create a new project variable.
-     *
-     * <p>NOTE: Setting the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @param environmentScope the environment_scope of the variable, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object projectIdOrPath, String key, String value, Boolean isProtected, String environmentScope) throws GitLabApiException {
-        return createVariable(projectIdOrPath, key, value, null, isProtected, null, environmentScope);
-    }
-
-    /**
-     * Create a new project variable.
-     *
-     * <p>NOTE: Setting the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param variableType the type of variable. Available types are: env_var (default) and file
-     * @param isProtected whether the variable is protected, optional
-     * @param isMasked whether the variable is masked, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object projectIdOrPath, String key, String value, Variable.Type variableType,
-            Boolean isProtected, Boolean isMasked) throws GitLabApiException {
-        return createVariable(projectIdOrPath, key, value, variableType, isProtected, isMasked, null);
-    }
-
-    /**
-     * Create a new project variable.
-     *
-     * <p>NOTE: Setting the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/variables</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of a variable; must have no more than 255 characters; only A-Z, a-z, 0-9, and _ are allowed, required
-     * @param value the value for the variable, required
-     * @param variableType the type of variable. Available types are: env_var (default) and file
-     * @param isProtected whether the variable is protected, optional
-     * @param isMasked whether the variable is masked, optional
-     * @param environmentScope the environment_scope of the variable, optional
-     * @return a Variable instance with the newly created variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable createVariable(Object projectIdOrPath, String key, String value, Variable.Type variableType,
-            Boolean isProtected, Boolean isMasked, String environmentScope) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("key", key, true)
-                .withParam("value", value, true)
-                .withParam("variable_type", variableType)
-                .withParam("protected", isProtected)
-                .withParam("masked", isMasked)
-                .withParam("environment_scope",  environmentScope);
-        Response response = post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "variables");
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Update a project variable.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object projectIdOrPath, String key, String value, Boolean isProtected) throws GitLabApiException {
-        return (updateVariable(projectIdOrPath, key, value, null, isProtected, null, null));
-    }
-
-    /**
-     * Update a project variable.
-     *
-     * <p>NOTE: Updating the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param isProtected whether the variable is protected, optional
-     * @param environmentScope the environment_scope of the variable, optional.
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object projectIdOrPath, String key, String value, Boolean isProtected, String environmentScope) throws GitLabApiException {
-        return updateVariable(projectIdOrPath, key, value, null, isProtected, null, environmentScope);
-    }
-
-    /**
-     * Update a project variable.
-     *
-     * <p>NOTE: Updating the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param variableType the type of variable. Available types are: env_var (default) and file
-     * @param isProtected whether the variable is protected, optional
-     * @param masked whether the variable is masked, optional
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object projectIdOrPath, String key, String value, Variable.Type variableType,
-            Boolean isProtected, Boolean masked) throws GitLabApiException {
-        return updateVariable(projectIdOrPath, key, value, variableType, isProtected, masked, null);
-    }
-
-    /**
-     * Update a project variable.
-     *
-     * <p>NOTE: Updating the environmentScope is only available on GitLab EE.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @param value the value for the variable, required
-     * @param variableType the type of variable. Available types are: env_var (default) and file
-     * @param isProtected whether the variable is protected, optional
-     * @param masked whether the variable is masked, optional
-     * @param environmentScope the environment_scope of the variable, optional.
-     * @return a Variable instance with the updated variable
-     * @throws GitLabApiException if any exception occurs during execution
-     */
-    public Variable updateVariable(Object projectIdOrPath, String key, String value, Variable.Type variableType,
-            Boolean isProtected, Boolean masked, String environmentScope) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("value", value, true)
-                .withParam("variable_type", variableType)
-                .withParam("protected", isProtected)
-                .withParam("masked", masked)
-                .withParam("environment_scope", environmentScope);
-        Response response = putWithFormData(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "variables", key);
-        return (response.readEntity(Variable.class));
-    }
-
-    /**
-     * Deletes a project variable.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/variables/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key of an existing variable, required
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteVariable(Object projectIdOrPath, String key) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "variables", key);
-    }
-
-    /**
-     * Get a List of the project access requests viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a List of project AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<AccessRequest> getAccessRequests(Object projectIdOrPath) throws GitLabApiException {
-        return (getAccessRequests(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of the project access requests viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of AccessRequest instances that will be fetched per page
-     * @return a Pager of project AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<AccessRequest> getAccessRequests(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<AccessRequest>(this, AccessRequest.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "access_requests"));
-    }
-
-    /**
-     * Get a Stream of the project access requests viewable by the authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/access_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project AccessRequest instances accessible by the authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<AccessRequest> getAccessRequestsStream(Object projectIdOrPath) throws GitLabApiException {
-       return (getAccessRequests(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Requests access for the authenticated user to the specified project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/access_requests</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the created AccessRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AccessRequest requestAccess(Object projectIdOrPath) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, (Form)null, "projects", getProjectIdOrPath(projectIdOrPath), "access_requests");
-        return (response.readEntity(AccessRequest.class));
-    }
-
-    /**
-     * Approve access for the specified user to the specified project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/access_requests/:user_id/approve</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID to approve access for
-     * @param accessLevel the access level the user is approved for, if null will be developer (30)
-     * @return the approved AccessRequest instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public AccessRequest approveAccessRequest(Object projectIdOrPath, Long userId, AccessLevel accessLevel) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("access_level", accessLevel);
-        Response response = this.putWithFormData(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "access_requests", userId, "approve");
-        return (response.readEntity(AccessRequest.class));
-    }
-
-    /**
-     * Deny access for the specified user to the specified project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/access_requests/:user_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param userId the user ID to deny access for
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void denyAccessRequest(Object projectIdOrPath, Long userId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "access_requests", userId);
-    }
-
-    /**
-     * Start the Housekeeping task for a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/housekeeping</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void triggerHousekeeping(Object projectIdOrPath) throws GitLabApiException {
-        post(Response.Status.OK, (Form) null, "projects", getProjectIdOrPath(projectIdOrPath), "housekeeping");
-    }
-
-    /**
-     * Gets a list of a project’s badges and its group badges.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a List of Badge instances for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Badge> getBadges(Object projectIdOrPath) throws GitLabApiException {
-	return getBadges(projectIdOrPath, null);
-    }
-
-    /**
-     * Gets a list of a project’s badges and its group badges, case-sensitively filtered on bagdeName if non-null.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges?name=:name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
-     * @param bagdeName The name to filter on (case-sensitive), ignored if null.
-     * @return All badges of the GitLab item, case insensitively filtered on name.
-     * @throws GitLabApiException If any problem is encountered
-     */
-    public List<Badge> getBadges(Object projectIdOrPath, String bagdeName) throws GitLabApiException {
-    Form queryParam = new GitLabApiForm().withParam("name", bagdeName);
-    Response response = get(Response.Status.OK, queryParam.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "badges");
+  /**
+   * Gets a list of a project’s badges and its group badges, case-sensitively filtered on bagdeName
+   * if non-null.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/badges?name=:name</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
+   * @param bagdeName The name to filter on (case-sensitive), ignored if null.
+   * @return All badges of the GitLab item, case insensitively filtered on name.
+   * @throws GitLabApiException If any problem is encountered
+   */
+  public List<Badge> getBadges(final Object projectIdOrPath, final String bagdeName)
+      throws GitLabApiException {
+    final Form queryParam = new GitLabApiForm().withParam("name", bagdeName);
+    final Response response =
+        get(
+            Response.Status.OK,
+            queryParam.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "badges");
     return (response.readEntity(new GenericType<List<Badge>>() {}));
-    }
+  }
 
-    /**
-     * Gets a badge of a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges/:badge_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param badgeId the ID of the badge to get
-     * @return a Badge instance for the specified project/badge ID pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge getBadge(Object projectIdOrPath, Long badgeId) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "badges", badgeId);
-	return (response.readEntity(Badge.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for the specified badge.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges/:badge_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param badgeId the ID of the badge to get
-     * @return an Optional instance with the specified badge as the value
-     */
-    public Optional<Badge> getOptionalBadge(Object projectIdOrPath, Long badgeId) {
-	try {
-	    return (Optional.ofNullable(getBadge(projectIdOrPath, badgeId)));
-	} catch (GitLabApiException glae) {
-	    return (GitLabApi.createOptionalFromException(glae));
-	}
-    }
-
-    /**
-     * Add a badge to a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/badges</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the added badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge addBadge(Object projectIdOrPath, String linkUrl, String imageUrl) throws GitLabApiException {
-    return addBadge(projectIdOrPath, null, linkUrl, imageUrl);
-    }
-
-    /**
-     * Add a badge to a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/badges</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
-     * @param name The name to give the badge (may be null)
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return A Badge instance for the added badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge addBadge(Object projectIdOrPath, String name, String linkUrl, String imageUrl) throws GitLabApiException {
-    GitLabApiForm formData = new GitLabApiForm()
-        .withParam("name", name, false)
-        .withParam("link_url", linkUrl, true)
-        .withParam("image_url", imageUrl, true);
-    Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges");
+  /**
+   * Gets a badge of a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/badges/:badge_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param badgeId the ID of the badge to get
+   * @return a Badge instance for the specified project/badge ID pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge getBadge(final Object projectIdOrPath, final Long badgeId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "badges",
+            badgeId);
     return (response.readEntity(Badge.class));
-    }
+  }
 
-    /**
-     * Edit a badge of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/badges</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param badgeId the ID of the badge to get
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the editted badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge editBadge(Object projectIdOrPath, Long badgeId, String linkUrl, String imageUrl) throws GitLabApiException {
-	return (editBadge(projectIdOrPath, badgeId, null, linkUrl, imageUrl));
+  /**
+   * Get an Optional instance with the value for the specified badge.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/badges/:badge_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param badgeId the ID of the badge to get
+   * @return an Optional instance with the specified badge as the value
+   */
+  public Optional<Badge> getOptionalBadge(final Object projectIdOrPath, final Long badgeId) {
+    try {
+      return (Optional.ofNullable(getBadge(projectIdOrPath, badgeId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Edit a badge of a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/badges</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
-     * @param badgeId the ID of the badge to edit
-     * @param name The name of the badge to edit (may be null)
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the editted badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge editBadge(Object projectIdOrPath, Long badgeId, String name, String linkUrl, String imageUrl) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+  /**
+   * Add a badge to a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/badges</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the added badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge addBadge(final Object projectIdOrPath, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    return addBadge(projectIdOrPath, null, linkUrl, imageUrl);
+  }
+
+  /**
+   * Add a badge to a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/badges</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
+   * @param name The name to give the badge (may be null)
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return A Badge instance for the added badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge addBadge(
+      final Object projectIdOrPath, final String name, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", name, false)
+            .withParam("link_url", linkUrl, true)
+            .withParam("image_url", imageUrl, true);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "badges");
+    return (response.readEntity(Badge.class));
+  }
+
+  /**
+   * Edit a badge of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/badges</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param badgeId the ID of the badge to get
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the editted badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge editBadge(
+      final Object projectIdOrPath, final Long badgeId, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    return (editBadge(projectIdOrPath, badgeId, null, linkUrl, imageUrl));
+  }
+
+  /**
+   * Edit a badge of a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/badges</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of a Long(ID), String(path), or Project instance
+   * @param badgeId the ID of the badge to edit
+   * @param name The name of the badge to edit (may be null)
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the editted badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge editBadge(
+      final Object projectIdOrPath,
+      final Long badgeId,
+      final String name,
+      final String linkUrl,
+      final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
             .withParam("name", name, false)
             .withParam("link_url", linkUrl, false)
             .withParam("image_url", imageUrl, false);
-        Response response = putWithFormData(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "badges", badgeId);
-        return (response.readEntity(Badge.class));
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "badges",
+            badgeId);
+    return (response.readEntity(Badge.class));
+  }
+
+  /**
+   * Remove a badge from a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/badges/:badge_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param badgeId the ID of the badge to remove
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void removeBadge(final Object projectIdOrPath, final Long badgeId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "badges",
+        badgeId);
+  }
+
+  /**
+   * Returns how the link_url and image_url final URLs would be after resolving the placeholder
+   * interpolation.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/badges/render</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param linkUrl the URL of the badge link
+   * @param imageUrl the URL of the image link
+   * @return a Badge instance for the rendered badge
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Badge previewBadge(
+      final Object projectIdOrPath, final String linkUrl, final String imageUrl)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("link_url", linkUrl, true)
+            .withParam("image_url", imageUrl, true);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "badges",
+            "render");
+    return (response.readEntity(Badge.class));
+  }
+
+  /**
+   * Get the project's approval information. Note: This API endpoint is only available on 10.6
+   * Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/approvals</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a ProjectApprovalsConfig instance with the project's approvals configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectApprovalsConfig getApprovalsConfiguration(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "approvals");
+    return (response.readEntity(ProjectApprovalsConfig.class));
+  }
+
+  /**
+   * Set the project's approvals configuration. Note: This API endpoint is only available on 10.6
+   * Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/approvals</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param config a ProjectApprovalsConfig instance with the approval configuration
+   * @return a ProjectApprovalsConfig instance with the project's approvals configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProjectApprovalsConfig setApprovalsConfiguration(
+      final Object projectIdOrPath, final ProjectApprovalsConfig config) throws GitLabApiException {
+    final GitLabApiForm formData = config.getForm();
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "approvals");
+    return (response.readEntity(ProjectApprovalsConfig.class));
+  }
+
+  /**
+   * Get a list of the project-level approval rules. Note: This API endpoint is only available on
+   * 12.3 Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a List of ApprovalRuke instances for the specified project.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ApprovalRule> getApprovalRules(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getApprovalRules(projectIdOrPath, -1).all());
+  }
+
+  /**
+   * Get a Pager of the project-level approval rules. Note: This API endpoint is only available on
+   * 12.3 Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of ApprovalRule instances that will be fetched per page
+   * @return a Pager of ApprovalRuke instances for the specified project.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ApprovalRule> getApprovalRules(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+
+    return (new Pager<ApprovalRule>(
+        this,
+        ApprovalRule.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "approval_rules"));
+  }
+
+  /**
+   * Get a Stream of the project-level approval rules. Note: This API endpoint is only available on
+   * 12.3 Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of ApprovalRule instances for the specified project.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ApprovalRule> getApprovalRulesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getApprovalRules(projectIdOrPath, -1).stream());
+  }
+
+  /**
+   * Create a project-level approval rule. Note: This API endpoint is only available on 12.3 Starter
+   * and above.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/approval_rules</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
+   * @return a ApprovalRule instance with approval configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ApprovalRule createApprovalRule(
+      final Object projectIdOrPath, final ApprovalRuleParams params) throws GitLabApiException {
+    final GitLabApiForm formData = params.getForm();
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "approval_rules");
+    return (response.readEntity(ApprovalRule.class));
+  }
+
+  /**
+   * Update the specified the project-level approval rule. Note: This API endpoint is only available
+   * on 12.3 Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/approval_rules/:approval_rule_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param approvalRuleId the ID of the approval rule
+   * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
+   *     update
+   * @return a ApprovalRule instance with approval configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ApprovalRule updateApprovalRule(
+      final Object projectIdOrPath, final Long approvalRuleId, final ApprovalRuleParams params)
+      throws GitLabApiException {
+
+    if (approvalRuleId == null) {
+      throw new RuntimeException("approvalRuleId cannot be null");
     }
 
-    /**
-     * Remove a badge from a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/badges/:badge_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param badgeId the ID of the badge to remove
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void removeBadge(Object projectIdOrPath, Long badgeId) throws GitLabApiException {
-	delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "badges", badgeId);
+    final GitLabApiForm formData = params.getForm();
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "approval_rules",
+            approvalRuleId);
+    return (response.readEntity(ApprovalRule.class));
+  }
+
+  /**
+   * Delete the specified the project-level approval rule. Note: This API endpoint is only available
+   * on 12.3 Starter and above.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/approval_rules/:approval_rule_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param approvalRuleId the ID of the approval rule
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteApprovalRule(final Object projectIdOrPath, final Long approvalRuleId)
+      throws GitLabApiException {
+
+    if (approvalRuleId == null) {
+      throw new RuntimeException("approvalRuleId cannot be null");
     }
 
-    /**
-     * Returns how the link_url and image_url final URLs would be after resolving the placeholder interpolation.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/badges/render</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param linkUrl the URL of the badge link
-     * @param imageUrl the URL of the image link
-     * @return a Badge instance for the rendered badge
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Badge previewBadge(Object projectIdOrPath,  String linkUrl, String imageUrl) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("link_url", linkUrl, true)
-		.withParam("image_url", imageUrl, true);
-	Response response = get(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "badges", "render");
-	return (response.readEntity(Badge.class));
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "approval_rules",
+        approvalRuleId);
+  }
+
+  /**
+   * Get all custom attributes for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's CustomAttributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<CustomAttribute> getCustomAttributes(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getCustomAttributes(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of custom attributes for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of items per page
+   * @return a Pager of project's custom attributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<CustomAttribute> getCustomAttributes(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<CustomAttribute>(
+        this,
+        CustomAttribute.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "custom_attributes"));
+  }
+
+  /**
+   * Get a Stream of all custom attributes for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's custom attributes
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<CustomAttribute> getCustomAttributesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getCustomAttributes(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single custom attribute for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param key the key for the custom attribute
+   * @return a CustomAttribute instance for the specified key
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomAttribute getCustomAttribute(final Object projectIdOrPath, final String key)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "custom_attributes",
+            key);
+    return (response.readEntity(CustomAttribute.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for a single custom attribute for the specified
+   * project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance, required
+   * @param key the key for the custom attribute, required
+   * @return an Optional instance with the value for a single custom attribute for the specified
+   *     project
+   */
+  public Optional<CustomAttribute> geOptionalCustomAttribute(
+      final Object projectIdOrPath, final String key) {
+    try {
+      return (Optional.ofNullable(getCustomAttribute(projectIdOrPath, key)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Set a custom attribute for the specified project. The attribute will be updated if it already
+   * exists, or newly created otherwise.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/custom_attributes/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param key the key for the custom attribute
+   * @param value the value for the customAttribute
+   * @return a CustomAttribute instance for the updated or created custom attribute
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomAttribute setCustomAttribute(
+      final Object projectIdOrPath, final String key, final String value)
+      throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key cannot be null or empty");
+    }
+    if (Objects.isNull(value) || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("Value cannot be null or empty");
     }
 
-    /**
-     * Get the project's approval information.
-     * Note: This API endpoint is only available on 10.6 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/approvals</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a ProjectApprovalsConfig instance with the project's approvals configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectApprovalsConfig getApprovalsConfiguration(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "approvals");
-        return (response.readEntity(ProjectApprovalsConfig.class));
+    final GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "custom_attributes",
+            key);
+    return (response.readEntity(CustomAttribute.class));
+  }
+
+  /**
+   * Delete a custom attribute for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/custom_attributes/:key</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param key the key of the custom attribute to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteCustomAttribute(final Object projectIdOrPath, final String key)
+      throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key can't be null or empty");
     }
 
-    /**
-     * Set the project's approvals configuration.
-     * Note: This API endpoint is only available on 10.6 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/approvals</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param config a ProjectApprovalsConfig instance with the approval configuration
-     * @return a ProjectApprovalsConfig instance with the project's approvals configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProjectApprovalsConfig setApprovalsConfiguration(Object projectIdOrPath, ProjectApprovalsConfig config) throws GitLabApiException {
-	GitLabApiForm formData = config.getForm();
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "approvals");
-        return (response.readEntity(ProjectApprovalsConfig.class));
-    }
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "custom_attributes",
+        key);
+  }
 
-    /**
-     * Get a list of the project-level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a List of ApprovalRuke instances for the specified project.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ApprovalRule> getApprovalRules(Object projectIdOrPath) throws GitLabApiException {
-        return (getApprovalRules(projectIdOrPath, -1).all());
-    }
+  /**
+   * Get all remote mirrors and their statuses for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of project's remote mirrors
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<RemoteMirror> getRemoteMirrors(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getRemoteMirrors(projectIdOrPath, getDefaultPerPage()).all());
+  }
 
-    /**
-     * Get a Pager of the project-level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of ApprovalRule instances that will be fetched per page
-     * @return a Pager of ApprovalRuke instances for the specified project.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ApprovalRule> getApprovalRules(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
+  /**
+   * Get a Pager of remote mirrors and their statuses for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of items per page
+   * @return a Pager of project's remote mirrors
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<RemoteMirror> getRemoteMirrors(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<RemoteMirror>(
+        this,
+        RemoteMirror.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "remote_mirrors"));
+  }
 
-	return (new Pager<ApprovalRule>(this, ApprovalRule.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "approval_rules"));
-    }
+  /**
+   * Get a Stream of all remote mirrors and their statuses for the specified project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of project's remote mirrors
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<RemoteMirror> getRemoteMirrorsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getRemoteMirrors(projectIdOrPath, getDefaultPerPage()).stream());
+  }
 
-    /**
-     * Get a Stream of the project-level approval rules.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of ApprovalRule instances for the specified project.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ApprovalRule> getApprovalRulesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getApprovalRules(projectIdOrPath, -1).stream());
-    }
+  /**
+   * Create a remote mirror for a project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/remote_mirrors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param url the URL of the remote repository to be mirrored
+   * @param enabled determines if the mirror is enabled
+   * @param onlyProtectedBranches determines if only protected branches are mirrored
+   * @param keepDivergentRefs determines if divergent refs are skipped
+   * @return a RemoteMirror instance with remote mirror configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RemoteMirror createRemoteMirror(
+      final Object projectIdOrPath,
+      final String url,
+      final Boolean enabled,
+      final Boolean onlyProtectedBranches,
+      final Boolean keepDivergentRefs)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("url", url, true)
+            .withParam("enabled", enabled)
+            .withParam("only_protected_branches", onlyProtectedBranches)
+            .withParam("keep_divergent_refs", keepDivergentRefs);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "remote_mirrors");
+    return (response.readEntity(RemoteMirror.class));
+  }
 
-    /**
-     * Create a project-level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/approval_rules</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param params the ApprovalRuleParams instance holding the parameters for the approval rule
-     * @return a ApprovalRule instance with approval configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ApprovalRule createApprovalRule(Object projectIdOrPath, ApprovalRuleParams params) throws GitLabApiException {
-        GitLabApiForm formData = params.getForm();
-        Response response = post(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "approval_rules");
-        return (response.readEntity(ApprovalRule.class));
-    }
+  /**
+   * Toggle a remote mirror on or off, or change which types of branches are mirrored.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/remote_mirrors/:mirror_id</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param mirrorId the ID of the remote mirror
+   * @param enabled determines if the mirror is enabled
+   * @param onlyProtectedBranches determines if only protected branches are mirrored
+   * @param keepDivergentRefs determines if divergent refs are skipped
+   * @return a RemoteMirror instance with the updated remote mirror configuration
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RemoteMirror updateRemoteMirror(
+      final Object projectIdOrPath,
+      final Long mirrorId,
+      final Boolean enabled,
+      final Boolean onlyProtectedBranches,
+      final Boolean keepDivergentRefs)
+      throws GitLabApiException {
 
-    /**
-     * Update the specified the project-level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/approval_rules/:approval_rule_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param approvalRuleId the ID of the approval rule
-     * @param params the ApprovalRuleParams instance holding the parameters for the approval rule update
-     * @return a ApprovalRule instance with approval configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ApprovalRule updateApprovalRule(Object projectIdOrPath, Long approvalRuleId, ApprovalRuleParams params) throws GitLabApiException {
-
-        if (approvalRuleId == null) {
-            throw new RuntimeException("approvalRuleId cannot be null");
-        }
-
-        GitLabApiForm formData = params.getForm();
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "approval_rules", approvalRuleId);
-        return (response.readEntity(ApprovalRule.class));
-    }
-
-    /**
-     * Delete the specified the project-level approval rule.
-     * Note: This API endpoint is only available on 12.3 Starter and above.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/approval_rules/:approval_rule_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param approvalRuleId the ID of the approval rule
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteApprovalRule(Object projectIdOrPath, Long approvalRuleId) throws GitLabApiException {
-
-        if (approvalRuleId == null) {
-            throw new RuntimeException("approvalRuleId cannot be null");
-        }
-
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "approval_rules", approvalRuleId);
-    }
-
-    /**
-     * Get all custom attributes for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's CustomAttributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<CustomAttribute> getCustomAttributes(final Object projectIdOrPath) throws GitLabApiException {
-        return (getCustomAttributes(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of custom attributes for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of items per page
-     * @return a Pager of project's custom attributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<CustomAttribute> getCustomAttributes(final Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<CustomAttribute>(this, CustomAttribute.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "custom_attributes"));
-    }
-
-    /**
-     * Get a Stream of all custom attributes for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's custom attributes
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<CustomAttribute> getCustomAttributesStream(final Object projectIdOrPath) throws GitLabApiException {
-        return (getCustomAttributes(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single custom attribute for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param key the key for the custom attribute
-     * @return a CustomAttribute instance for the specified key
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomAttribute getCustomAttribute(final Object projectIdOrPath, final String key) throws GitLabApiException {
-	Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "custom_attributes", key);
-        return (response.readEntity(CustomAttribute.class));
-    }
-
-    /**
-     * Get an Optional instance with the value for a single custom attribute for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/custom_attributes/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param key the key for the custom attribute, required
-     * @return an Optional instance with the value for a single custom attribute for the specified project
-     */
-    public Optional<CustomAttribute> geOptionalCustomAttribute(final Object projectIdOrPath, final String key) {
-        try {
-            return (Optional.ofNullable(getCustomAttribute(projectIdOrPath, key)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Set a custom attribute for the specified project. The attribute will be updated if it already exists,
-     * or newly created otherwise.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/custom_attributes/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param key the key for the custom attribute
-     * @param value the value for the customAttribute
-     * @return a CustomAttribute instance for the updated or created custom attribute
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomAttribute setCustomAttribute(final Object projectIdOrPath, final String key, final String value) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key cannot be null or empty");
-        }
-        if (Objects.isNull(value) || value.trim().isEmpty()) {
-            throw new IllegalArgumentException("Value cannot be null or empty");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "custom_attributes", key);
-        return (response.readEntity(CustomAttribute.class));
-    }
-
-    /**
-     * Delete a custom attribute for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/custom_attributes/:key</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param key the key of the custom attribute to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteCustomAttribute(final Object projectIdOrPath, final String key) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key can't be null or empty");
-        }
-
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "custom_attributes", key);
-    }
-
-    /**
-     * Get all remote mirrors and their statuses for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of project's remote mirrors
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<RemoteMirror> getRemoteMirrors(final Object projectIdOrPath) throws GitLabApiException {
-        return (getRemoteMirrors(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of remote mirrors and their statuses for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of items per page
-     * @return a Pager of project's remote mirrors
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<RemoteMirror> getRemoteMirrors(final Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<RemoteMirror>(this, RemoteMirror.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "remote_mirrors"));
-    }
-
-    /**
-     * Get a Stream of all remote mirrors and their statuses for the specified project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/remote_mirrors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of project's remote mirrors
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<RemoteMirror> getRemoteMirrorsStream(final Object projectIdOrPath) throws GitLabApiException {
-        return (getRemoteMirrors(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-
-    /**
-     * Create a remote mirror for a project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/remote_mirrors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param url the URL of the remote repository to be mirrored
-     * @param enabled determines if the mirror is enabled
-     * @param onlyProtectedBranches determines if only protected branches are mirrored
-     * @param keepDivergentRefs determines if divergent refs are skipped
-     * @return a RemoteMirror instance with remote mirror configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RemoteMirror createRemoteMirror(Object projectIdOrPath, String url, Boolean enabled,
-	    Boolean onlyProtectedBranches, Boolean keepDivergentRefs) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("url", url, true)
-                .withParam("enabled", enabled)
-                .withParam("only_protected_branches", onlyProtectedBranches)
-                .withParam("keep_divergent_refs", keepDivergentRefs);
-        Response response = post(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "remote_mirrors");
-        return (response.readEntity(RemoteMirror.class));
-    }
-
-    /**
-     * Toggle a remote mirror on or off, or change which types of branches are mirrored.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/remote_mirrors/:mirror_id</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param mirrorId the ID of the remote mirror
-     * @param enabled determines if the mirror is enabled
-     * @param onlyProtectedBranches determines if only protected branches are mirrored
-     * @param keepDivergentRefs determines if divergent refs are skipped
-     * @return a RemoteMirror instance with the updated remote mirror configuration
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RemoteMirror updateRemoteMirror(Object projectIdOrPath, Long mirrorId, Boolean enabled,
-	    Boolean onlyProtectedBranches, Boolean keepDivergentRefs) throws GitLabApiException {
-
-	GitLabApiForm formData = new GitLabApiForm()
-		.withParam("enabled", enabled)
-		.withParam("only_protected_branches", onlyProtectedBranches)
-		.withParam("keep_divergent_refs", keepDivergentRefs);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "remote_mirrors", mirrorId);
-        return (response.readEntity(RemoteMirror.class));
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("enabled", enabled)
+            .withParam("only_protected_branches", onlyProtectedBranches)
+            .withParam("keep_divergent_refs", keepDivergentRefs);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "remote_mirrors",
+            mirrorId);
+    return (response.readEntity(RemoteMirror.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -3,258 +3,352 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AllowedTo;
 import org.gitlab4j.api.models.ProtectedBranch;
 
 /**
  * This class provides an entry point to all the Protected Branches API calls.
- * @see <a href="https://docs.gitlab.com/ee/api/protected_branches.html">Protected branches API at GitLab</a>
+ *
+ * @see <a href="https://docs.gitlab.com/ee/api/protected_branches.html">Protected branches API at
+ *     GitLab</a>
  */
 public class ProtectedBranchesApi extends AbstractApi {
 
-    public ProtectedBranchesApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ProtectedBranchesApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Gets a list of protected branches from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the list of protected branches for the project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProtectedBranch> getProtectedBranches(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProtectedBranches(projectIdOrPath, this.getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a Pager of protected branches from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of instances that will be fetched per page
+   * @return the Pager of protected branches for the project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProtectedBranch> getProtectedBranches(
+      final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<ProtectedBranch>(
+        this,
+        ProtectedBranch.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "protected_branches"));
+  }
+
+  /**
+   * Gets a Stream of protected branches from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the Stream of protected branches for the project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProtectedBranch> getProtectedBranchesStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProtectedBranches(projectIdOrPath, this.getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single protected branch or wildcard protected branch.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches/:branch_name</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch or wildcard
+   * @return a ProtectedBranch instance with info on the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch getProtectedBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "protected_branches",
+            urlEncode(branchName));
+    return (response.readEntity(ProtectedBranch.class));
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific protected branch.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches/:branch_name</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch or wildcard
+   * @return an Optional instance with the specified protected branch as a value
+   */
+  public Optional<ProtectedBranch> getOptionalProtectedBranch(
+      final Object projectIdOrPath, final String branchName) {
+    try {
+      return (Optional.ofNullable(getProtectedBranch(projectIdOrPath, branchName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Gets a list of protected branches from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the list of protected branches for the project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProtectedBranch> getProtectedBranches(Object projectIdOrPath) throws GitLabApiException {
-        return (getProtectedBranches(projectIdOrPath, this.getDefaultPerPage()).all());
-    }
+  /**
+   * Unprotects the given protected branch or wildcard protected branch.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/protected_branches/:name</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to un-protect, can be a wildcard
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void unprotectBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "protected_branches",
+        urlEncode(branchName));
+  }
 
-    /**
-     * Gets a Pager of protected branches from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of instances that will be fetched per page
-     * @return the Pager of protected branches for the project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProtectedBranch> getProtectedBranches(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<ProtectedBranch>(this, ProtectedBranch.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches"));
-    }
+  /**
+   * Protects a single repository branch or several project repository branches using a wildcard
+   * protected branch.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch protectBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    return protectBranch(
+        projectIdOrPath, branchName, AccessLevel.MAINTAINER, AccessLevel.MAINTAINER);
+  }
 
-    /**
-     * Gets a Stream of protected branches from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the Stream of protected branches for the project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProtectedBranch> getProtectedBranchesStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProtectedBranches(projectIdOrPath, this.getDefaultPerPage()).stream());
-    }
+  /**
+   * Protects a single repository branch or several project repository branches using a wildcard
+   * protected branch.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @param pushAccessLevel Access levels allowed to push (defaults: 40, maintainer access level)
+   * @param mergeAccessLevel Access levels allowed to merge (defaults: 40, maintainer access level)
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch protectBranch(
+      final Object projectIdOrPath,
+      final String branchName,
+      final AccessLevel pushAccessLevel,
+      final AccessLevel mergeAccessLevel)
+      throws GitLabApiException {
+    return (protectBranch(
+        projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, null, null));
+  }
 
-    /**
-     * Get a single protected branch or wildcard protected branch.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches/:branch_name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch or wildcard
-     * @return a ProtectedBranch instance with info on the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch getProtectedBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", this.getProjectIdOrPath(projectIdOrPath), "protected_branches", urlEncode(branchName));
-        return (response.readEntity(ProtectedBranch.class));
-    }
+  /**
+   * Protects a single repository branch or several project repository branches using a wildcard
+   * protected branch.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @param pushAccessLevel access levels allowed to push (defaults: 40, maintainer access level)
+   * @param mergeAccessLevel access levels allowed to merge (defaults: 40, maintainer access level)
+   * @param unprotectAccessLevel access levels allowed to unprotect (defaults: 40, maintainer access
+   *     level)
+   * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the
+   *     CODEOWNERS file. (defaults: false)
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch protectBranch(
+      final Object projectIdOrPath,
+      final String branchName,
+      final AccessLevel pushAccessLevel,
+      final AccessLevel mergeAccessLevel,
+      final AccessLevel unprotectAccessLevel,
+      final Boolean codeOwnerApprovalRequired)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", branchName, true)
+            .withParam("push_access_level", pushAccessLevel)
+            .withParam("merge_access_level", mergeAccessLevel)
+            .withParam("unprotect_access_level", unprotectAccessLevel)
+            .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_branches");
+    return (response.readEntity(ProtectedBranch.class));
+  }
 
-    /**
-     * Get an Optional instance with the value for the specific protected branch.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_branches/:branch_name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch or wildcard
-     * @return an Optional instance with the specified protected branch as a value
-     */
-    public Optional<ProtectedBranch> getOptionalProtectedBranch(Object projectIdOrPath, String branchName) {
-        try {
-            return (Optional.ofNullable(getProtectedBranch(projectIdOrPath, branchName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
+  /**
+   * Protects a single repository branch or several project repository branches using a wildcard
+   * protected branch.
+   *
+   * <p>NOTE: This method is only available to GitLab Starter, Bronze, or higher.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @param allowedToPushUserId user ID allowed to push, can be null
+   * @param allowedToMergeUserId user ID allowed to merge, can be null
+   * @param allowedToUnprotectUserId user ID allowed to unprotect, can be null
+   * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the
+   *     CODEOWNERS file. (defaults: false)
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch protectBranch(
+      final Object projectIdOrPath,
+      final String branchName,
+      final Integer allowedToPushUserId,
+      final Integer allowedToMergeUserId,
+      final Integer allowedToUnprotectUserId,
+      final Boolean codeOwnerApprovalRequired)
+      throws GitLabApiException {
 
-    /**
-     * Unprotects the given protected branch or wildcard protected branch.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/protected_branches/:name</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to un-protect, can be a wildcard
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void unprotectBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches", urlEncode(branchName));
-    }
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", branchName, true)
+            .withParam("allowed_to_push[][user_id]", allowedToPushUserId)
+            .withParam("allowed_to_merge[][user_id]", allowedToMergeUserId)
+            .withParam("allowed_to_unprotect[][user_id]", allowedToUnprotectUserId)
+            .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_branches");
+    return (response.readEntity(ProtectedBranch.class));
+  }
 
-    /**
-     * Protects a single repository branch or several project repository branches
-     * using a wildcard protected branch.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        return protectBranch(projectIdOrPath, branchName, AccessLevel.MAINTAINER, AccessLevel.MAINTAINER);
-    }
+  /**
+   * Protects a single repository branch or several project repository branches using a wildcard
+   * protected branch.
+   *
+   * <p>NOTE: This method is only available to GitLab Starter, Bronze, or higher.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @param allowedToPush an AllowedTo instance holding the configuration for "allowed_to_push"
+   * @param allowedToMerge an AllowedTo instance holding the configuration for "allowed_to_merge"
+   * @param allowedToUnprotect an AllowedTo instance holding the configuration for
+   *     "allowed_to_unprotect" be null
+   * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the
+   *     CODEOWNERS file. (defaults: false)
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch protectBranch(
+      final Object projectIdOrPath,
+      final String branchName,
+      final AllowedTo allowedToPush,
+      final AllowedTo allowedToMerge,
+      final AllowedTo allowedToUnprotect,
+      final Boolean codeOwnerApprovalRequired)
+      throws GitLabApiException {
 
-    /**
-     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @param pushAccessLevel Access levels allowed to push (defaults: 40, maintainer access level)
-     * @param mergeAccessLevel Access levels allowed to merge (defaults: 40, maintainer access level)
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName, AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel) throws GitLabApiException {
-        return (protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, null, null));
-    }
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("name", branchName, true)
+            .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
 
-    /**
-     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @param pushAccessLevel access levels allowed to push (defaults: 40, maintainer access level)
-     * @param mergeAccessLevel access levels allowed to merge (defaults: 40, maintainer access level)
-     * @param unprotectAccessLevel access levels allowed to unprotect (defaults: 40, maintainer access level)
-     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-            AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("name", branchName, true)
-                .withParam("push_access_level", pushAccessLevel)
-                .withParam("merge_access_level", mergeAccessLevel)
-                .withParam("unprotect_access_level", unprotectAccessLevel)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
-        return (response.readEntity(ProtectedBranch.class));
-    }
+    if (allowedToPush != null) allowedToPush.getForm(formData, "allowed_to_push");
+    if (allowedToMerge != null) allowedToMerge.getForm(formData, "allowed_to_merge");
+    if (allowedToUnprotect != null) allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
 
-    /**
-     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
-     *
-     * <p>NOTE: This method is only available to GitLab Starter, Bronze, or higher.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @param allowedToPushUserId user ID allowed to push, can be null
-     * @param allowedToMergeUserId user ID allowed to merge, can be null
-     * @param allowedToUnprotectUserId user ID allowed to unprotect, can be null
-     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-            Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_branches");
+    return (response.readEntity(ProtectedBranch.class));
+  }
 
-        Form formData = new GitLabApiForm()
-                .withParam("name", branchName, true)
-                .withParam("allowed_to_push[][user_id]", allowedToPushUserId)
-                .withParam("allowed_to_merge[][user_id]", allowedToMergeUserId)
-                .withParam("allowed_to_unprotect[][user_id]", allowedToUnprotectUserId)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
-        return (response.readEntity(ProtectedBranch.class));
-    }
+  /**
+   * Sets the code_owner_approval_required flag on the specified protected branch.
+   *
+   * <p>NOTE: This method is only available in GitLab Premium or higher.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: PATCH /projects/:id/protected_branches/:branch_name?code_owner_approval_required=true</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect, can be a wildcard
+   * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the
+   *     CODEOWNERS file.
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedBranch setCodeOwnerApprovalRequired(
+      final Object projectIdOrPath,
+      final String branchName,
+      final Boolean codeOwnerApprovalRequired)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm().withParam("code_owner_approval_required", codeOwnerApprovalRequired);
 
-    /**
-     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
-     *
-     * <p>NOTE: This method is only available to GitLab Starter, Bronze, or higher.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @param allowedToPush an AllowedTo instance holding the configuration for "allowed_to_push"
-     * @param allowedToMerge an AllowedTo instance holding the configuration for "allowed_to_merge"
-     * @param allowedToUnprotect an AllowedTo instance holding the configuration for "allowed_to_unprotect" be null
-     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-            AllowedTo allowedToPush, AllowedTo allowedToMerge, AllowedTo allowedToUnprotect,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", branchName, true)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
-
-        if (allowedToPush != null)
-            allowedToPush.getForm(formData, "allowed_to_push");
-        if (allowedToMerge != null)
-            allowedToMerge.getForm(formData, "allowed_to_merge");
-        if (allowedToUnprotect != null)
-            allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
-
-        Response response = post(Response.Status.CREATED, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
-        return (response.readEntity(ProtectedBranch.class));
-    }
-
-    /**
-     * Sets the code_owner_approval_required flag on the specified protected branch.
-     *
-     * <p>NOTE: This method is only available in GitLab Premium or higher.</p>
-     *
-     * <pre><code>GitLab Endpoint: PATCH /projects/:id/protected_branches/:branch_name?code_owner_approval_required=true</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect, can be a wildcard
-     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file.
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedBranch setCodeOwnerApprovalRequired(Object projectIdOrPath, String branchName,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
-
-        Response response = patch(Response.Status.OK, formData.asMap(),
-                "projects", this.getProjectIdOrPath(projectIdOrPath),
-                "protected_branches", urlEncode(branchName));
-        return (response.readEntity(ProtectedBranch.class));
-    }
+    final Response response =
+        patch(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            this.getProjectIdOrPath(projectIdOrPath),
+            "protected_branches",
+            urlEncode(branchName));
+    return (response.readEntity(ProtectedBranch.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ReleasesApi.java
+++ b/src/main/java/org/gitlab4j/api/ReleasesApi.java
@@ -3,9 +3,7 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Release;
 import org.gitlab4j.api.models.ReleaseParams;
 
@@ -16,7 +14,7 @@ import org.gitlab4j.api.models.ReleaseParams;
  */
 public class ReleasesApi extends AbstractApi {
 
-    public ReleasesApi(GitLabApi gitLabApi) {
+    public ReleasesApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -29,7 +27,7 @@ public class ReleasesApi extends AbstractApi {
      * @return the list of releases for the specified project
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Release> getReleases(Object projectIdOrPath) throws GitLabApiException {
+    public List<Release> getReleases(final Object projectIdOrPath) throws GitLabApiException {
         return (getReleases(projectIdOrPath, getDefaultPerPage()).all());
     }
 
@@ -43,7 +41,7 @@ public class ReleasesApi extends AbstractApi {
      * @return the Pager of Release instances for the specified project ID
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Release> getReleases(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
+    public Pager<Release> getReleases(final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
         return (new Pager<Release>(this, Release.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "releases"));
     }
 
@@ -56,7 +54,7 @@ public class ReleasesApi extends AbstractApi {
      * @return a Stream of Release instances for the specified project ID
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Release> getReleasesStream(Object projectIdOrPath) throws GitLabApiException {
+    public Stream<Release> getReleasesStream(final Object projectIdOrPath) throws GitLabApiException {
         return (getReleases(projectIdOrPath, getDefaultPerPage()).stream());
     }
 
@@ -70,8 +68,8 @@ public class ReleasesApi extends AbstractApi {
      * @return a Releases instance with info on the specified tag
      * @throws GitLabApiException if any exception occurs
      */
-    public Release getRelease(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "releases", urlEncode(tagName));
+    public Release getRelease(final Object projectIdOrPath, final String tagName) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "releases", urlEncode(tagName));
         return (response.readEntity(Release.class));
     }
 
@@ -85,10 +83,10 @@ public class ReleasesApi extends AbstractApi {
      * @return an Optional instance with the specified Release as the value
      * @throws GitLabApiException if any exception occurs
      */
-    public Optional<Release> getOptionalRelease(Object projectIdOrPath, String tagName) throws GitLabApiException {
+    public Optional<Release> getOptionalRelease(final Object projectIdOrPath, final String tagName) throws GitLabApiException {
         try {
             return (Optional.ofNullable(getRelease(projectIdOrPath, tagName)));
-        } catch (GitLabApiException glae) {
+        } catch (final GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
     }
@@ -103,8 +101,8 @@ public class ReleasesApi extends AbstractApi {
      * @return a Release instance containing the newly created Release info
      * @throws GitLabApiException if any exception occurs
      */
-    public Release createRelease(Object projectIdOrPath, ReleaseParams params) throws GitLabApiException {
-        Response response = post(Response.Status.CREATED, params,
+    public Release createRelease(final Object projectIdOrPath, final ReleaseParams params) throws GitLabApiException {
+        final Response response = post(Response.Status.CREATED, params,
                 "projects", getProjectIdOrPath(projectIdOrPath), "releases");
         return (response.readEntity(Release.class));
     }
@@ -119,14 +117,14 @@ public class ReleasesApi extends AbstractApi {
      * @return a Release instance containing info on the updated Release
      * @throws GitLabApiException if any exception occurs
      */
-    public Release updateRelease(Object projectIdOrPath, ReleaseParams params) throws GitLabApiException {
+    public Release updateRelease(final Object projectIdOrPath, final ReleaseParams params) throws GitLabApiException {
 
-	String tagName = params.getTagName();
+	final String tagName = params.getTagName();
 	if (tagName == null || tagName.trim().isEmpty()) {
 	    throw new RuntimeException("params.tagName cannot be null or empty");
 	}
 
-        Response response = put(Response.Status.OK, params,
+        final Response response = put(Response.Status.OK, params,
                 "projects", getProjectIdOrPath(projectIdOrPath), "releases", urlEncode(tagName));
         return (response.readEntity(Release.class));
     }
@@ -140,7 +138,7 @@ public class ReleasesApi extends AbstractApi {
      * @param tagName the tag name that the release was created from
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteRelease(Object projectIdOrPath, String tagName) throws GitLabApiException {
+    public void deleteRelease(final Object projectIdOrPath, final String tagName) throws GitLabApiException {
         delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "releases", urlEncode(tagName));
     }
  }

--- a/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -9,13 +9,11 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.ChangelogPayload;
@@ -26,784 +24,1041 @@ import org.gitlab4j.api.models.TreeItem;
 import org.gitlab4j.api.utils.FileUtils;
 
 /**
- * <p>This class provides an entry point to all the GitLab API repository calls.
- * For more information on the repository APIs see:</p>
- *
- * <a href="https://docs.gitlab.com/ce/api/repositories.html">Repositories API</a>
- * <a href="https://docs.gitlab.com/ce/api/branches.html">Branches API</a>
+ * This class provides an entry point to all the GitLab API repository calls. For more information
+ * on the repository APIs see: <a
+ * href="https://docs.gitlab.com/ce/api/repositories.html">Repositories API</a> <a
+ * href="https://docs.gitlab.com/ce/api/branches.html">Branches API</a>
  */
 public class RepositoryApi extends AbstractApi {
 
-    public RepositoryApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public RepositoryApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of repository branches from a project, sorted by name alphabetically.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return the list of repository branches for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Branch> getBranches(final Object projectIdOrPath) throws GitLabApiException {
+    return getBranches(projectIdOrPath, null, getDefaultPerPage()).all();
+  }
+
+  /**
+   * Get a list of repository branches from a project, sorted by name alphabetically.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of Branch instances per page
+   * @return the list of repository branches for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Branch> getBranches(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "branches");
+    return (response.readEntity(new GenericType<List<Branch>>() {}));
+  }
+
+  /**
+   * Get a Pager of repository branches from a project, sorted by name alphabetically.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the list of repository branches for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Branch> getBranches(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return getBranches(projectIdOrPath, null, itemsPerPage);
+  }
+
+  /**
+   * Get a Stream of repository branches from a project, sorted by name alphabetically.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream of repository branches for the specified project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Branch> getBranchesStream(final Object projectIdOrPath) throws GitLabApiException {
+    return getBranches(projectIdOrPath, null, getDefaultPerPage()).stream();
+  }
+
+  /**
+   * Get a single project repository branch.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches/:branch</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to get
+   * @return the branch info for the specified project ID/branch name pair
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Branch getBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "branches",
+            urlEncode(branchName));
+    return (response.readEntity(Branch.class));
+  }
+
+  /**
+   * Get a List of repository branches from a project, sorted by name alphabetically, filter by the
+   * search term.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param search the branch name search term
+   * @return the List of repository branches for the specified project ID and search term
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Branch> getBranches(final Object projectIdOrPath, final String search)
+      throws GitLabApiException {
+    return (getBranches(projectIdOrPath, search, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of repository branches from a project, sorted by name alphabetically, filter by the
+   * search term.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param search the branch name search term
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the list of repository branches for the specified project ID and search term
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Branch> getBranches(
+      final Object projectIdOrPath, final String search, final int itemsPerPage)
+      throws GitLabApiException {
+    final MultivaluedMap<String, String> queryParams =
+        (search == null
+            ? null
+            : new GitLabApiForm().withParam("search", urlEncode(search)).asMap());
+
+    return (new Pager<Branch>(
+        this,
+        Branch.class,
+        itemsPerPage,
+        queryParams,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "branches"));
+  }
+
+  /**
+   * Get a Stream of repository branches from a project, sorted by name alphabetically, filter by
+   * the search term.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param search the branch name search term
+   * @return the Stream of repository branches for the specified project ID and search term
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Branch> getBranchesStream(final Object projectIdOrPath, final String search)
+      throws GitLabApiException {
+    return (getBranches(projectIdOrPath, search, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get an Optional instance with the value for the specific repository branch.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches/:branch</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to get
+   * @return an Optional instance with the info for the specified project ID/branch name pair as the
+   *     value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<Branch> getOptionalBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getBranch(projectIdOrPath, branchName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a branch for the project. Support as of version 6.8.x
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to create
+   * @param ref Source to create the branch from, can be an existing branch, tag or commit SHA
+   * @return the branch info for the created branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Branch createBranch(
+      final Object projectIdOrPath, final String branchName, final String ref)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam(isApiVersion(ApiVersion.V3) ? "branch_name" : "branch", branchName, true)
+            .withParam("ref", ref, true);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "branches");
+    return (response.readEntity(Branch.class));
+  }
+
+  /**
+   * Delete a single project repository branch.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/branches/:branch</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "branches",
+        urlEncode(branchName));
+  }
+
+  /**
+   * Protects a single project repository branch. This is an idempotent function, protecting an
+   * already protected repository branch will not produce an error.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/branches/:branch/protect</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to protect
+   * @return the branch info for the protected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Branch protectBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "branches",
+            urlEncode(branchName),
+            "protect");
+    return (response.readEntity(Branch.class));
+  }
+
+  /**
+   * Unprotects a single project repository branch. This is an idempotent function, unprotecting an
+   * already unprotected repository branch will not produce an error.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/branches/:branch/unprotect</code>
+   * </pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param branchName the name of the branch to un-protect
+   * @return the branch info for the unprotected branch
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Branch unprotectBranch(final Object projectIdOrPath, final String branchName)
+      throws GitLabApiException {
+    final Response response =
+        put(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "branches",
+            urlEncode(branchName),
+            "unprotect");
+    return (response.readEntity(Branch.class));
+  }
+
+  /**
+   * Get a list of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a tree with the root directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<TreeItem> getTree(final Object projectIdOrPath) throws GitLabApiException {
+    return (getTree(projectIdOrPath, "/", "master"));
+  }
+
+  /**
+   * Get a Pager of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager containing a tree with the root directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<TreeItem> getTree(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getTree(projectIdOrPath, "/", "master", false, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Stream containing a tree with the root directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<TreeItem> getTreeStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getTreeStream(projectIdOrPath, "/", "master"));
+  }
+
+  /**
+   * Get a list of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * content of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @return a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<TreeItem> getTree(
+      final Object projectIdOrPath, final String filePath, final String refName)
+      throws GitLabApiException {
+    return (getTree(projectIdOrPath, filePath, refName, false));
+  }
+
+  /**
+   * Get a Pager of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * content of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager containing a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<TreeItem> getTree(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String refName,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    return (getTree(projectIdOrPath, filePath, refName, false, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * content of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @return a Stream containing a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<TreeItem> getTreeStream(
+      final Object projectIdOrPath, final String filePath, final String refName)
+      throws GitLabApiException {
+    return (getTreeStream(projectIdOrPath, filePath, refName, false));
+  }
+
+  /**
+   * Get a list of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * contend of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch recursive (optional) - Boolean value used to get a recursive tree
+   * (false by default)
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @param recursive flag to get a recursive tree or not
+   * @return a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<TreeItem> getTree(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String refName,
+      final Boolean recursive)
+      throws GitLabApiException {
+    return (getTree(projectIdOrPath, filePath, refName, recursive, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * contend of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch recursive (optional) - Boolean value used to get a recursive tree
+   * (false by default)
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @param recursive flag to get a recursive tree or not
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<TreeItem> getTree(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String refName,
+      final Boolean recursive,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("id", getProjectIdOrPath(projectIdOrPath), true)
+            .withParam("path", filePath, false)
+            .withParam(
+                isApiVersion(ApiVersion.V3) ? "ref_name" : "ref",
+                (refName != null ? urlEncode(refName) : null),
+                false)
+            .withParam("recursive", recursive, false);
+    return (new Pager<TreeItem>(
+        this,
+        TreeItem.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "tree"));
+  }
+
+  /**
+   * Get a Stream of repository files and directories in a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
+   *
+   * id (required) - The ID of a project path (optional) - The path inside repository. Used to get
+   * contend of subdirectories ref_name (optional) - The name of a repository branch or tag or if
+   * not given the default branch recursive (optional) - Boolean value used to get a recursive tree
+   * (false by default)
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path inside repository, used to get content of subdirectories
+   * @param refName the name of a repository branch or tag or if not given the default branch
+   * @param recursive flag to get a recursive tree or not
+   * @return a Stream containing a tree with the directories and files of a project
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<TreeItem> getTreeStream(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String refName,
+      final Boolean recursive)
+      throws GitLabApiException {
+    return (getTree(projectIdOrPath, filePath, refName, recursive, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the raw file contents for a blob by blob SHA.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/raw_blobs/:sha</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the file to get the contents for
+   * @return the raw file contents for the blob on an InputStream
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream getRawBlobContent(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            null,
+            MediaType.MEDIA_TYPE_WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "blobs",
+            sha,
+            "raw");
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional).
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @return an input stream that can be used to save as a file or to read the content of the
+   *     archive
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream getRepositoryArchive(final Object projectIdOrPath, final String sha)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("sha", sha);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "archive");
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional).
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @param format The archive format, defaults to "tar.gz" if null
+   * @return an input stream that can be used to save as a file or to read the content of the
+   *     archive
+   * @throws GitLabApiException if format is not a valid archive format or any exception occurs
+   */
+  public InputStream getRepositoryArchive(
+      final Object projectIdOrPath, final String sha, final String format)
+      throws GitLabApiException {
+    final ArchiveFormat archiveFormat = ArchiveFormat.forValue(format);
+    return (getRepositoryArchive(projectIdOrPath, sha, archiveFormat));
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional).
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @param format The archive format, defaults to TAR_GZ if null
+   * @return an input stream that can be used to save as a file or to read the content of the
+   *     archive
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream getRepositoryArchive(
+      final Object projectIdOrPath, final String sha, ArchiveFormat format)
+      throws GitLabApiException {
+
+    if (format == null) {
+      format = ArchiveFormat.TAR_GZ;
     }
 
-    /**
-     * Get a list of repository branches from a project, sorted by name alphabetically.
+    /*
+     * Gitlab-ce has a bug when you try to download file archives with format by using "&format=zip(or tar... etc.)",
+     * there is a solution to request .../archive.:format instead of .../archive?format=:format.
      *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return the list of repository branches for the specified project
-     * @throws GitLabApiException if any exception occurs
+     * Issue:  https://gitlab.com/gitlab-org/gitlab-ce/issues/45992
+     *         https://gitlab.com/gitlab-com/support-forum/issues/3067
      */
-    public List<Branch> getBranches(Object projectIdOrPath) throws GitLabApiException {
-        return getBranches(projectIdOrPath, null, getDefaultPerPage()).all();
+    final Form formData = new GitLabApiForm().withParam("sha", sha);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "archive" + "." + format.toString());
+    return (response.readEntity(InputStream.class));
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional) and saves to the specified
+   * directory. If the archive already exists in the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @param directory the File instance of the directory to save the archive to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the downloaded instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File getRepositoryArchive(final Object projectIdOrPath, final String sha, File directory)
+      throws GitLabApiException {
+
+    final Form formData = new GitLabApiForm().withParam("sha", sha);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "archive");
+
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = FileUtils.getFilenameFromContentDisposition(response);
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
+    }
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional) and saves to the specified
+   * directory. If the archive already exists in the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @param directory the File instance of the directory to save the archive to, if null will use
+   *     "java.io.tmpdir"
+   * @param format The archive format, defaults to "tar.gz" if null
+   * @return a File instance pointing to the downloaded instance
+   * @throws GitLabApiException if format is not a valid archive format or any exception occurs
+   */
+  public File getRepositoryArchive(
+      final Object projectIdOrPath, final String sha, final File directory, final String format)
+      throws GitLabApiException {
+    final ArchiveFormat archiveFormat = ArchiveFormat.forValue(format);
+    return (getRepositoryArchive(projectIdOrPath, sha, directory, archiveFormat));
+  }
+
+  /**
+   * Get an archive of the complete repository by SHA (optional) and saves to the specified
+   * directory. If the archive already exists in the directory it will be overwritten.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param sha the SHA of the archive to get
+   * @param directory the File instance of the directory to save the archive to, if null will use
+   *     "java.io.tmpdir"
+   * @param format The archive format, defaults to TAR_GZ if null
+   * @return a File instance pointing to the downloaded instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File getRepositoryArchive(
+      final Object projectIdOrPath, final String sha, File directory, ArchiveFormat format)
+      throws GitLabApiException {
+
+    if (format == null) {
+      format = ArchiveFormat.TAR_GZ;
     }
 
-    /**
-     * Get a list of repository branches from a project, sorted by name alphabetically.
+    /*
+     * Gitlab-ce has a bug when you try to download file archives with format by using "&format=zip(or tar... etc.)",
+     * there is a solution to request .../archive.:format instead of .../archive?format=:format.
      *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of Branch instances per page
-     * @return the list of repository branches for the specified project
-     * @throws GitLabApiException if any exception occurs
+     * Issue:  https://gitlab.com/gitlab-org/gitlab-ce/issues/45992
+     *         https://gitlab.com/gitlab-com/support-forum/issues/3067
      */
-    public List<Branch> getBranches(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches");
-        return (response.readEntity(new GenericType<List<Branch>>() {}));
+    final Form formData = new GitLabApiForm().withParam("sha", sha);
+    final Response response =
+        getWithAccepts(
+            Response.Status.OK,
+            formData.asMap(),
+            MediaType.WILDCARD,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "archive" + "." + format.toString());
+
+    try {
+
+      if (directory == null) directory = new File(System.getProperty("java.io.tmpdir"));
+
+      final String filename = FileUtils.getFilenameFromContentDisposition(response);
+      final File file = new File(directory, filename);
+
+      final InputStream in = response.readEntity(InputStream.class);
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
+    }
+  }
+
+  /**
+   * Compare branches, tags or commits. This can be accessed without authentication if the
+   * repository is publicly accessible.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param from the commit SHA or branch name
+   * @param to the commit SHA or branch name
+   * @param straight specifies the comparison method, true for direct comparison between from and to
+   *     (from..to), false to compare using merge base (from…to)’.
+   * @return a CompareResults containing the results of the comparison
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CompareResults compare(
+      final Object projectIdOrPath, final String from, final String to, final boolean straight)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("from", from, true)
+            .withParam("to", to, true)
+            .withParam("straight", straight);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "compare");
+    return (response.readEntity(CompareResults.class));
+  }
+
+  /**
+   * Compare branches, tags or commits. This can be accessed without authentication if the
+   * repository is publicly accessible.
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param from the commit SHA or branch name
+   * @param to the commit SHA or branch name
+   * @return a CompareResults containing the results of the comparison
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CompareResults compare(final Object projectIdOrPath, final String from, final String to)
+      throws GitLabApiException {
+    return (compare(projectIdOrPath, from, to, false));
+  }
+
+  /**
+   * Get a list of contributors from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a List containing the contributors for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Contributor> getContributors(final Object projectIdOrPath) throws GitLabApiException {
+    return (getContributors(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of contributors from a project and in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @return a List containing the contributors for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Contributor> getContributors(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "contributors");
+    return (response.readEntity(new GenericType<List<Contributor>>() {}));
+  }
+
+  /**
+   * Get a list of contributors from a project and in the specified page range, sorted by specified
+   * param.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of projects per page
+   * @param orderBy (optional param) returns contributors ordered by NAME, EMAIL, or COMMITS.
+   *     Default is COMMITS
+   * @param sortOrder (optional param) returns contributors sorted in ASC or DESC order. Default is
+   *     ASC
+   * @return a List containing the contributors for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Contributor> getContributors(
+      final Object projectIdOrPath,
+      final int page,
+      final int perPage,
+      final ContributorOrderBy orderBy,
+      final SortOrder sortOrder)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
+    if (sortOrder != null) {
+      formData.withParam("sort", sortOrder, false);
     }
 
-    /**
-     * Get a Pager of repository branches from a project, sorted by name alphabetically.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the list of repository branches for the specified project ID
-     *
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Branch> getBranches(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return getBranches(projectIdOrPath, null, itemsPerPage);
+    if (orderBy != null) {
+      formData.withParam("order_by", orderBy, false);
     }
 
-    /**
-     * Get a Stream of repository branches from a project, sorted by name alphabetically.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream of repository branches for the specified project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Branch> getBranchesStream(Object projectIdOrPath) throws GitLabApiException {
-        return getBranches(projectIdOrPath, null, getDefaultPerPage()).stream();
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "contributors");
+    return (response.readEntity(new GenericType<List<Contributor>>() {}));
+  }
+
+  /**
+   * Get a Pager of contributors from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager containing the contributors for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Contributor> getContributors(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return new Pager<Contributor>(
+        this,
+        Contributor.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "contributors");
+  }
+
+  /**
+   * Get a list of contributors from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a List containing the contributors for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Contributor> getContributorsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getContributors(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get the common ancestor for 2 or more refs (commit SHAs, branch names or tags).
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/merge_base</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param refs a List of 2 or more refs (commit SHAs, branch names or tags)
+   * @return the Commit instance containing the common ancestor
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Commit getMergeBase(final Object projectIdOrPath, final List<String> refs)
+      throws GitLabApiException {
+
+    if (refs == null || refs.size() < 2) {
+      throw new RuntimeException("refs must conatin at least 2 refs");
     }
 
-    /**
-     * Get a single project repository branch.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches/:branch</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to get
-     * @return the branch info for the specified project ID/branch name pair
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Branch getBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches", urlEncode(branchName));
-        return (response.readEntity(Branch.class));
+    final List<String> encodedRefs = new ArrayList<>(refs.size());
+    for (final String ref : refs) {
+      encodedRefs.add(urlEncode(ref));
     }
 
-    /**
-     * Get a List of repository branches from a project, sorted by name alphabetically, filter by the search term.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param search the branch name search term
-     * @return the List of repository branches for the specified project ID and search term
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Branch> getBranches(Object projectIdOrPath, String search) throws GitLabApiException {
-        return (getBranches(projectIdOrPath, search, getDefaultPerPage()).all());
+    final GitLabApiForm queryParams = new GitLabApiForm().withParam("refs", encodedRefs, true);
+    final Response response =
+        get(
+            Response.Status.OK,
+            queryParams.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "merge_base");
+    return (response.readEntity(Commit.class));
+  }
+
+  /**
+   * Get an Optional instance with the value of the common ancestor for 2 or more refs (commit SHAs,
+   * branch names or tags).
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/merge_base</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param refs a List of 2 or more refs (commit SHAs, branch names or tags)
+   * @return an Optional instance with the Commit instance containing the common ancestor as the
+   *     value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<Commit> getOptionalMergeBase(
+      final Object projectIdOrPath, final List<String> refs) throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getMergeBase(projectIdOrPath, refs)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get a Pager of repository branches from a project, sorted by name alphabetically, filter by the search term.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param search the branch name search term
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the list of repository branches for the specified project ID and search term
-     *
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Branch> getBranches(Object projectIdOrPath, String search, int itemsPerPage) throws GitLabApiException {
-        MultivaluedMap<String, String> queryParams = ( search == null ? null :
-            new GitLabApiForm().withParam("search", urlEncode(search)).asMap() );
+  /**
+   * Delete all branches that are merged into the project’s default branch. NOTE: Protected branches
+   * will not be deleted as part of this operation.
+   *
+   * <pre><code>GitLab Endpoint: /projects/:id/repository/merged_branches</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMergedBranches(final Object projectIdOrPath) throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "merged_branches");
+  }
 
-        return (new Pager<Branch>(this, Branch.class, itemsPerPage, queryParams, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches"));
-    }
+  /**
+   * Generate changelog data based on commits in a repository.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param version the version to generate the changelog for
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void generateChangelog(final Object projectIdOrPath, final String version)
+      throws GitLabApiException {
+    generateChangelog(projectIdOrPath, new ChangelogPayload(version));
+  }
 
-    /**
-     * Get a Stream of repository branches from a project, sorted by name alphabetically, filter by the search term.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches?search=:search</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param search the branch name search term
-     * @return the Stream of repository branches for the specified project ID and search term
-     *
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Branch> getBranchesStream(Object projectIdOrPath, String search) throws GitLabApiException {
-        return (getBranches(projectIdOrPath, search, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get an Optional instance with the value for the specific repository branch.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/branches/:branch</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to get
-     * @return an Optional instance with the info for the specified project ID/branch name pair as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<Branch> getOptionalBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getBranch(projectIdOrPath, branchName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a branch for the project. Support as of version 6.8.x
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to create
-     * @param ref Source to create the branch from, can be an existing branch, tag or commit SHA
-     * @return the branch info for the created branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Branch createBranch(Object projectIdOrPath, String branchName, String ref) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam(isApiVersion(ApiVersion.V3) ? "branch_name" : "branch", branchName, true)
-                .withParam("ref", ref, true);
-        Response response = post(Response.Status.CREATED, formData.asMap(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches");
-        return (response.readEntity(Branch.class));
-    }
-
-    /**
-     * Delete a single project repository branch.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/branches/:branch</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches", urlEncode(branchName));
-    }
-
-    /**
-     * Protects a single project repository branch. This is an idempotent function,
-     * protecting an already protected repository branch will not produce an error.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/branches/:branch/protect</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to protect
-     * @return the branch info for the protected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Branch protectBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        Response response = put(Response.Status.OK, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches", urlEncode(branchName), "protect");
-        return (response.readEntity(Branch.class));
-    }
-
-    /**
-     * Unprotects a single project repository branch. This is an idempotent function, unprotecting an
-     * already unprotected repository branch will not produce an error.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/branches/:branch/unprotect</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param branchName the name of the branch to un-protect
-     * @return the branch info for the unprotected branch
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Branch unprotectBranch(Object projectIdOrPath, String branchName) throws GitLabApiException {
-        Response response = put(Response.Status.OK, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "branches", urlEncode(branchName), "unprotect");
-        return (response.readEntity(Branch.class));
-    }
-
-    /**
-     * Get a list of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a tree with the root directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<TreeItem> getTree(Object projectIdOrPath) throws GitLabApiException {
-        return (getTree(projectIdOrPath, "/", "master"));
-    }
-
-    /**
-     * Get a Pager of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager containing a tree with the root directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<TreeItem> getTree(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (getTree(projectIdOrPath, "/", "master", false, itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Stream containing a tree with the root directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<TreeItem> getTreeStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getTreeStream(projectIdOrPath, "/", "master"));
-    }
-
-    /**
-     * Get a list of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get content of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @return a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<TreeItem> getTree(Object projectIdOrPath, String filePath, String refName) throws GitLabApiException {
-        return (getTree(projectIdOrPath, filePath, refName, false));
-    }
-
-    /**
-     * Get a Pager of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get content of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager containing a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<TreeItem> getTree(Object projectIdOrPath, String filePath, String refName, int itemsPerPage) throws GitLabApiException {
-        return (getTree(projectIdOrPath, filePath, refName, false, itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get content of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @return a Stream containing a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<TreeItem> getTreeStream(Object projectIdOrPath, String filePath, String refName) throws GitLabApiException {
-        return (getTreeStream(projectIdOrPath, filePath, refName, false));
-    }
-
-    /**
-     * Get a list of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get contend of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     * recursive (optional) - Boolean value used to get a recursive tree (false by default)
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @param recursive flag to get a recursive tree or not
-     * @return a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<TreeItem> getTree(Object projectIdOrPath, String filePath, String refName, Boolean recursive) throws GitLabApiException {
-        return (getTree(projectIdOrPath, filePath, refName, recursive, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get contend of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     * recursive (optional) - Boolean value used to get a recursive tree (false by default)
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @param recursive flag to get a recursive tree or not
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<TreeItem> getTree(Object projectIdOrPath, String filePath, String refName, Boolean recursive, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("id", getProjectIdOrPath(projectIdOrPath), true)
-                .withParam("path", filePath, false)
-                .withParam(isApiVersion(ApiVersion.V3) ? "ref_name" : "ref", (refName != null ? urlEncode(refName) : null), false)
-                .withParam("recursive", recursive, false);
-        return (new Pager<TreeItem>(this, TreeItem.class, itemsPerPage, formData.asMap(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "tree"));
-    }
-
-    /**
-     * Get a Stream of repository files and directories in a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tree</code></pre>
-     *
-     * id (required) - The ID of a project
-     * path (optional) - The path inside repository. Used to get contend of subdirectories
-     * ref_name (optional) - The name of a repository branch or tag or if not given the default branch
-     * recursive (optional) - Boolean value used to get a recursive tree (false by default)
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path inside repository, used to get content of subdirectories
-     * @param refName the name of a repository branch or tag or if not given the default branch
-     * @param recursive flag to get a recursive tree or not
-     * @return a Stream containing a tree with the directories and files of a project
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<TreeItem> getTreeStream(Object projectIdOrPath, String filePath, String refName, Boolean recursive) throws GitLabApiException {
-        return (getTree(projectIdOrPath, filePath, refName, recursive, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the raw file contents for a blob by blob SHA.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/raw_blobs/:sha</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the file to get the contents for
-     * @return the raw file contents for the blob on an InputStream
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream getRawBlobContent(Object projectIdOrPath, String sha) throws GitLabApiException {
-        Response response = getWithAccepts(Response.Status.OK, null, MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "blobs", sha, "raw");
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional).
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @return an input stream that can be used to save as a file
-     * or to read the content of the archive
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream getRepositoryArchive(Object projectIdOrPath, String sha) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive");
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional).
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @param format The archive format, defaults to "tar.gz" if null
-     * @return an input stream that can be used to save as a file or to read the content of the archive
-     * @throws GitLabApiException if format is not a valid archive format or any exception occurs
-     */
-    public InputStream getRepositoryArchive(Object projectIdOrPath, String sha, String format) throws GitLabApiException {
-        ArchiveFormat archiveFormat = ArchiveFormat.forValue(format);
-        return (getRepositoryArchive(projectIdOrPath, sha, archiveFormat));
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional).
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @param format The archive format, defaults to TAR_GZ if null
-     * @return an input stream that can be used to save as a file or to read the content of the archive
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream getRepositoryArchive(Object projectIdOrPath, String sha, ArchiveFormat format) throws GitLabApiException {
-
-        if (format == null) {
-            format = ArchiveFormat.TAR_GZ;
-        }
-
-        /*
-         * Gitlab-ce has a bug when you try to download file archives with format by using "&format=zip(or tar... etc.)",
-         * there is a solution to request .../archive.:format instead of .../archive?format=:format.
-         *
-         * Issue:  https://gitlab.com/gitlab-org/gitlab-ce/issues/45992
-         *         https://gitlab.com/gitlab-com/support-forum/issues/3067
-         */
-        Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive" + "." + format.toString());
-        return (response.readEntity(InputStream.class));
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional) and saves to the specified directory.
-     * If the archive already exists in the directory it will be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @param directory the File instance of the directory to save the archive to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the downloaded instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File getRepositoryArchive(Object projectIdOrPath, String sha, File directory) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive");
-
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = FileUtils.getFilenameFromContentDisposition(response);
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional) and saves to the specified directory.
-     * If the archive already exists in the directory it will be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @param directory the File instance of the directory to save the archive to, if null will use "java.io.tmpdir"
-     * @param format The archive format, defaults to "tar.gz" if null
-     * @return a File instance pointing to the downloaded instance
-     * @throws GitLabApiException if format is not a valid archive format or any exception occurs
-     */
-    public File getRepositoryArchive(Object projectIdOrPath, String sha, File directory, String format) throws GitLabApiException {
-        ArchiveFormat archiveFormat = ArchiveFormat.forValue(format);
-        return (getRepositoryArchive(projectIdOrPath, sha, directory, archiveFormat));
-    }
-
-    /**
-     * Get an archive of the complete repository by SHA (optional) and saves to the specified directory.
-     * If the archive already exists in the directory it will be overwritten.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/archive</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param sha the SHA of the archive to get
-     * @param directory the File instance of the directory to save the archive to, if null will use "java.io.tmpdir"
-     * @param format The archive format, defaults to TAR_GZ if null
-     * @return a File instance pointing to the downloaded instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File getRepositoryArchive(Object projectIdOrPath, String sha, File directory, ArchiveFormat format) throws GitLabApiException {
-
-        if (format == null) {
-            format = ArchiveFormat.TAR_GZ;
-        }
-
-        /*
-         * Gitlab-ce has a bug when you try to download file archives with format by using "&format=zip(or tar... etc.)",
-         * there is a solution to request .../archive.:format instead of .../archive?format=:format.
-         *
-         * Issue:  https://gitlab.com/gitlab-org/gitlab-ce/issues/45992
-         *         https://gitlab.com/gitlab-com/support-forum/issues/3067
-         */
-        Form formData = new GitLabApiForm().withParam("sha", sha);
-        Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "archive" + "." + format.toString());
-
-        try {
-
-            if (directory == null)
-                directory = new File(System.getProperty("java.io.tmpdir"));
-
-            String filename = FileUtils.getFilenameFromContentDisposition(response);
-            File file = new File(directory, filename);
-
-            InputStream in = response.readEntity(InputStream.class);
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-    }
-
-    /**
-     * Compare branches, tags or commits. This can be accessed without authentication
-     * if the repository is publicly accessible.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param from the commit SHA or branch name
-     * @param to the commit SHA or branch name
-     * @param straight specifies the comparison method, true for direct comparison between from and to (from..to),
-     *          false to compare using merge base (from…to)’.
-     * @return a CompareResults containing the results of the comparison
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CompareResults compare(Object projectIdOrPath, String from, String to, boolean straight) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("from", from, true)
-                .withParam("to", to, true)
-                .withParam("straight", straight);
-        Response response = get(Response.Status.OK, formData.asMap(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "compare");
-        return (response.readEntity(CompareResults.class));
-    }
-
-    /**
-     * Compare branches, tags or commits. This can be accessed without authentication
-     * if the repository is publicly accessible.
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param from the commit SHA or branch name
-     * @param to the commit SHA or branch name
-     * @return a CompareResults containing the results of the comparison
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CompareResults compare(Object projectIdOrPath, String from, String to) throws GitLabApiException {
-        return (compare(projectIdOrPath, from, to, false));
-    }
-
-    /**
-     * Get a list of contributors from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a List containing the contributors for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Contributor> getContributors(Object projectIdOrPath) throws GitLabApiException {
-        return (getContributors(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of contributors from a project and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @return a List containing the contributors for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Contributor> getContributors(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "contributors");
-        return (response.readEntity(new GenericType<List<Contributor>>() { }));
-    }
-
-    /**
-     * Get a list of contributors from a project and in the specified page range, sorted by specified param.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of projects per page
-     * @param orderBy (optional param) returns contributors ordered by NAME, EMAIL, or COMMITS. Default is COMMITS
-     * @param sortOrder (optional param) returns contributors sorted in ASC or DESC order. Default is ASC
-     * @return a List containing the contributors for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Contributor> getContributors(Object projectIdOrPath, int page, int perPage, ContributorOrderBy orderBy, SortOrder sortOrder) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam(PAGE_PARAM, page).withParam(PER_PAGE_PARAM, perPage);
-        if (sortOrder != null) {
-            formData.withParam("sort", sortOrder, false);
-        }
-
-        if (orderBy != null) {
-            formData.withParam("order_by", orderBy, false);
-        }
-
-        Response response = get(Response.Status.OK, formData.asMap(),
-            "projects", getProjectIdOrPath(projectIdOrPath), "repository", "contributors");
-        return (response.readEntity(new GenericType<List<Contributor>>() { }));
-    }
-
-    /**
-     * Get a Pager of contributors from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager containing the contributors for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Contributor> getContributors(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return new Pager<Contributor>(this, Contributor.class, itemsPerPage, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "contributors");
-    }
-
-    /**
-     * Get a list of contributors from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/contributors</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a List containing the contributors for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Contributor> getContributorsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getContributors(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get the common ancestor for 2 or more refs (commit SHAs, branch names or tags).
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/merge_base</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param refs a List of 2 or more refs (commit SHAs, branch names or tags)
-     * @return the Commit instance containing the common ancestor
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Commit getMergeBase(Object projectIdOrPath, List<String> refs) throws GitLabApiException {
-
-	if (refs == null || refs.size() < 2) {
-	    throw new RuntimeException("refs must conatin at least 2 refs");
-	}
-
-	List<String> encodedRefs = new ArrayList<>(refs.size());
-	for (String ref : refs) {
-	    encodedRefs.add(urlEncode(ref));
-	}
-
-        GitLabApiForm queryParams = new GitLabApiForm().withParam("refs", encodedRefs, true);
-        Response response = get(Response.Status.OK, queryParams.asMap(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "merge_base");
-        return (response.readEntity(Commit.class));
-    }
-
-    /**
-     * Get an Optional instance with the value of the common ancestor
-     * for 2 or more refs (commit SHAs, branch names or tags).
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/merge_base</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param refs a List of 2 or more refs (commit SHAs, branch names or tags)
-     * @return an Optional instance with the Commit instance containing the common ancestor as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<Commit> getOptionalMergeBase(Object projectIdOrPath, List<String> refs) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getMergeBase(projectIdOrPath, refs)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * <p>Delete all branches that are merged into the project’s default branch.</p>
-     * NOTE: Protected branches will not be deleted as part of this operation.
-     *
-     * <pre><code>GitLab Endpoint: /projects/:id/repository/merged_branches</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMergedBranches(Object projectIdOrPath) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "merged_branches");
-    }
-
-    /**
-     * Generate changelog data based on commits in a repository.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param version         the version to generate the changelog for
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void generateChangelog(Object projectIdOrPath, String version) throws GitLabApiException {
-        generateChangelog(projectIdOrPath, new ChangelogPayload(version));
-    }
-
-    /**
-     * Generate changelog data based on commits in a repository.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param payload         the payload to generate the changelog for
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void generateChangelog(Object projectIdOrPath, ChangelogPayload payload) throws GitLabApiException {
-        post(Response.Status.OK, payload.getFormData(), "projects",
-                getProjectIdOrPath(projectIdOrPath), "repository", "changelog");
-    }
-
+  /**
+   * Generate changelog data based on commits in a repository.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/changelog</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param payload the payload to generate the changelog for
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void generateChangelog(final Object projectIdOrPath, final ChangelogPayload payload)
+      throws GitLabApiException {
+    post(
+        Response.Status.OK,
+        payload.getFormData(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "changelog");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
@@ -8,512 +8,666 @@ import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Blame;
 import org.gitlab4j.api.models.RepositoryFile;
 
 /**
- * This class provides an entry point to all the GitLab API repository files calls.
- * See <a href="https://docs.gitlab.com/ce/api/repository_files.html">Repository Files API at GitLab</a> for more information.
+ * This class provides an entry point to all the GitLab API repository files calls. See <a
+ * href="https://docs.gitlab.com/ce/api/repository_files.html">Repository Files API at GitLab</a>
+ * for more information.
  */
 public class RepositoryFileApi extends AbstractApi {
 
-    public RepositoryFileApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public RepositoryFileApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get an Optional instance with the value holding information on a file in the repository. Allows
+   * you to receive information about file in repository like name, size. Only works with GitLab
+   * 11.1.0+, value will be an empty object for earlier versions of GitLab.
+   *
+   * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param ref (required) - The name of branch, tag or commit
+   * @return an Optional instance with the specified RepositoryFile as a value
+   * @since GitLab-11.1.0
+   */
+  public Optional<RepositoryFile> getOptionalFileInfo(
+      final Object projectIdOrPath, final String filePath, final String ref) {
+    try {
+      return (Optional.ofNullable(getFileInfo(projectIdOrPath, filePath, ref)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get information on a file in the repository. Allows you to receive information about file in
+   * repository like name, size. Only works with GitLab 11.1.0+, returns an empty object for earlier
+   * versions of GitLab.
+   *
+   * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param ref (required) - The name of branch, tag or commit
+   * @return a RepositoryFile instance with the file info
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab-11.1.0
+   */
+  public RepositoryFile getFileInfo(
+      final Object projectIdOrPath, final String filePath, final String ref)
+      throws GitLabApiException {
+
+    final Form form = new Form();
+    addFormParam(form, "ref", (ref != null ? urlEncode(ref) : null), true);
+    final Response response =
+        head(
+            Response.Status.OK,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "files",
+            urlEncode(filePath));
+
+    final RepositoryFile file = new RepositoryFile();
+    file.setBlobId(response.getHeaderString("X-Gitlab-Blob-Id"));
+    file.setCommitId(response.getHeaderString("X-Gitlab-Commit-Id"));
+    file.setContentSha256(response.getHeaderString("X-Gitlab-Content-Sha256"));
+
+    final String encoding = response.getHeaderString("X-Gitlab-Encoding");
+    file.setEncoding(Constants.Encoding.forValue(encoding));
+
+    file.setFileName(response.getHeaderString("X-Gitlab-File-Name"));
+    file.setFilePath(response.getHeaderString("X-Gitlab-File-Path"));
+    file.setLastCommitId(response.getHeaderString("X-Gitlab-Last-Commit-Id"));
+    file.setRef(response.getHeaderString("X-Gitlab-Ref"));
+
+    final String sizeStr = response.getHeaderString("X-Gitlab-Size");
+    file.setSize(sizeStr != null ? Integer.valueOf(sizeStr) : -1);
+
+    return (file);
+  }
+
+  /**
+   * Get an Optional instance with the value holding information and content for a file in the
+   * repository. Allows you to receive information about file in repository like name, size, and
+   * content. Only works with GitLab 11.1.0+, value will be an empty object for earlier versions of
+   * GitLab.
+   *
+   * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param ref (required) - The name of branch, tag or commit
+   * @return an Optional instance with the specified RepositoryFile as a value
+   */
+  public Optional<RepositoryFile> getOptionalFile(
+      final Object projectIdOrPath, final String filePath, final String ref) {
+    try {
+      return (Optional.ofNullable(getFile(projectIdOrPath, filePath, ref, true)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Get file from repository. Allows you to receive information about file in repository like name,
+   * size, content. Note that file content is Base64 encoded.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param ref (required) - The name of branch, tag or commit
+   * @return a RepositoryFile instance with the file info and file content
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RepositoryFile getFile(
+      final Object projectIdOrPath, final String filePath, final String ref)
+      throws GitLabApiException {
+    return (getFile(projectIdOrPath, filePath, ref, true));
+  }
+
+  /**
+   * Get file from repository. Allows you to receive information about file in repository like name,
+   * size, content. Note that file content is Base64 encoded.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
+   *
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param projectId (required) - the project ID
+   * @param ref (required) - The name of branch, tag or commit
+   * @return a RepositoryFile instance with the file info and file content
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #getFile(Object, String,
+   *     String)}
+   */
+  @Deprecated
+  public RepositoryFile getFile(final String filePath, final Long projectId, final String ref)
+      throws GitLabApiException {
+
+    if (isApiVersion(ApiVersion.V3)) {
+      return (getFileV3(filePath, projectId, ref));
+    } else {
+      return (getFile(projectId, filePath, ref, true));
+    }
+  }
+
+  /**
+   * Get file from repository. Allows you to receive information about file in repository like name,
+   * size, and optionally content. Note that file content is Base64 encoded.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath (required) - Full path to the file. Ex. lib/class.rb
+   * @param ref (required) - The name of branch, tag or commit
+   * @param includeContent if true will also fetch file content
+   * @return a RepositoryFile instance with the file info and optionally file content
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RepositoryFile getFile(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String ref,
+      final boolean includeContent)
+      throws GitLabApiException {
+
+    if (!includeContent) {
+      return (getFileInfo(projectIdOrPath, filePath, ref));
     }
 
-    /**
-     * Get an Optional instance with the value holding information on a file in the repository.
-     * Allows you to receive information about file in repository like name, size.
-     * Only works with GitLab 11.1.0+, value will be an empty object for earlier versions of GitLab.
-     *
-     * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param ref (required) - The name of branch, tag or commit
-     * @return an Optional instance with the specified RepositoryFile as a value
-     * @since GitLab-11.1.0
-     */
-    public Optional<RepositoryFile> getOptionalFileInfo(Object projectIdOrPath, String filePath, String ref) {
-        try {
-            return (Optional.ofNullable(getFileInfo(projectIdOrPath, filePath, ref)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+    final Form form = new Form();
+    addFormParam(form, "ref", (ref != null ? urlEncode(ref) : null), true);
+    final Response response =
+        get(
+            Response.Status.OK,
+            form.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "files",
+            urlEncode(filePath));
+    return (response.readEntity(RepositoryFile.class));
+  }
+
+  /**
+   * Get file from repository. Allows you to receive information about file in repository like name,
+   * size, content. Note that file content is Base64 encoded.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
+   *
+   * @param filePath (required) - Full path to new file. Ex. lib/class.rb
+   * @param projectId (required) - the project ID
+   * @param ref (required) - The name of branch, tag or commit
+   * @return a RepositoryFile instance with the file info
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0
+   */
+  @Deprecated
+  protected RepositoryFile getFileV3(final String filePath, final Long projectId, final String ref)
+      throws GitLabApiException {
+    final Form form = new Form();
+    addFormParam(form, "file_path", filePath, true);
+    addFormParam(form, "ref", ref, true);
+    final Response response =
+        get(Response.Status.OK, form.asMap(), "projects", projectId, "repository", "files");
+    return (response.readEntity(RepositoryFile.class));
+  }
+
+  /**
+   * Create new file in repository
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to new file. Ex. lib/class.rb branch_name (required) - The
+   * name of branch encoding (optional) - 'text' or 'base64'. Text is default. content (required) -
+   * File content commit_message (required) - Commit message
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param file a ReposityoryFile instance with info for the file to create
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @return a RepositoryFile instance with the created file info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RepositoryFile createFile(
+      final Object projectIdOrPath,
+      final RepositoryFile file,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
+
+    final Form formData = createForm(file, branchName, commitMessage);
+    final Response response;
+    if (isApiVersion(ApiVersion.V3)) {
+      response =
+          post(
+              Response.Status.CREATED,
+              formData,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "files");
+    } else {
+      response =
+          post(
+              Response.Status.CREATED,
+              formData,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "files",
+              urlEncode(file.getFilePath()));
     }
 
-    /**
-     * Get information on a file in the repository. Allows you to receive information about file in repository like name, size.
-     * Only works with GitLab 11.1.0+, returns an empty object for earlier versions of GitLab.
-     *
-     * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param ref (required) - The name of branch, tag or commit
-     * @return a RepositoryFile instance with the file info
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab-11.1.0
-     */
-    public RepositoryFile getFileInfo(Object projectIdOrPath, String filePath, String ref) throws GitLabApiException {
+    return (response.readEntity(RepositoryFile.class));
+  }
 
-        Form form = new Form();
-        addFormParam(form, "ref", (ref != null ? urlEncode(ref) : null), true);
-        Response response = head(Response.Status.OK, form.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(filePath));
+  /**
+   * Create new file in repository
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to new file. Ex. lib/class.rb branch_name (required) - The
+   * name of branch encoding (optional) - 'text' or 'base64'. Text is default. content (required) -
+   * File content commit_message (required) - Commit message
+   *
+   * @param file a ReposityoryFile instance with info for the file to create
+   * @param projectId the project ID
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @return a RepositoryFile instance with the created file info
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #createFile(Object,
+   *     RepositoryFile, String, String)}
+   */
+  @Deprecated
+  public RepositoryFile createFile(
+      final RepositoryFile file,
+      final Long projectId,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
+    return (createFile(projectId, file, branchName, commitMessage));
+  }
 
-        RepositoryFile file = new RepositoryFile();
-        file.setBlobId(response.getHeaderString("X-Gitlab-Blob-Id"));
-        file.setCommitId(response.getHeaderString("X-Gitlab-Commit-Id"));
-        file.setContentSha256(response.getHeaderString("X-Gitlab-Content-Sha256"));
+  /**
+   * Update existing file in repository
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to new file. Ex. lib/class.rb branch_name (required) - The
+   * name of branch encoding (optional) - 'text' or 'base64'. Text is default. content (required) -
+   * File content commit_message (required) - Commit message
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param file a ReposityoryFile instance with info for the file to update
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @return a RepositoryFile instance with the updated file info
+   * @throws GitLabApiException if any exception occurs
+   */
+  public RepositoryFile updateFile(
+      final Object projectIdOrPath,
+      final RepositoryFile file,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
 
-        String encoding = response.getHeaderString("X-Gitlab-Encoding");
-        file.setEncoding(Constants.Encoding.forValue(encoding));
-
-        file.setFileName(response.getHeaderString("X-Gitlab-File-Name"));
-        file.setFilePath(response.getHeaderString("X-Gitlab-File-Path"));
-        file.setLastCommitId(response.getHeaderString("X-Gitlab-Last-Commit-Id"));
-        file.setRef(response.getHeaderString("X-Gitlab-Ref"));
-
-        String sizeStr = response.getHeaderString("X-Gitlab-Size");
-        file.setSize(sizeStr != null ? Integer.valueOf(sizeStr) : -1);
-
-        return (file);
+    final Form formData = createForm(file, branchName, commitMessage);
+    final Response response;
+    if (isApiVersion(ApiVersion.V3)) {
+      response =
+          put(
+              Response.Status.OK,
+              formData.asMap(),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "files");
+    } else {
+      response =
+          put(
+              Response.Status.OK,
+              formData.asMap(),
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "files",
+              urlEncode(file.getFilePath()));
     }
 
-    /**
-     * Get an Optional instance with the value holding information and content for a file in the repository.
-     * Allows you to receive information about file in repository like name, size, and content.
-     * Only works with GitLab 11.1.0+, value will be an empty object for earlier versions of GitLab.
-     *
-     * <pre><code>GitLab Endpoint: HEAD /projects/:id/repository/files</code></pre>
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param ref (required) - The name of branch, tag or commit
-     * @return an Optional instance with the specified RepositoryFile as a value
-     */
-    public Optional<RepositoryFile> getOptionalFile(Object projectIdOrPath, String filePath, String ref) {
-        try {
-            return (Optional.ofNullable(getFile(projectIdOrPath, filePath, ref, true)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
+    return (response.readEntity(RepositoryFile.class));
+  }
+
+  /**
+   * Update existing file in repository
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to new file. Ex. lib/class.rb branch_name (required) - The
+   * name of branch encoding (optional) - 'text' or 'base64'. Text is default. content (required) -
+   * File content commit_message (required) - Commit message
+   *
+   * @param file a ReposityoryFile instance with info for the file to update
+   * @param projectId the project ID
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @return a RepositoryFile instance with the updated file info
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #updateFile(Object,
+   *     RepositoryFile, String, String)}
+   */
+  @Deprecated
+  public RepositoryFile updateFile(
+      final RepositoryFile file,
+      final Long projectId,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
+    return (updateFile(projectId, file, branchName, commitMessage));
+  }
+
+  /**
+   * Delete existing file in repository
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to file. Ex. lib/class.rb branch_name (required) - The name of
+   * branch commit_message (required) - Commit message
+   *
+   * @param projectIdOrPath the id, path of the project, or a Project instance holding the project
+   *     ID or path
+   * @param filePath full path to new file. Ex. lib/class.rb
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteFile(
+      final Object projectIdOrPath,
+      final String filePath,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
+
+    if (filePath == null) {
+      throw new RuntimeException("filePath cannot be null");
     }
 
-    /**
-     * Get file from repository. Allows you to receive information about file in repository like name, size, content.
-     * Note that file content is Base64 encoded.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param ref (required) - The name of branch, tag or commit
-     * @return a RepositoryFile instance with the file info and file content
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RepositoryFile getFile(Object projectIdOrPath, String filePath, String ref) throws GitLabApiException {
-        return (getFile(projectIdOrPath, filePath, ref, true));
+    final Form form = new Form();
+    addFormParam(
+        form,
+        isApiVersion(ApiVersion.V3) ? "branch_name" : "branch",
+        (branchName != null ? urlEncode(branchName) : null),
+        true);
+    addFormParam(form, "commit_message", commitMessage, true);
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+
+    if (isApiVersion(ApiVersion.V3)) {
+      addFormParam(form, "file_path", filePath, true);
+      delete(
+          expectedStatus,
+          form.asMap(),
+          "projects",
+          getProjectIdOrPath(projectIdOrPath),
+          "repository",
+          "files");
+    } else {
+      delete(
+          expectedStatus,
+          form.asMap(),
+          "projects",
+          getProjectIdOrPath(projectIdOrPath),
+          "repository",
+          "files",
+          urlEncode(filePath));
+    }
+  }
+
+  /**
+   * Delete existing file in repository
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/files</code></pre>
+   *
+   * file_path (required) - Full path to file. Ex. lib/class.rb branch_name (required) - The name of
+   * branch commit_message (required) - Commit message
+   *
+   * @param filePath full path to new file. Ex. lib/class.rb
+   * @param projectId the project ID
+   * @param branchName the name of branch
+   * @param commitMessage the commit message
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #deleteFile(Object, String,
+   *     String, String)}
+   */
+  @Deprecated
+  public void deleteFile(
+      final String filePath,
+      final Long projectId,
+      final String branchName,
+      final String commitMessage)
+      throws GitLabApiException {
+    deleteFile(projectId, filePath, branchName, commitMessage);
+  }
+
+  /**
+   * Get the raw file for the file by commit sha and path. Thye file will be saved to the specified
+   * directory. If the file already exists in the directory it will be overwritten.
+   *
+   * <p>V3:
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/blobs/:sha</code></pre>
+   *
+   * V4:
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:filepath</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param commitOrBranchName the commit or branch name to get the file for
+   * @param filepath the path of the file to get
+   * @param directory the File instance of the directory to save the file to, if null will use
+   *     "java.io.tmpdir"
+   * @return a File instance pointing to the download of the specified file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public File getRawFile(
+      final Object projectIdOrPath,
+      final String commitOrBranchName,
+      final String filepath,
+      File directory)
+      throws GitLabApiException {
+
+    final InputStream in = getRawFile(projectIdOrPath, commitOrBranchName, filepath);
+
+    try {
+
+      if (directory == null) {
+        directory = new File(System.getProperty("java.io.tmpdir"));
+      }
+
+      final String filename = new File(filepath).getName();
+      final File file = new File(directory, filename);
+
+      Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+      return (file);
+
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
+    } finally {
+      try {
+        in.close();
+      } catch (final IOException ignore) {
+      }
+    }
+  }
+
+  /**
+   * Get the raw file contents for a file by commit sha and path.
+   *
+   * <p>V3:
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/blobs/:sha</code></pre>
+   *
+   * V4:
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:filepath</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param ref the commit or branch name to get the file contents for
+   * @param filepath the path of the file to get
+   * @return an InputStream to read the raw file from
+   * @throws GitLabApiException if any exception occurs
+   */
+  public InputStream getRawFile(
+      final Object projectIdOrPath, final String ref, final String filepath)
+      throws GitLabApiException {
+
+    final Form formData = new GitLabApiForm().withParam("ref", (ref != null ? ref : null), true);
+    if (isApiVersion(ApiVersion.V3)) {
+      final Response response =
+          getWithAccepts(
+              Response.Status.OK,
+              formData.asMap(),
+              MediaType.MEDIA_TYPE_WILDCARD,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "blobs",
+              ref);
+      return (response.readEntity(InputStream.class));
+    } else {
+      final Response response =
+          getWithAccepts(
+              Response.Status.OK,
+              formData.asMap(),
+              MediaType.MEDIA_TYPE_WILDCARD,
+              "projects",
+              getProjectIdOrPath(projectIdOrPath),
+              "repository",
+              "files",
+              urlEncode(filepath),
+              "raw");
+      return (response.readEntity(InputStream.class));
+    }
+  }
+
+  /**
+   * Gets the query params based on the API version.
+   *
+   * @param file the RepositoryFile instance with the info for the query params
+   * @param branchName the branch name
+   * @param commitMessage the commit message
+   * @return a Form instance with the correct query params.
+   */
+  protected Form createForm(
+      final RepositoryFile file, final String branchName, final String commitMessage) {
+
+    final Form form = new Form();
+    if (isApiVersion(ApiVersion.V3)) {
+      addFormParam(form, "file_path", file.getFilePath(), true);
+      addFormParam(form, "branch_name", branchName, true);
+    } else {
+      addFormParam(form, "branch", branchName, true);
     }
 
-    /**
-     * Get file from repository. Allows you to receive information about file in repository like name, size, content.
-     * Note that file content is Base64 encoded.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
-     *
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param projectId (required) - the project ID
-     * @param ref (required) - The name of branch, tag or commit
-     * @return a RepositoryFile instance with the file info and file content
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #getFile(Object, String, String)}
-     */
-    @Deprecated
-    public RepositoryFile getFile(String filePath, Long projectId, String ref) throws GitLabApiException {
+    addFormParam(form, "encoding", file.getEncoding(), false);
 
-        if (isApiVersion(ApiVersion.V3)) {
-            return (getFileV3(filePath, projectId, ref));
-        } else {
-            return (getFile(projectId, filePath, ref, true));
-        }
+    // Cannot use addFormParam() as it does not accept an empty or whitespace only string
+    final String content = file.getContent();
+    if (content == null) {
+      throw new IllegalArgumentException("content cannot be null");
     }
+    form.param("content", content);
 
-    /**
-     * Get file from repository. Allows you to receive information about file in repository like name, size, and optionally content.
-     * Note that file content is Base64 encoded.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath (required) - Full path to the file. Ex. lib/class.rb
-     * @param ref (required) - The name of branch, tag or commit
-     * @param includeContent if true will also fetch file content
-     * @return a RepositoryFile instance with the file info and optionally file content
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RepositoryFile getFile(Object projectIdOrPath, String filePath, String ref, boolean includeContent) throws GitLabApiException {
+    addFormParam(form, "commit_message", commitMessage, true);
+    return (form);
+  }
 
-        if (!includeContent) {
-            return (getFileInfo(projectIdOrPath, filePath, ref));
-        }
+  /**
+   * Get a List of file blame from repository. Allows you to receive blame information. Each blame
+   * range contains lines and corresponding commit information.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path of the file to get the blame for
+   * @param ref the name of branch, tag or commit
+   * @return a List of Blame instances for the specified filePath and ref
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Blame> getBlame(final Object projectIdOrPath, final String filePath, final String ref)
+      throws GitLabApiException {
+    return (getBlame(projectIdOrPath, filePath, ref, getDefaultPerPage()).all());
+  }
 
-        Form form = new Form();
-        addFormParam(form, "ref", (ref != null ? urlEncode(ref) : null), true);
-        Response response = get(Response.Status.OK, form.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(filePath));
-        return (response.readEntity(RepositoryFile.class));
-    }
+  /**
+   * Get a Pager of file blame from repository. Allows you to receive blame information. Each blame
+   * range contains lines and corresponding commit information.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path of the file to get the blame for
+   * @param ref the name of branch, tag or commit
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return a Pager of Blame instances for the specified filePath and ref
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Blame> getBlame(
+      final Object projectIdOrPath, final String filePath, final String ref, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("ref", ref, true);
+    return (new Pager<Blame>(
+        this,
+        Blame.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "files",
+        urlEncode(filePath),
+        "blame"));
+  }
 
-    /**
-     * Get file from repository. Allows you to receive information about file in repository like name, size, content.
-     * Note that file content is Base64 encoded.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files</code></pre>
-     *
-     * @param filePath (required) - Full path to new file. Ex. lib/class.rb
-     * @param projectId (required) - the project ID
-     * @param ref (required) - The name of branch, tag or commit
-     * @return a RepositoryFile instance with the file info
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0
-     */
-    @Deprecated
-    protected RepositoryFile getFileV3(String filePath, Long projectId, String ref) throws GitLabApiException {
-        Form form = new Form();
-        addFormParam(form, "file_path", filePath, true);
-        addFormParam(form, "ref", ref, true);
-        Response response = get(Response.Status.OK, form.asMap(), "projects", projectId, "repository", "files");
-        return (response.readEntity(RepositoryFile.class));
-    }
-
-    /**
-     * Create new file in repository
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to new file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * encoding (optional) - 'text' or 'base64'. Text is default.
-     * content (required) - File content
-     * commit_message (required) - Commit message
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param file a ReposityoryFile instance with info for the file to create
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @return a RepositoryFile instance with the created file info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RepositoryFile createFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
-
-        Form formData = createForm(file, branchName, commitMessage);
-        Response response;
-        if (isApiVersion(ApiVersion.V3)) {
-            response = post(Response.Status.CREATED, formData,
-                    "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files");
-        } else {
-            response = post(Response.Status.CREATED, formData,
-                    "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(file.getFilePath()));
-        }
-
-        return (response.readEntity(RepositoryFile.class));
-    }
-
-    /**
-     * Create new file in repository
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to new file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * encoding (optional) - 'text' or 'base64'. Text is default.
-     * content (required) - File content
-     * commit_message (required) - Commit message
-     *
-     * @param file a ReposityoryFile instance with info for the file to create
-     * @param projectId the project ID
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @return a RepositoryFile instance with the created file info
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #createFile(Object, RepositoryFile, String, String)}
-     */
-    @Deprecated
-    public RepositoryFile createFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
-        return (createFile(projectId, file, branchName, commitMessage));
-    }
-
-    /**
-     * Update existing file in repository
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to new file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * encoding (optional) - 'text' or 'base64'. Text is default.
-     * content (required) - File content
-     * commit_message (required) - Commit message
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param file a ReposityoryFile instance with info for the file to update
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @return a RepositoryFile instance with the updated file info
-     * @throws GitLabApiException if any exception occurs
-     */
-    public RepositoryFile updateFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
-
-        Form formData = createForm(file, branchName, commitMessage);
-        Response response;
-        if (isApiVersion(ApiVersion.V3)) {
-            response = put(Response.Status.OK, formData.asMap(),
-                    "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files");
-        } else {
-            response = put(Response.Status.OK, formData.asMap(),
-                    "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(file.getFilePath()));
-        }
-
-        return (response.readEntity(RepositoryFile.class));
-    }
-
-    /**
-     * Update existing file in repository
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to new file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * encoding (optional) - 'text' or 'base64'. Text is default.
-     * content (required) - File content
-     * commit_message (required) - Commit message
-     *
-     * @param file a ReposityoryFile instance with info for the file to update
-     * @param projectId the project ID
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @return a RepositoryFile instance with the updated file info
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #updateFile(Object, RepositoryFile, String, String)}
-     */
-    @Deprecated
-    public RepositoryFile updateFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
-        return (updateFile(projectId, file, branchName, commitMessage));
-    }
-
-    /**
-     * Delete existing file in repository
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * commit_message (required) - Commit message
-     *
-     * @param projectIdOrPath the id, path of the project, or a Project instance holding the project ID or path
-     * @param filePath full path to new file. Ex. lib/class.rb
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteFile(Object projectIdOrPath, String filePath, String branchName, String commitMessage) throws GitLabApiException {
-
-        if (filePath == null) {
-            throw new RuntimeException("filePath cannot be null");
-        }
-
-        Form form = new Form();
-        addFormParam(form, isApiVersion(ApiVersion.V3) ? "branch_name" : "branch",
-                (branchName != null ? urlEncode(branchName) : null), true);
-        addFormParam(form, "commit_message", commitMessage, true);
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-
-        if (isApiVersion(ApiVersion.V3)) {
-            addFormParam(form, "file_path", filePath, true);
-            delete(expectedStatus, form.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files");
-        } else {
-            delete(expectedStatus, form.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(filePath));
-        }
-    }
-
-    /**
-     * Delete existing file in repository
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/files</code></pre>
-     *
-     * file_path (required) - Full path to file. Ex. lib/class.rb
-     * branch_name (required) - The name of branch
-     * commit_message (required) - Commit message
-     *
-     * @param filePath full path to new file. Ex. lib/class.rb
-     * @param projectId the project ID
-     * @param branchName the name of branch
-     * @param commitMessage the commit message
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated  Will be removed in version 6.0, replaced by {@link #deleteFile(Object, String, String, String)}
-     */
-    @Deprecated
-    public void deleteFile(String filePath, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
-        deleteFile(projectId, filePath, branchName, commitMessage);
-    }
-
-    /**
-     * Get the raw file for the file by commit sha and path. Thye file will be saved to the specified directory.
-     * If the file already exists in the directory it will be overwritten.
-     *
-     * V3:
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/blobs/:sha</code></pre>
-     *
-     * V4:
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:filepath</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param commitOrBranchName the commit or branch name to get the file for
-     * @param filepath the path of the file to get
-     * @param directory the File instance of the directory to save the file to, if null will use "java.io.tmpdir"
-     * @return a File instance pointing to the download of the specified file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public File getRawFile(Object projectIdOrPath, String commitOrBranchName, String filepath, File directory) throws GitLabApiException {
-
-        InputStream in = getRawFile(projectIdOrPath, commitOrBranchName, filepath);
-
-        try {
-
-            if (directory == null) {
-                directory = new File(System.getProperty("java.io.tmpdir"));
-            }
-
-            String filename = new File(filepath).getName();
-            File file = new File(directory, filename);
-
-            Files.copy(in, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
-            return (file);
-
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        } finally {
-            try {
-                in.close();
-            } catch (IOException ignore) {
-            }
-        }
-    }
-
-    /**
-     * Get the raw file contents for a file by commit sha and path.
-     *
-     * V3:
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/blobs/:sha</code></pre>
-     *
-     * V4:
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:filepath</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param ref the commit or branch name to get the file contents for
-     * @param filepath the path of the file to get
-     * @return an InputStream to read the raw file from
-     * @throws GitLabApiException if any exception occurs
-     */
-    public InputStream getRawFile(Object projectIdOrPath, String ref, String filepath) throws GitLabApiException {
-
-	Form formData = new GitLabApiForm().withParam("ref", (ref != null ? ref : null), true);
-        if (isApiVersion(ApiVersion.V3)) {
-            Response response = getWithAccepts(Response.Status.OK, formData.asMap(), MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "blobs", ref);
-            return (response.readEntity(InputStream.class));
-        } else {
-            Response response = getWithAccepts(Response.Status.OK, formData.asMap(),  MediaType.MEDIA_TYPE_WILDCARD,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(filepath), "raw");
-            return (response.readEntity(InputStream.class));
-        }
-    }
-
-    /**
-     * Gets the query params based on the API version.
-     *
-     * @param file the RepositoryFile instance with the info for the query params
-     * @param branchName the branch name
-     * @param commitMessage the commit message
-     * @return a Form instance with the correct query params.
-     */
-    protected Form createForm(RepositoryFile file, String branchName, String commitMessage) {
-
-        Form form = new Form();
-        if (isApiVersion(ApiVersion.V3)) {
-            addFormParam(form, "file_path", file.getFilePath(), true);
-            addFormParam(form, "branch_name", branchName, true);
-        } else {
-            addFormParam(form, "branch", branchName, true);
-        }
-
-        addFormParam(form, "encoding", file.getEncoding(), false);
-
-        // Cannot use addFormParam() as it does not accept an empty or whitespace only string
-        String content = file.getContent();
-        if (content == null) {
-            throw new IllegalArgumentException("content cannot be null");
-        }
-        form.param("content", content);
-
-        addFormParam(form, "commit_message", commitMessage, true);
-        return (form);
-    }
-
-    /**
-     * Get a List of file blame from repository.  Allows you to receive blame information.
-     * Each blame range contains lines and corresponding commit information.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path of the file to get the blame for
-     * @param ref the name of branch, tag or commit
-     * @return a List of Blame instances for the specified filePath and ref
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Blame> getBlame(Object projectIdOrPath, String filePath, String ref) throws GitLabApiException {
-       return (getBlame(projectIdOrPath, filePath, ref, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of file blame from repository.  Allows you to receive blame information.
-     * Each blame range contains lines and corresponding commit information.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path of the file to get the blame for
-     * @param ref the name of branch, tag or commit
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return a Pager of Blame instances for the specified filePath and ref
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Blame> getBlame(Object projectIdOrPath, String filePath, String ref, int itemsPerPage) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm().withParam("ref", ref, true);
-        return (new Pager<Blame>(this, Blame.class, itemsPerPage, formData.asMap(),
-                "projects",  getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(filePath), "blame"));
-    }
-
-    /**
-     * Get a Stream of file blame from repository.  Allows you to receive blame information.
-     * Each blame range contains lines and corresponding commit information.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param filePath the path of the file to get the blame for
-     * @param ref the name of branch, tag or commit
-     * @return a Stream of Blame instances for the specified filePath and ref
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Blame> getBlameStream(Object projectIdOrPath, String filePath, String ref) throws GitLabApiException {
-       return (getBlame(projectIdOrPath, filePath, ref, getDefaultPerPage()).stream());
-    }
+  /**
+   * Get a Stream of file blame from repository. Allows you to receive blame information. Each blame
+   * range contains lines and corresponding commit information.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/files/:file_path/blame</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param filePath the path of the file to get the blame for
+   * @param ref the name of branch, tag or commit
+   * @return a Stream of Blame instances for the specified filePath and ref
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Blame> getBlameStream(
+      final Object projectIdOrPath, final String filePath, final String ref)
+      throws GitLabApiException {
+    return (getBlame(projectIdOrPath, filePath, ref, getDefaultPerPage()).stream());
+  }
 }

--- a/src/main/java/org/gitlab4j/api/ResourceLabelEventsApi.java
+++ b/src/main/java/org/gitlab4j/api/ResourceLabelEventsApi.java
@@ -3,265 +3,374 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.LabelEvent;
-
 
 /**
  * This class provides an entry point to all the GitLab Resource label events API
- * @see <a href="https://docs.gitlab.com/ce/api/resource_label_events.html">Resource label events API at GitLab</a>
+ *
+ * @see <a href="https://docs.gitlab.com/ce/api/resource_label_events.html">Resource label events
+ *     API at GitLab</a>
  */
 public class ResourceLabelEventsApi extends AbstractApi {
 
-    public ResourceLabelEventsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public ResourceLabelEventsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Gets a list of all label events for a single issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the IID of the issue
+   * @return a List of LabelEvent for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<LabelEvent> getIssueLabelEvents(final Object projectIdOrPath, final Long issueIid)
+      throws GitLabApiException {
+    return (getIssueLabelEvents(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a Pager of all label events for a single issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the IID of the issue
+   * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
+   * @return the Pager of LabelEvent instances for the specified issue IID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<LabelEvent> getIssueLabelEvents(
+      final Object projectIdOrPath, final Long issueIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<LabelEvent>(
+        this,
+        LabelEvent.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "issues",
+        issueIid,
+        "resource_label_events"));
+  }
+
+  /**
+   * Gets a Stream of all label events for a single issue.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the IID of the issue
+   * @return a Stream of LabelEvent for the specified issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<LabelEvent> getIssueLabelEventsStream(
+      final Object projectIdOrPath, final Long issueIid) throws GitLabApiException {
+    return (getIssueLabelEvents(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single label event for a specific project issue.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the IID of the issue
+   * @param resourceLabelEventId the ID of a label event
+   * @return LabelEvent instance for the specified project issue
+   * @throws GitLabApiException if any exception occurs
+   */
+  public LabelEvent getIssueLabelEvent(
+      final Object projectIdOrPath, final Long issueIid, final Long resourceLabelEventId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "issues",
+            issueIid,
+            "resource_label_events",
+            resourceLabelEventId);
+    return (response.readEntity(LabelEvent.class));
+  }
+
+  /**
+   * Get an Optional instance holding a LabelEvent for a specific project issue
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param issueIid the IID of the issue
+   * @param resourceLabelEventId the ID of a label event
+   * @return an Optional instance with the specified LabelEvent as the value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<LabelEvent> getOptionalIssueLabelEvent(
+      final Object projectIdOrPath, final Long issueIid, final Long resourceLabelEventId)
+      throws GitLabApiException {
+
+    try {
+      return (Optional.ofNullable(
+          getIssueLabelEvent(projectIdOrPath, issueIid, resourceLabelEventId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Gets a list of all label events for a single issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the IID of the issue
-     * @return a List of LabelEvent for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<LabelEvent> getIssueLabelEvents(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueLabelEvents(projectIdOrPath, issueIid, getDefaultPerPage()).all());
+  /**
+   * Gets a list of all label events for an epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param epicId the ID of the epic
+   * @return a List of LabelEvent for the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<LabelEvent> getEpicLabelEvents(final Object projectIdOrPath, final Long epicId)
+      throws GitLabApiException {
+    return (getEpicLabelEvents(projectIdOrPath, epicId, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a Pager of all label events for the specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param epicId the ID of the epic
+   * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
+   * @return the Pager of LabelEvent instances for the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<LabelEvent> getEpicLabelEvents(
+      final Object projectIdOrPath, final Long epicId, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<LabelEvent>(
+        this,
+        LabelEvent.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "epics",
+        epicId,
+        "resource_label_events"));
+  }
+
+  /**
+   * Gets a Stream of all label events for he specified epic.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param epicId the ID of the epic
+   * @return a Stream of LabelEvent for the specified epic
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<LabelEvent> getEpicLabelEventsStream(
+      final Object projectIdOrPath, final Long epicId) throws GitLabApiException {
+    return (getEpicLabelEvents(projectIdOrPath, epicId, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single label event for a specific epic label event.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param epicId the ID of the epic
+   * @param resourceLabelEventId the ID of a label event
+   * @return LabelEvent instance for the specified epic label event
+   * @throws GitLabApiException if any exception occurs
+   */
+  public LabelEvent getEpicLabelEvent(
+      final Object projectIdOrPath, final Long epicId, final Long resourceLabelEventId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "epics",
+            epicId,
+            "resource_label_events",
+            resourceLabelEventId);
+    return (response.readEntity(LabelEvent.class));
+  }
+
+  /**
+   * Get an Optional instance holding a LabelEvent for a specific epic label event.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param epicId the ID of the epic
+   * @param resourceLabelEventId the ID of a label event
+   * @return an Optional instance with the specified LabelEvent as the value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<LabelEvent> getOptionalEpicLabelEvent(
+      final Object projectIdOrPath, final Long epicId, final Long resourceLabelEventId)
+      throws GitLabApiException {
+
+    try {
+      return (Optional.ofNullable(
+          getEpicLabelEvent(projectIdOrPath, epicId, resourceLabelEventId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Gets a Pager of all label events for a single issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the IID of the issue
-     * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
-     * @return the Pager of LabelEvent instances for the specified issue IID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<LabelEvent> getIssueLabelEvents(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<LabelEvent>(this, LabelEvent.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "resource_label_events"));
+  /**
+   * Gets a list of all label events for a merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request
+   * @return a List of LabelEvent for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<LabelEvent> getMergeRequestLabelEvents(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestLabelEvents(projectIdOrPath, mergeRequestIid, getDefaultPerPage())
+        .all());
+  }
+
+  /**
+   * Gets a Pager of all label events for the specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request
+   * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
+   * @return the Pager of LabelEvent instances for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<LabelEvent> getMergeRequestLabelEvents(
+      final Object projectIdOrPath, final Long mergeRequestIid, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<LabelEvent>(
+        this,
+        LabelEvent.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "merge_requests",
+        mergeRequestIid,
+        "resource_label_events"));
+  }
+
+  /**
+   * Gets a Stream of all label events for he specified merge request.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:issue_iid/resource_label_events</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request
+   * @return a Stream of LabelEvent for the specified merge request
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<LabelEvent> getMergeRequestLabelEventsStream(
+      final Object projectIdOrPath, final Long mergeRequestIid) throws GitLabApiException {
+    return (getMergeRequestLabelEvents(projectIdOrPath, mergeRequestIid, getDefaultPerPage())
+        .stream());
+  }
+
+  /**
+   * Get a single label event for a specific merge request label event.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request
+   * @param resourceLabelEventId the ID of a label event
+   * @return LabelEvent instance for the specified epic label event
+   * @throws GitLabApiException if any exception occurs
+   */
+  public LabelEvent getMergeRequestLabelEvent(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long resourceLabelEventId)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "merge_requests",
+            mergeRequestIid,
+            "resource_label_events",
+            resourceLabelEventId);
+    return (response.readEntity(LabelEvent.class));
+  }
+
+  /**
+   * Get an Optional instance holding a LabelEvent for a specific merge request label event.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /projects/:id/merge_requests/:issue_iid/resource_label_events/:resource_label_event_id</code>
+   * </pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mergeRequestIid the IID of the merge request
+   * @param resourceLabelEventId the ID of a label event
+   * @return an Optional instance with the specified LabelEvent as the value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<LabelEvent> getOptionalMergeRequestLabelEvent(
+      final Object projectIdOrPath, final Long mergeRequestIid, final Long resourceLabelEventId)
+      throws GitLabApiException {
+
+    try {
+      return (Optional.ofNullable(
+          getMergeRequestLabelEvent(projectIdOrPath, mergeRequestIid, resourceLabelEventId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
-
-    /**
-     * Gets a Stream of all label events for a single issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the IID of the issue
-     * @return a Stream of LabelEvent for the specified issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<LabelEvent> getIssueLabelEventsStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
-        return (getIssueLabelEvents(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single label event for a specific project issue.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the IID of the issue
-     * @param resourceLabelEventId the ID of a label event
-     * @return LabelEvent instance for the specified project issue
-     * @throws GitLabApiException if any exception occurs
-     */
-    public LabelEvent getIssueLabelEvent(Object projectIdOrPath, Long issueIid, Long resourceLabelEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "issues", issueIid, "resource_label_events", resourceLabelEventId);
-        return (response.readEntity(LabelEvent.class));
-    }
-
-    /**
-     * Get an Optional instance holding a LabelEvent for a specific project issue
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param issueIid the IID of the issue
-     * @param resourceLabelEventId the ID of a label event
-     * @return an Optional instance with the specified LabelEvent as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<LabelEvent> getOptionalIssueLabelEvent(Object projectIdOrPath,
-	    Long issueIid, Long resourceLabelEventId) throws GitLabApiException {
-
-        try {
-            return (Optional.ofNullable(getIssueLabelEvent(projectIdOrPath, issueIid, resourceLabelEventId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Gets a list of all label events for an epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param epicId the ID of the epic
-     * @return a List of LabelEvent for the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<LabelEvent> getEpicLabelEvents(Object projectIdOrPath, Long epicId) throws GitLabApiException {
-        return (getEpicLabelEvents(projectIdOrPath, epicId, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a Pager of all label events for the specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param epicId the ID of the epic
-     * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
-     * @return the Pager of LabelEvent instances for the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<LabelEvent> getEpicLabelEvents(Object projectIdOrPath, Long epicId, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<LabelEvent>(this, LabelEvent.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "epics", epicId, "resource_label_events"));
-    }
-
-    /**
-     * Gets a Stream of all label events for he specified epic.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param epicId the ID of the epic
-     * @return a Stream of LabelEvent for the specified epic
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<LabelEvent> getEpicLabelEventsStream(Object projectIdOrPath, Long epicId) throws GitLabApiException {
-        return (getEpicLabelEvents(projectIdOrPath, epicId, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single label event for a specific epic label event.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param epicId the ID of the epic
-     * @param resourceLabelEventId the ID of a label event
-     * @return LabelEvent instance for the specified epic label event
-     * @throws GitLabApiException if any exception occurs
-     */
-    public LabelEvent getEpicLabelEvent(Object projectIdOrPath, Long epicId, Long resourceLabelEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "epics", epicId, "resource_label_events", resourceLabelEventId);
-        return (response.readEntity(LabelEvent.class));
-    }
-
-    /**
-     * Get an Optional instance holding a LabelEvent for a specific epic label event.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/epics/:epic_id/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param epicId the ID of the epic
-     * @param resourceLabelEventId the ID of a label event
-     * @return an Optional instance with the specified LabelEvent as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<LabelEvent> getOptionalEpicLabelEvent(Object projectIdOrPath,
-	    Long epicId, Long resourceLabelEventId) throws GitLabApiException {
-
-        try {
-            return (Optional.ofNullable(getEpicLabelEvent(projectIdOrPath, epicId, resourceLabelEventId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Gets a list of all label events for a merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request
-     * @return a List of LabelEvent for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<LabelEvent> getMergeRequestLabelEvents(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestLabelEvents(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a Pager of all label events for the specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request
-     * @param itemsPerPage the number of LabelEvent instances that will be fetched per page
-     * @return the Pager of LabelEvent instances for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<LabelEvent> getMergeRequestLabelEvents(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<LabelEvent>(this, LabelEvent.class, itemsPerPage, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "resource_label_events"));
-    }
-
-    /**
-     * Gets a Stream of all label events for he specified merge request.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:issue_iid/resource_label_events</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request
-     * @return a Stream of LabelEvent for the specified merge request
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<LabelEvent> getMergeRequestLabelEventsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestLabelEvents(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single label event for a specific merge request label event.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:epic_id/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request
-     * @param resourceLabelEventId the ID of a label event
-     * @return LabelEvent instance for the specified epic label event
-     * @throws GitLabApiException if any exception occurs
-     */
-    public LabelEvent getMergeRequestLabelEvent(Object projectIdOrPath, Long mergeRequestIid, Long resourceLabelEventId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
-                "merge_requests", mergeRequestIid, "resource_label_events", resourceLabelEventId);
-        return (response.readEntity(LabelEvent.class));
-    }
-
-    /**
-     * Get an Optional instance holding a LabelEvent for a specific merge request label event.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:issue_iid/resource_label_events/:resource_label_event_id</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mergeRequestIid the IID of the merge request
-     * @param resourceLabelEventId the ID of a label event
-     * @return an Optional instance with the specified LabelEvent as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<LabelEvent> getOptionalMergeRequestLabelEvent(Object projectIdOrPath,
-	    Long mergeRequestIid, Long resourceLabelEventId) throws GitLabApiException {
-
-        try {
-            return (Optional.ofNullable(getMergeRequestLabelEvent(projectIdOrPath, mergeRequestIid, resourceLabelEventId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
+  }
 }

--- a/src/main/java/org/gitlab4j/api/RunnersApi.java
+++ b/src/main/java/org/gitlab4j/api/RunnersApi.java
@@ -2,10 +2,8 @@ package org.gitlab4j.api;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Job;
 import org.gitlab4j.api.models.JobStatus;
 import org.gitlab4j.api.models.Runner;
@@ -18,7 +16,7 @@ import org.gitlab4j.api.models.RunnerDetail;
  */
 public class RunnersApi extends AbstractApi {
 
-    public RunnersApi(GitLabApi gitLabApi) {
+    public RunnersApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -44,7 +42,7 @@ public class RunnersApi extends AbstractApi {
      * @return List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getRunners(int page, int perPage) throws GitLabApiException {
+    public List<Runner> getRunners(final int page, final int perPage) throws GitLabApiException {
         return getRunners(null, null, page, perPage);
     }
 
@@ -57,7 +55,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Pager containing the Runners for the user
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Runner> getRunners(int itemsPerPage) throws GitLabApiException {
+    public Pager<Runner> getRunners(final int itemsPerPage) throws GitLabApiException {
         return (getRunners(null, null, itemsPerPage));
     }
 
@@ -83,7 +81,7 @@ public class RunnersApi extends AbstractApi {
      * @return List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getRunners(RunnerType type, RunnerStatus status) throws GitLabApiException {
+    public List<Runner> getRunners(final RunnerType type, final RunnerStatus status) throws GitLabApiException {
         return (getRunners(type, status, getDefaultPerPage()).all());
     }
 
@@ -99,11 +97,11 @@ public class RunnersApi extends AbstractApi {
      * @return List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getRunners(RunnerType type, RunnerStatus status, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm(page, perPage)
+    public List<Runner> getRunners(final RunnerType type, final RunnerStatus status, final int page, final int perPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm(page, perPage)
                 .withParam("type", type, false)
                 .withParam("status", status, false);
-        Response response = get(Response.Status.OK, formData.asMap(), "runners");
+        final Response response = get(Response.Status.OK, formData.asMap(), "runners");
         return (response.readEntity(new GenericType<List<Runner>>() {}));
     }
 
@@ -118,8 +116,8 @@ public class RunnersApi extends AbstractApi {
      * @return a Pager containing the Runners for the user
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Runner> getRunners(RunnerType type, RunnerStatus status, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    public Pager<Runner> getRunners(final RunnerType type, final RunnerStatus status, final int itemsPerPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("type", type, false)
                 .withParam("status", status, false);
         return (new Pager<>(this, Runner.class, itemsPerPage, formData.asMap(), "runners"));
@@ -135,7 +133,7 @@ public class RunnersApi extends AbstractApi {
      * @return Stream of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Runner> getRunnersStream(RunnerType type, RunnerStatus status) throws GitLabApiException {
+    public Stream<Runner> getRunnersStream(final RunnerType type, final RunnerStatus status) throws GitLabApiException {
         return (getRunners(type, status, getDefaultPerPage()).stream());
     }
 
@@ -161,7 +159,7 @@ public class RunnersApi extends AbstractApi {
      * @return a list of all runners in the GitLab instance
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getAllRunners(int page, int perPage) throws GitLabApiException {
+    public List<Runner> getAllRunners(final int page, final int perPage) throws GitLabApiException {
         return (getAllRunners(null, null, page, perPage));
     }
 
@@ -174,7 +172,7 @@ public class RunnersApi extends AbstractApi {
      * @return List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Runner> getAllRunners(int itemsPerPage) throws GitLabApiException {
+    public Pager<Runner> getAllRunners(final int itemsPerPage) throws GitLabApiException {
         return getAllRunners(null, null, itemsPerPage);
     }
 
@@ -200,7 +198,7 @@ public class RunnersApi extends AbstractApi {
      * @return a List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getAllRunners(RunnerType type, RunnerStatus status) throws GitLabApiException {
+    public List<Runner> getAllRunners(final RunnerType type, final RunnerStatus status) throws GitLabApiException {
         return (getAllRunners(type, status, getDefaultPerPage()).all());
     }
 
@@ -216,11 +214,11 @@ public class RunnersApi extends AbstractApi {
      * @return List of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getAllRunners(RunnerType type, RunnerStatus status, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm(page, perPage)
+    public List<Runner> getAllRunners(final RunnerType type, final RunnerStatus status, final int page, final int perPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm(page, perPage)
                 .withParam("type", type, false)
                 .withParam("status", status, false);
-        Response response = get(Response.Status.OK, formData.asMap(), "runners", "all");
+        final Response response = get(Response.Status.OK, formData.asMap(), "runners", "all");
         return (response.readEntity(new GenericType<List<Runner>>() {}));
     }
 
@@ -235,8 +233,8 @@ public class RunnersApi extends AbstractApi {
      * @return a Pager containing the Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Runner> getAllRunners(RunnerType type, RunnerStatus status, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    public Pager<Runner> getAllRunners(final RunnerType type, final RunnerStatus status, final int itemsPerPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("type", type, false)
                 .withParam("status", status, false);
         return (new Pager<>(this, Runner.class, itemsPerPage, formData.asMap(), "runners", "all"));
@@ -252,7 +250,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Stream of Runners
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Runner> getAllRunnersStream(RunnerType type, RunnerStatus status) throws GitLabApiException {
+    public Stream<Runner> getAllRunnersStream(final RunnerType type, final RunnerStatus status) throws GitLabApiException {
         return (getAllRunners(type, status, getDefaultPerPage()).stream());
     }
 
@@ -265,13 +263,13 @@ public class RunnersApi extends AbstractApi {
      * @return RunnerDetail instance.
      * @throws GitLabApiException if any exception occurs
      */
-    public RunnerDetail getRunnerDetail(Long runnerId) throws GitLabApiException {
+    public RunnerDetail getRunnerDetail(final Long runnerId) throws GitLabApiException {
 
         if (runnerId == null) {
             throw new RuntimeException("runnerId cannot be null");
         }
 
-        Response response = get(Response.Status.OK, null, "runners", runnerId);
+        final Response response = get(Response.Status.OK, null, "runners", runnerId);
         return (response.readEntity(RunnerDetail.class));
     }
 
@@ -290,20 +288,20 @@ public class RunnersApi extends AbstractApi {
      * @return RunnerDetail instance.
      * @throws GitLabApiException if any exception occurs
      */
-    public RunnerDetail updateRunner(Long runnerId, String description, Boolean active, List<String> tagList,
-                                     Boolean runUntagged, Boolean locked, RunnerDetail.RunnerAccessLevel accessLevel) throws GitLabApiException {
+    public RunnerDetail updateRunner(final Long runnerId, final String description, final Boolean active, final List<String> tagList,
+                                     final Boolean runUntagged, final Boolean locked, final RunnerDetail.RunnerAccessLevel accessLevel) throws GitLabApiException {
         if (runnerId == null) {
             throw new RuntimeException("runnerId cannot be null");
         }
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("description", description, false)
                 .withParam("active", active, false)
                 .withParam("tag_list", tagList, false)
                 .withParam("run_untagged", runUntagged, false)
                 .withParam("locked", locked, false)
                 .withParam("access_level", accessLevel, false);
-        Response response = put(Response.Status.OK, formData.asMap(), "runners", runnerId);
+        final Response response = put(Response.Status.OK, formData.asMap(), "runners", runnerId);
         return (response.readEntity(RunnerDetail.class));
     }
 
@@ -315,7 +313,7 @@ public class RunnersApi extends AbstractApi {
      * @param runnerId The ID of a runner
      * @throws GitLabApiException if any exception occurs
      */
-    public void removeRunner(Long runnerId) throws GitLabApiException {
+    public void removeRunner(final Long runnerId) throws GitLabApiException {
 
         if (runnerId == null) {
             throw new RuntimeException("runnerId cannot be null");
@@ -333,7 +331,7 @@ public class RunnersApi extends AbstractApi {
      * @return List jobs that are being processed or were processed by specified Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Job> getJobs(Long runnerId) throws GitLabApiException {
+    public List<Job> getJobs(final Long runnerId) throws GitLabApiException {
         return (getJobs(runnerId, null, getDefaultPerPage()).all());
     }
 
@@ -346,7 +344,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Stream of jobs that are being processed or were processed by specified Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Job> getJobsStream(Long runnerId) throws GitLabApiException {
+    public Stream<Job> getJobsStream(final Long runnerId) throws GitLabApiException {
         return (getJobs(runnerId, null, getDefaultPerPage()).stream());
     }
 
@@ -360,7 +358,7 @@ public class RunnersApi extends AbstractApi {
      * @return List jobs that are being processed or were processed by specified Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Job> getJobs(Long runnerId, JobStatus status) throws GitLabApiException {
+    public List<Job> getJobs(final Long runnerId, final JobStatus status) throws GitLabApiException {
         return (getJobs(runnerId, status, getDefaultPerPage()).all());
     }
 
@@ -374,7 +372,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Stream of jobs that are being processed or were processed by specified Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Job> getJobsStream(Long runnerId, JobStatus status) throws GitLabApiException {
+    public Stream<Job> getJobsStream(final Long runnerId, final JobStatus status) throws GitLabApiException {
         return (getJobs(runnerId, status, getDefaultPerPage()).stream());
     }
 
@@ -388,7 +386,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Pager containing the Jobs for the Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Job> getJobs(Long runnerId, int itemsPerPage) throws GitLabApiException {
+    public Pager<Job> getJobs(final Long runnerId, final int itemsPerPage) throws GitLabApiException {
         return (getJobs(runnerId, null, itemsPerPage));
     }
 
@@ -403,13 +401,13 @@ public class RunnersApi extends AbstractApi {
      * @return a Pager containing the Jobs for the Runner
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Job> getJobs(Long runnerId, JobStatus status, int itemsPerPage) throws GitLabApiException {
+    public Pager<Job> getJobs(final Long runnerId, final JobStatus status, final int itemsPerPage) throws GitLabApiException {
 
         if (runnerId == null) {
             throw new RuntimeException("runnerId cannot be null");
         }
 
-        GitLabApiForm formData = new GitLabApiForm().withParam("status", status, false);
+        final GitLabApiForm formData = new GitLabApiForm().withParam("status", status, false);
         return (new Pager<>(this, Job.class, itemsPerPage, formData.asMap(), "runners", runnerId, "jobs"));
     }
 
@@ -423,7 +421,7 @@ public class RunnersApi extends AbstractApi {
      * @return List of all Runner available in the project
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Runner> getProjectRunners(Object projectIdOrPath) throws GitLabApiException {
+    public List<Runner> getProjectRunners(final Object projectIdOrPath) throws GitLabApiException {
         return (getProjectRunners(projectIdOrPath, getDefaultPerPage()).all());
     }
 
@@ -437,7 +435,7 @@ public class RunnersApi extends AbstractApi {
      * @return a Stream of all Runner available in the project
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Runner> getProjectRunnersStream(Object projectIdOrPath) throws GitLabApiException {
+    public Stream<Runner> getProjectRunnersStream(final Object projectIdOrPath) throws GitLabApiException {
         return (getProjectRunners(projectIdOrPath, getDefaultPerPage()).stream());
     }
 
@@ -452,7 +450,7 @@ public class RunnersApi extends AbstractApi {
      * @return Pager of all Runner available in the project
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Runner> getProjectRunners(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
+    public Pager<Runner> getProjectRunners(final Object projectIdOrPath, final int itemsPerPage) throws GitLabApiException {
         return (new Pager<>(this, Runner.class, itemsPerPage, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "runners"));
     }
@@ -467,9 +465,9 @@ public class RunnersApi extends AbstractApi {
      * @return Runner instance of the Runner enabled
      * @throws GitLabApiException if any exception occurs
      */
-    public Runner enableRunner(Object projectIdOrPath, Long runnerId) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("runner_id", runnerId, true);
-        Response response = post(Response.Status.CREATED, formData.asMap(),
+    public Runner enableRunner(final Object projectIdOrPath, final Long runnerId) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("runner_id", runnerId, true);
+        final Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "runners");
         return (response.readEntity(Runner.class));
     }
@@ -485,8 +483,8 @@ public class RunnersApi extends AbstractApi {
      * @return Runner instance of the Runner disabled
      * @throws GitLabApiException if any exception occurs
      */
-    public Runner disableRunner(Object projectIdOrPath, Long runnerId) throws GitLabApiException {
-        Response response = delete(Response.Status.OK, null,
+    public Runner disableRunner(final Object projectIdOrPath, final Long runnerId) throws GitLabApiException {
+        final Response response = delete(Response.Status.OK, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "runners", runnerId);
         return (response.readEntity(Runner.class));
     }
@@ -506,10 +504,10 @@ public class RunnersApi extends AbstractApi {
      * @return RunnerDetail instance.
      * @throws GitLabApiException if any exception occurs
      */
-    public RunnerDetail registerRunner(String token, String description, Boolean active, List<String> tagList,
-                                     Boolean runUntagged, Boolean locked, Integer maximumTimeout) throws GitLabApiException {
+    public RunnerDetail registerRunner(final String token, final String description, final Boolean active, final List<String> tagList,
+                                     final Boolean runUntagged, final Boolean locked, final Integer maximumTimeout) throws GitLabApiException {
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("token", token, true)
                 .withParam("description", description, false)
                 .withParam("active", active, false)
@@ -517,7 +515,7 @@ public class RunnersApi extends AbstractApi {
                 .withParam("run_untagged", runUntagged, false)
                 .withParam("tag_list", tagList, false)
                 .withParam("maximum_timeout", maximumTimeout, false);
-        Response response = post(Response.Status.CREATED, formData.asMap(), "runners");
+        final Response response = post(Response.Status.CREATED, formData.asMap(), "runners");
         return (response.readEntity(RunnerDetail.class));
     }
 
@@ -529,8 +527,8 @@ public class RunnersApi extends AbstractApi {
      * @param token the runners authentication token
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteRunner(String token) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("token", token, true);
+    public void deleteRunner(final String token) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm().withParam("token", token, true);
         delete(Response.Status.NO_CONTENT, formData.asMap(), "runners");
     }
 }

--- a/src/main/java/org/gitlab4j/api/ServicesApi.java
+++ b/src/main/java/org/gitlab4j/api/ServicesApi.java
@@ -1,5 +1,7 @@
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.services.BugzillaService;
 import org.gitlab4j.api.services.CustomIssueTrackerService;
@@ -10,544 +12,756 @@ import org.gitlab4j.api.services.JiraService;
 import org.gitlab4j.api.services.MattermostService;
 import org.gitlab4j.api.services.SlackService;
 
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.Response;
-
 /**
- * Access for the services API.  Currently only the gitlab-ci, HipChatService, Slack, and JIRA service are supported.
- * See <a href="https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/services.md">GitLab documentation</a> for more info.
+ * Access for the services API. Currently only the gitlab-ci, HipChatService, Slack, and JIRA
+ * service are supported. See <a
+ * href="https://github.com/gitlabhq/gitlabhq/blob/master/doc/api/services.md">GitLab
+ * documentation</a> for more info.
  */
 public class ServicesApi extends AbstractApi {
 
-    public ServicesApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
+  public ServicesApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
 
-    /**
-     * Activates the gitlab-ci service for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/gitlab-ci</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param token           for authentication
-     * @param projectCIUrl    URL of the GitLab-CI project
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated No longer supported
-     */
-    public void setGitLabCI(Object projectIdOrPath, String token, String projectCIUrl) throws GitLabApiException {
-        final Form formData = new Form();
-        formData.param("token", token);
-        formData.param("project_url", projectCIUrl);
-        put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "gitlab-ci");
-    }
+  /**
+   * Activates the gitlab-ci service for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/gitlab-ci</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param token for authentication
+   * @param projectCIUrl URL of the GitLab-CI project
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated No longer supported
+   */
+  public void setGitLabCI(
+      final Object projectIdOrPath, final String token, final String projectCIUrl)
+      throws GitLabApiException {
+    final Form formData = new Form();
+    formData.param("token", token);
+    formData.param("project_url", projectCIUrl);
+    put(
+        Response.Status.OK,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "gitlab-ci");
+  }
 
-    /**
-     * Deletes the gitlab-ci service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/gitlab-ci</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated No longer supported
-     */
-    public void deleteGitLabCI(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "gitlab-ci");
-    }
+  /**
+   * Deletes the gitlab-ci service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/gitlab-ci</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated No longer supported
+   */
+  public void deleteGitLabCI(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "gitlab-ci");
+  }
 
-    /**
-     * Get the HipChatService notification configuration for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/hipchat</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a HipChatService instance holding the HipChatService notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public HipChatService getHipChatService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "hipchat");
-        return (response.readEntity(HipChatService.class));
-    }
+  /**
+   * Get the HipChatService notification configuration for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/hipchat</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a HipChatService instance holding the HipChatService notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public HipChatService getHipChatService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "hipchat");
+    return (response.readEntity(HipChatService.class));
+  }
 
-    /**
-     * Updates the HipChatService notification settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/hipchat</code></pre>
-     *
-     * The following properties on the HipChatService instance are utilized in the update of the settings:
-     * <p>
-     * pushEvents (optional) - Enable notifications for push events
-     * issuesEvents (optional) - Enable notifications for issue events
-     * confidentialIssuesEvents (optional) - Enable notifications for confidential issue events
-     * MergeRequestsEvents (optional) - Enable notifications for merge request events
-     * tagPushEvents (optional) - Enable notifications for tag push events
-     * noteEvents (optional) - Enable notifications for note events
-     * confidentialNoteEvents (optional) - Enable notifications for confidential note events
-     * pipelineEvents (optional) - Enable notifications for pipeline events
-     * token (required) - The room token
-     * color (optional) - The room color
-     * notify (optional) - Enable notifications
-     * room (optional) - Room name or ID
-     * apiVersion (optional) - Leave blank for default (v2)
-     * server (false) - Leave blank for default. https://hipchat.example.com
-     * notifyOnlyBrokenPipelines (optional) - Send notifications for broken pipelines
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param hipChat         the HipChatService instance holding the settings
-     * @return a HipChatService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public HipChatService updateHipChatService(Object projectIdOrPath, HipChatService hipChat) throws GitLabApiException {
-        GitLabApiForm formData = hipChat.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "hipchat");
-        return (response.readEntity(HipChatService.class));
-    }
+  /**
+   * Updates the HipChatService notification settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/hipchat</code></pre>
+   *
+   * The following properties on the HipChatService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>pushEvents (optional) - Enable notifications for push events issuesEvents (optional) -
+   * Enable notifications for issue events confidentialIssuesEvents (optional) - Enable
+   * notifications for confidential issue events MergeRequestsEvents (optional) - Enable
+   * notifications for merge request events tagPushEvents (optional) - Enable notifications for tag
+   * push events noteEvents (optional) - Enable notifications for note events confidentialNoteEvents
+   * (optional) - Enable notifications for confidential note events pipelineEvents (optional) -
+   * Enable notifications for pipeline events token (required) - The room token color (optional) -
+   * The room color notify (optional) - Enable notifications room (optional) - Room name or ID
+   * apiVersion (optional) - Leave blank for default (v2) server (false) - Leave blank for default.
+   * https://hipchat.example.com notifyOnlyBrokenPipelines (optional) - Send notifications for
+   * broken pipelines
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param hipChat the HipChatService instance holding the settings
+   * @return a HipChatService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public HipChatService updateHipChatService(
+      final Object projectIdOrPath, final HipChatService hipChat) throws GitLabApiException {
+    final GitLabApiForm formData = hipChat.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "hipchat");
+    return (response.readEntity(HipChatService.class));
+  }
 
-    /**
-     * Activates HipChatService notifications.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/hipchat</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param token           for authentication
-     * @param room            HipChatService Room
-     * @param server          HipChatService Server URL
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated replaced with {@link #updateHipChatService(Object, HipChatService) updateHipChat} method
-     */
-    public void setHipChat(Object projectIdOrPath, String token, String room, String server) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("token", token)
-                .withParam("room", room)
-                .withParam("server", server);
-        put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "hipchat");
-    }
+  /**
+   * Activates HipChatService notifications.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/hipchat</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param token for authentication
+   * @param room HipChatService Room
+   * @param server HipChatService Server URL
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated replaced with {@link #updateHipChatService(Object, HipChatService) updateHipChat}
+   *     method
+   */
+  public void setHipChat(
+      final Object projectIdOrPath, final String token, final String room, final String server)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("token", token)
+            .withParam("room", room)
+            .withParam("server", server);
+    put(
+        Response.Status.OK,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "hipchat");
+  }
 
-    /**
-     * Deletes the HipChatService service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/hipchat</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated replaced with {@link #deleteHipChatService(Object) updateHipChat} method
-     */
-    public void deleteHipChat(Object projectIdOrPath) throws GitLabApiException {
-        deleteHipChatService(projectIdOrPath);
-    }
+  /**
+   * Deletes the HipChatService service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/hipchat</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated replaced with {@link #deleteHipChatService(Object) updateHipChat} method
+   */
+  public void deleteHipChat(final Object projectIdOrPath) throws GitLabApiException {
+    deleteHipChatService(projectIdOrPath);
+  }
 
-    /**
-     * Deletes the HipChatService service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/hipchat</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteHipChatService(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "hipchat");
-    }
+  /**
+   * Deletes the HipChatService service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/hipchat</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteHipChatService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "hipchat");
+  }
 
-    /**
-     * Get the Slack notification settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/slack</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a SlackService instance holding the Slack notification settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public SlackService getSlackService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "slack");
-        return (response.readEntity(SlackService.class));
-    }
+  /**
+   * Get the Slack notification settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/slack</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a SlackService instance holding the Slack notification settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public SlackService getSlackService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "slack");
+    return (response.readEntity(SlackService.class));
+  }
 
-    /**
-     * Updates the Slack notification settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/slack</code></pre>
-     *
-     * The following properties on the SlackService instance are utilized in the update of the settings:
-     * <p>
-     * webhook (required) - https://hooks.slack.com/services/...
-     * username (optional) - username
-     * defaultChannel (optional) - Default channel to use if others are not configured
-     * notifyOnlyBrokenPipelines (optional) - Send notifications for broken pipelines
-     * notifyOnlyDefault_branch (optional) - Send notifications only for the default branch
-     * pushEvents (optional) - Enable notifications for push events
-     * issuesEvents (optional) - Enable notifications for issue events
-     * confidentialIssuesEvents (optional) - Enable notifications for confidential issue events
-     * mergeRequestsEvents (optional) - Enable notifications for merge request events
-     * tagPushEvents (optional) - Enable notifications for tag push events
-     * noteEvents (optional) - Enable notifications for note events
-     * confidentialNoteEvents (optional) - Enable notifications for confidential note events
-     * pipelineEvents (optional) - Enable notifications for pipeline events
-     * wikiPageEvents (optional) - Enable notifications for wiki page events
-     * pushChannel (optional) - The name of the channel to receive push events notifications
-     * issueChannel (optional) - The name of the channel to receive issues events notifications
-     * confidentialIssueChannel (optional) - The name of the channel to receive confidential issues events notifications
-     * mergeRequestChannel (optional) - The name of the channel to receive merge request events notifications
-     * noteChannel (optional) - The name of the channel to receive note events notifications
-     * confidentialNoteChannel (optional) - The name of the channel to receive confidential note events notifications
-     * tagPushChannel (optional) - The name of the channel to receive tag push events notifications
-     * pipelineChannel (optional) - The name of the channel to receive pipeline events notifications
-     * wikiPageChannel (optional) - The name of the channel to receive wiki page events notifications
-     *
-     * @param projectIdOrPath    id, path of the project, or a Project instance holding the project ID or path
-     * @param slackNotifications the SlackService instance holding the settings
-     * @return a SlackService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public SlackService updateSlackService(Object projectIdOrPath, SlackService slackNotifications) throws GitLabApiException {
-        GitLabApiForm formData = slackNotifications.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "slack");
-        return (response.readEntity(SlackService.class));
-    }
+  /**
+   * Updates the Slack notification settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/slack</code></pre>
+   *
+   * The following properties on the SlackService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>webhook (required) - https://hooks.slack.com/services/... username (optional) - username
+   * defaultChannel (optional) - Default channel to use if others are not configured
+   * notifyOnlyBrokenPipelines (optional) - Send notifications for broken pipelines
+   * notifyOnlyDefault_branch (optional) - Send notifications only for the default branch pushEvents
+   * (optional) - Enable notifications for push events issuesEvents (optional) - Enable
+   * notifications for issue events confidentialIssuesEvents (optional) - Enable notifications for
+   * confidential issue events mergeRequestsEvents (optional) - Enable notifications for merge
+   * request events tagPushEvents (optional) - Enable notifications for tag push events noteEvents
+   * (optional) - Enable notifications for note events confidentialNoteEvents (optional) - Enable
+   * notifications for confidential note events pipelineEvents (optional) - Enable notifications for
+   * pipeline events wikiPageEvents (optional) - Enable notifications for wiki page events
+   * pushChannel (optional) - The name of the channel to receive push events notifications
+   * issueChannel (optional) - The name of the channel to receive issues events notifications
+   * confidentialIssueChannel (optional) - The name of the channel to receive confidential issues
+   * events notifications mergeRequestChannel (optional) - The name of the channel to receive merge
+   * request events notifications noteChannel (optional) - The name of the channel to receive note
+   * events notifications confidentialNoteChannel (optional) - The name of the channel to receive
+   * confidential note events notifications tagPushChannel (optional) - The name of the channel to
+   * receive tag push events notifications pipelineChannel (optional) - The name of the channel to
+   * receive pipeline events notifications wikiPageChannel (optional) - The name of the channel to
+   * receive wiki page events notifications
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param slackNotifications the SlackService instance holding the settings
+   * @return a SlackService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public SlackService updateSlackService(
+      final Object projectIdOrPath, final SlackService slackNotifications)
+      throws GitLabApiException {
+    final GitLabApiForm formData = slackNotifications.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "slack");
+    return (response.readEntity(SlackService.class));
+  }
 
-    /**
-     * Deletes the Slack notifications service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/slack</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteSlackService(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "slack");
-    }
+  /**
+   * Deletes the Slack notifications service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/slack</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteSlackService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "slack");
+  }
 
-    /**
-     * Get the JIRA service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/jira</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a JiraService instance holding the JIRA service settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public JiraService getJiraService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "jira");
-        return (response.readEntity(JiraService.class));
-    }
+  /**
+   * Get the JIRA service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/jira</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a JiraService instance holding the JIRA service settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public JiraService getJiraService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "jira");
+    return (response.readEntity(JiraService.class));
+  }
 
-    /**
-     * Updates the JIRA service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/jira</code></pre>
-     *
-     * The following properties on the JiraService instance are utilized in the update of the settings:
-     * <p>
-     * mergeRequestsEvents (optional) - Enable notifications for merge request events
-     * commitEvents (optional) - Enable notifications for commit events
-     * url (required) - The URL to the JIRA project which is being linked to this GitLab project, e.g., https://jira.example.com.
-     * apiUrl (optional) - The JIRA API url if different than url
-     * projectKey (optional) - The short identifier for your JIRA project, all uppercase, e.g., PROJ.
-     * username (required) - The username of the user created to be used with GitLab/JIRA.
-     * password (required) - The password of the user created to be used with GitLab/JIRA.
-     * jiraIssueTransitionId (optional) - The ID of a transition that moves issues to a closed state.
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param jira            the JiraService instance holding the settings
-     * @return a JiraService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public JiraService updateJiraService(Object projectIdOrPath, JiraService jira) throws GitLabApiException {
-        GitLabApiForm formData = jira.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "jira");
-        return (response.readEntity(JiraService.class));
-    }
+  /**
+   * Updates the JIRA service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/jira</code></pre>
+   *
+   * The following properties on the JiraService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>mergeRequestsEvents (optional) - Enable notifications for merge request events commitEvents
+   * (optional) - Enable notifications for commit events url (required) - The URL to the JIRA
+   * project which is being linked to this GitLab project, e.g., https://jira.example.com. apiUrl
+   * (optional) - The JIRA API url if different than url projectKey (optional) - The short
+   * identifier for your JIRA project, all uppercase, e.g., PROJ. username (required) - The username
+   * of the user created to be used with GitLab/JIRA. password (required) - The password of the user
+   * created to be used with GitLab/JIRA. jiraIssueTransitionId (optional) - The ID of a transition
+   * that moves issues to a closed state.
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param jira the JiraService instance holding the settings
+   * @return a JiraService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public JiraService updateJiraService(final Object projectIdOrPath, final JiraService jira)
+      throws GitLabApiException {
+    final GitLabApiForm formData = jira.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "jira");
+    return (response.readEntity(JiraService.class));
+  }
 
-    /**
-     * Deletes the JIRA service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/jira</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteJiraService(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "jira");
-    }
+  /**
+   * Deletes the JIRA service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/jira</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteJiraService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "jira");
+  }
 
-    /**
-     * Get the ExternalWiki service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/external-wiki</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a ExternalWikiService instance holding the External Wiki service settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalWikiService getExternalWikiService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = this.get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "external-wiki");
-        return (response.readEntity(ExternalWikiService.class));
-    }
+  /**
+   * Get the ExternalWiki service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/external-wiki</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a ExternalWikiService instance holding the External Wiki service settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalWikiService getExternalWikiService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        this.get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "external-wiki");
+    return (response.readEntity(ExternalWikiService.class));
+  }
 
-    /**
-     * Updates the ExternalWikiService service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/external-wiki</code></pre>
-     *
-     * The following properties on the JiraService instance are utilized in the update of the settings:
-     * <p>
-     * external_wiki_url (required) - The URL to the External Wiki project which is being linked to this GitLab project, e.g., http://www.wikidot.com/
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param externalWiki            the ExternalWikiService instance holding the settings
-     * @return a ExternalWikiService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ExternalWikiService updateExternalWikiService(Object projectIdOrPath,  ExternalWikiService externalWiki) throws GitLabApiException {
-        GitLabApiForm formData = externalWiki.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "external-wiki");
-        return (response.readEntity(ExternalWikiService.class));
-    }
+  /**
+   * Updates the ExternalWikiService service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/external-wiki</code></pre>
+   *
+   * The following properties on the JiraService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>external_wiki_url (required) - The URL to the External Wiki project which is being linked to
+   * this GitLab project, e.g., http://www.wikidot.com/
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param externalWiki the ExternalWikiService instance holding the settings
+   * @return a ExternalWikiService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ExternalWikiService updateExternalWikiService(
+      final Object projectIdOrPath, final ExternalWikiService externalWiki)
+      throws GitLabApiException {
+    final GitLabApiForm formData = externalWiki.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "external-wiki");
+    return (response.readEntity(ExternalWikiService.class));
+  }
 
-    /**
-     * Deletes the ExternalWiki service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/external-wiki</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteExternalWikiService(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "external-wiki");
+  /**
+   * Deletes the ExternalWiki service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/external-wiki</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteExternalWikiService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "external-wiki");
+  }
 
-    }
+  /**
+   * Get the Mattermost service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/mattermost</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a MattermostService instance holding the Mattermost service settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MattermostService getMattermostService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        this.get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "mattermost");
+    return (response.readEntity(MattermostService.class));
+  }
 
-    /**
-     * Get the Mattermost service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/mattermost</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a MattermostService instance holding the Mattermost service settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MattermostService getMattermostService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = this.get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "mattermost");
-        return (response.readEntity(MattermostService.class));
-    }
+  /**
+   * Updates the Mattermost service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/mattermost</code></pre>
+   *
+   * The following properties on the MattermostService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>webhook (required) - https://hooks.slack.com/services/... username (optional) - username
+   * defaultChannel (optional) - Default channel to use if others are not configured
+   * notifyOnlyBrokenPipelines (optional) - Send notifications for broken pipelines
+   * notifyOnlyDefault_branch (optional) - Send notifications only for the default branch pushEvents
+   * (optional) - Enable notifications for push events issuesEvents (optional) - Enable
+   * notifications for issue events confidentialIssuesEvents (optional) - Enable notifications for
+   * confidential issue events mergeRequestsEvents (optional) - Enable notifications for merge
+   * request events tagPushEvents (optional) - Enable notifications for tag push events noteEvents
+   * (optional) - Enable notifications for note events confidentialNoteEvents (optional) - Enable
+   * notifications for confidential note events pipelineEvents (optional) - Enable notifications for
+   * pipeline events wikiPageEvents (optional) - Enable notifications for wiki page events
+   * pushChannel (optional) - The name of the channel to receive push events notifications
+   * issueChannel (optional) - The name of the channel to receive issues events notifications
+   * confidentialIssueChannel (optional) - The name of the channel to receive confidential issues
+   * events notifications mergeRequestChannel (optional) - The name of the channel to receive merge
+   * request events notifications noteChannel (optional) - The name of the channel to receive note
+   * events notifications confidentialNoteChannel (optional) - The name of the channel to receive
+   * confidential note events notifications tagPushChannel (optional) - The name of the channel to
+   * receive tag push events notifications pipelineChannel (optional) - The name of the channel to
+   * receive pipeline events notifications wikiPageChannel (optional) - The name of the channel to
+   * receive wiki page events notifications
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param mattermostNotifications the MattermostService instance holding the settings
+   * @return a MattermostService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public MattermostService updateMattermostService(
+      final Object projectIdOrPath, final MattermostService mattermostNotifications)
+      throws GitLabApiException {
+    final GitLabApiForm formData = mattermostNotifications.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "mattermost");
+    return (response.readEntity(MattermostService.class));
+  }
 
-    /**
-     * Updates the Mattermost service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/mattermost</code></pre>
-     *
-      * The following properties on the MattermostService instance are utilized in the update of the settings:
-     * <p>
-     * webhook (required) - https://hooks.slack.com/services/...
-     * username (optional) - username
-     * defaultChannel (optional) - Default channel to use if others are not configured
-     * notifyOnlyBrokenPipelines (optional) - Send notifications for broken pipelines
-     * notifyOnlyDefault_branch (optional) - Send notifications only for the default branch
-     * pushEvents (optional) - Enable notifications for push events
-     * issuesEvents (optional) - Enable notifications for issue events
-     * confidentialIssuesEvents (optional) - Enable notifications for confidential issue events
-     * mergeRequestsEvents (optional) - Enable notifications for merge request events
-     * tagPushEvents (optional) - Enable notifications for tag push events
-     * noteEvents (optional) - Enable notifications for note events
-     * confidentialNoteEvents (optional) - Enable notifications for confidential note events
-     * pipelineEvents (optional) - Enable notifications for pipeline events
-     * wikiPageEvents (optional) - Enable notifications for wiki page events
-     * pushChannel (optional) - The name of the channel to receive push events notifications
-     * issueChannel (optional) - The name of the channel to receive issues events notifications
-     * confidentialIssueChannel (optional) - The name of the channel to receive confidential issues events notifications
-     * mergeRequestChannel (optional) - The name of the channel to receive merge request events notifications
-     * noteChannel (optional) - The name of the channel to receive note events notifications
-     * confidentialNoteChannel (optional) - The name of the channel to receive confidential note events notifications
-     * tagPushChannel (optional) - The name of the channel to receive tag push events notifications
-     * pipelineChannel (optional) - The name of the channel to receive pipeline events notifications
-     * wikiPageChannel (optional) - The name of the channel to receive wiki page events notifications
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param mattermostNotifications the MattermostService instance holding the settings
-     * @return a MattermostService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public MattermostService updateMattermostService(Object projectIdOrPath,  MattermostService mattermostNotifications) throws GitLabApiException {
-        GitLabApiForm formData = mattermostNotifications.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "mattermost");
-        return (response.readEntity(MattermostService.class));
-    }
+  /**
+   * Deletes the Mattermost service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/external-wiki</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteMattermostService(final Object projectIdOrPath) throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "mattermost");
+  }
 
-    /**
-     * Deletes the Mattermost service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/external-wiki</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteMattermostService(Object projectIdOrPath) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "mattermost");
-    }
+  /**
+   * Get the Bugzilla service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/bugzilla</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a BugzillaService instance holding the External Wiki service settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BugzillaService getBugzillaService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        this.get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "bugzilla");
+    return (response.readEntity(BugzillaService.class));
+  }
 
-    /**
-     * Get the Bugzilla service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/bugzilla</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a BugzillaService instance holding the External Wiki service settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BugzillaService getBugzillaService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = this.get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "bugzilla");
-        return (response.readEntity(BugzillaService.class));
-    }
+  /**
+   * Updates the Bugzilla service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/bugzilla</code></pre>
+   *
+   * The following properties on the BugzillaService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>description (optional), description issuesUrl (required), issue url newIssueUrl (required),
+   * new Issue url projectUrl (required), project url pushEvents (optional) - Enable notifications
+   * for push events title (optional), the title for the custom issue tracker
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param bugzillaService the BugzillaService instance holding the settings
+   * @return a BugzillaService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public BugzillaService updateBugzillaService(
+      final Object projectIdOrPath, final BugzillaService bugzillaService)
+      throws GitLabApiException {
+    final GitLabApiForm formData = bugzillaService.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "bugzilla");
+    return (response.readEntity(BugzillaService.class));
+  }
 
-    /**
-     * Updates the Bugzilla service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/bugzilla</code></pre>
-     *
-     * The following properties on the BugzillaService instance are utilized in the update of the settings:
-     * <p>
-     * description (optional), description
-     * issuesUrl (required), issue url
-     * newIssueUrl (required), new Issue url
-     * projectUrl (required), project url
-     * pushEvents (optional) - Enable notifications for push events
-     * title (optional), the title for the custom issue tracker
-     * </p>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param bugzillaService the BugzillaService instance holding the settings
-     * @return a BugzillaService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public BugzillaService updateBugzillaService(Object projectIdOrPath,  BugzillaService bugzillaService) throws GitLabApiException {
-        GitLabApiForm formData = bugzillaService.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "bugzilla");
-        return (response.readEntity(BugzillaService.class));
-    }
+  /**
+   * Deletes the Bugzilla service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/bugzilla</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteBugzillaService(final Object projectIdOrPath) throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "bugzilla");
+  }
 
-    /**
-     * Deletes the Bugzilla service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/bugzilla</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteBugzillaService(Object projectIdOrPath) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "bugzilla");
+  /**
+   * Get the Custom Issue Tracker service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/custom_issue_tracker</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a ExternalWikiService instance holding the External Wiki service settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomIssueTrackerService getCustomIssueTrackerService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        this.get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "custom-issue-tracker");
+    return (response.readEntity(CustomIssueTrackerService.class));
+  }
 
-    }
+  /**
+   * Updates the Custom Issue Tracker service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/custom_issue_tracker</code></pre>
+   *
+   * The following properties on the CustomIssueTrackerService instance are utilized in the update
+   * of the settings:
+   *
+   * <p>description (optional), description issuesUrl (required), issue url newIssueUrl (required),
+   * new Issue url projectUrl (required), project url pushEvents (optional) - Enable notifications
+   * for push events title (optional), the title for the custom issue tracker
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param customIssueTracker the CustomIssueTrackerService instance holding the settings
+   * @return a CustomIssueTrackerService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public CustomIssueTrackerService updateCustomIssueTrackerService(
+      final Object projectIdOrPath, final CustomIssueTrackerService customIssueTracker)
+      throws GitLabApiException {
+    final GitLabApiForm formData = customIssueTracker.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "custom-issue-tracker");
+    return (response.readEntity(CustomIssueTrackerService.class));
+  }
 
-    /**
-     * Get the Custom Issue Tracker service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/custom_issue_tracker</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a ExternalWikiService instance holding the External Wiki service settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomIssueTrackerService getCustomIssueTrackerService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = this.get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "custom-issue-tracker");
-        return (response.readEntity(CustomIssueTrackerService.class));
-    }
+  /**
+   * Deletes the Custom Issue Tracker service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/custom_issue_tracker</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteCustomIssueTrackerService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "custom-issue-tracker");
+  }
 
-    /**
-     * Updates the Custom Issue Tracker service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/custom_issue_tracker</code></pre>
-     *
-     * The following properties on the CustomIssueTrackerService instance are utilized in the update of the settings:
-     * <p>
-     * description (optional), description
-     * issuesUrl (required), issue url
-     * newIssueUrl (required), new Issue url
-     * projectUrl (required), project url
-     * pushEvents (optional) - Enable notifications for push events
-     * title (optional), the title for the custom issue tracker
-     * </p>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param customIssueTracker the CustomIssueTrackerService instance holding the settings
-     * @return a CustomIssueTrackerService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public CustomIssueTrackerService updateCustomIssueTrackerService(Object projectIdOrPath,  CustomIssueTrackerService customIssueTracker) throws GitLabApiException {
-        GitLabApiForm formData = customIssueTracker.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "custom-issue-tracker");
-        return (response.readEntity(CustomIssueTrackerService.class));
-    }
+  /**
+   * Get Emails on push service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/services/emails-on-push</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a EmailOnPushService instance holding the Email on push settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public EmailOnPushService getEmailOnPushService(final Object projectIdOrPath)
+      throws GitLabApiException {
+    final Response response =
+        this.get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "emails-on-push");
+    return (response.readEntity(EmailOnPushService.class));
+  }
 
-    /**
-     * Deletes the Custom Issue Tracker service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/custom_issue_tracker</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteCustomIssueTrackerService(Object projectIdOrPath) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "custom-issue-tracker");
+  /**
+   * Updates the EmailsOnPush service settings for a project.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/services/emails-on-push</code></pre>
+   *
+   * The following properties on the EmailOnPushService instance are utilized in the update of the
+   * settings:
+   *
+   * <p>recipients (required), Emails separated by whitespace disable_diffs (optional), Disable code
+   * diffs send_from_committer_email (optional), Send from committer push_events (optional), Enable
+   * notifications for push events tag_push_events(optional), Enable notifications for tag push
+   * events branches_to_be_notified (optional), Branches to send notifications for. Valid options
+   * are "all", "default", "protected", and "default_and_protected". Notifications are always fired
+   * for tag pushes. The default value is "all"
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param emailsOnPush the EmailOnPushService instance holding the settings
+   * @return a EmailOnPushService instance holding the newly updated settings
+   * @throws GitLabApiException if any exception occurs
+   */
+  public EmailOnPushService updateEmailOnPushService(
+      final Object projectIdOrPath, final EmailOnPushService emailsOnPush)
+      throws GitLabApiException {
+    final GitLabApiForm formData = emailsOnPush.servicePropertiesForm();
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "services",
+            "emails-on-push");
+    return (response.readEntity(EmailOnPushService.class));
+  }
 
-    }
-
-    /**
-     * Get Emails on push service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/services/emails-on-push</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a EmailOnPushService instance holding the Email on push settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public EmailOnPushService getEmailOnPushService(Object projectIdOrPath) throws GitLabApiException {
-        Response response = this.get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "emails-on-push");
-        return (response.readEntity(EmailOnPushService.class));
-    }
-
-    /**
-     * Updates the EmailsOnPush service settings for a project.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/services/emails-on-push</code></pre>
-     *
-     * The following properties on the EmailOnPushService instance are utilized in the update of the settings:
-     * <p>
-     * recipients (required), Emails separated by whitespace
-     * disable_diffs (optional), Disable code diffs
-     * send_from_committer_email (optional), Send from committer
-     * push_events (optional), Enable notifications for push events
-     * tag_push_events(optional), Enable notifications for tag push events
-     * branches_to_be_notified (optional), Branches to send notifications for. Valid options are "all", "default",
-     *                                     "protected", and "default_and_protected". Notifications are always fired
-     *                                     for tag pushes. The default value is "all"
-     * </p>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param emailsOnPush the EmailOnPushService instance holding the settings
-     * @return a EmailOnPushService instance holding the newly updated settings
-     * @throws GitLabApiException if any exception occurs
-     */
-    public EmailOnPushService updateEmailOnPushService(Object projectIdOrPath,  EmailOnPushService emailsOnPush) throws GitLabApiException {
-        GitLabApiForm formData = emailsOnPush.servicePropertiesForm();
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "services", "emails-on-push");
-        return (response.readEntity(EmailOnPushService.class));
-    }
-
-    /**
-     * Deletes the Emails on push service for a project.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/emails-on-push</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteEmailonPushService(Object projectIdOrPath) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "services", "emails-on-push");
-
-    }
-
+  /**
+   * Deletes the Emails on push service for a project.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/services/emails-on-push</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteEmailonPushService(final Object projectIdOrPath) throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "services",
+        "emails-on-push");
+  }
 }

--- a/src/main/java/org/gitlab4j/api/SnippetsApi.java
+++ b/src/main/java/org/gitlab4j/api/SnippetsApi.java
@@ -3,10 +3,8 @@ package org.gitlab4j.api;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Snippet;
 import org.gitlab4j.api.models.Visibility;
 
@@ -15,7 +13,7 @@ import org.gitlab4j.api.models.Visibility;
  */
 public class SnippetsApi extends AbstractApi {
 
-    public SnippetsApi(GitLabApi gitLabApi) {
+    public SnippetsApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -28,13 +26,13 @@ public class SnippetsApi extends AbstractApi {
      * @return a list of authenticated user's snippets
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Snippet> getSnippets(boolean downloadContent) throws GitLabApiException {
+    public List<Snippet> getSnippets(final boolean downloadContent) throws GitLabApiException {
 
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(), "snippets");
-        List<Snippet> snippets = (response.readEntity(new GenericType<List<Snippet>>(){}));
+        final Response response = get(Response.Status.OK, getDefaultPerPageParam(), "snippets");
+        final List<Snippet> snippets = (response.readEntity(new GenericType<List<Snippet>>(){}));
 
         if (downloadContent) {
-            for (Snippet snippet : snippets) {
+            for (final Snippet snippet : snippets) {
                 snippet.setContent(getSnippetContent(snippet.getId()));
             }
         }
@@ -63,7 +61,7 @@ public class SnippetsApi extends AbstractApi {
      * @return the Pager of snippets
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Snippet> getSnippets(int itemsPerPage) throws GitLabApiException {
+    public Pager<Snippet> getSnippets(final int itemsPerPage) throws GitLabApiException {
         return (new Pager<Snippet>(this, Snippet.class, itemsPerPage, null, "snippets"));
     }
 
@@ -88,8 +86,8 @@ public class SnippetsApi extends AbstractApi {
      * @return the content of snippet
      * @throws GitLabApiException if any exception occurs
      */
-    public String getSnippetContent(Long snippetId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "snippets", snippetId, "raw");
+    public String getSnippetContent(final Long snippetId) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, null, "snippets", snippetId, "raw");
         return (response.readEntity(String.class));
     }
 
@@ -101,14 +99,14 @@ public class SnippetsApi extends AbstractApi {
      * @return the snippet with the given id
      * @throws GitLabApiException if any exception occurs
      */
-    public Snippet getSnippet(Long snippetId, boolean downloadContent) throws GitLabApiException {
+    public Snippet getSnippet(final Long snippetId, final boolean downloadContent) throws GitLabApiException {
 
         if (snippetId == null) {
             throw new RuntimeException("snippetId can't be null");
         }
 
-        Response response = get(Response.Status.OK, null, "snippets", snippetId);
-        Snippet snippet = response.readEntity(Snippet.class);
+        final Response response = get(Response.Status.OK, null, "snippets", snippetId);
+        final Snippet snippet = response.readEntity(Snippet.class);
 
         if (downloadContent) {
             snippet.setContent(getSnippetContent(snippet.getId()));
@@ -124,7 +122,7 @@ public class SnippetsApi extends AbstractApi {
      * @return the snippet with the given id
      * @throws GitLabApiException if any exception occurs
      */
-    public Snippet getSnippet(Long snippetId) throws GitLabApiException {
+    public Snippet getSnippet(final Long snippetId) throws GitLabApiException {
         return getSnippet(snippetId, false);
     }
 
@@ -136,7 +134,7 @@ public class SnippetsApi extends AbstractApi {
      * @param snippetId the ID of the snippet to get the Optional instance for
      * @return the specified Snippet as an Optional instance
      */
-    public Optional<Snippet> getOptionalSnippet(Long snippetId) {
+    public Optional<Snippet> getOptionalSnippet(final Long snippetId) {
         return (getOptionalSnippet(snippetId, false));
     }
 
@@ -149,10 +147,10 @@ public class SnippetsApi extends AbstractApi {
      * @param downloadContent indicating whether to download the snippet content
      * @return the specified Snippet as an Optional instance
      */
-    public Optional<Snippet> getOptionalSnippet(Long snippetId, boolean downloadContent) {
+    public Optional<Snippet> getOptionalSnippet(final Long snippetId, final boolean downloadContent) {
         try {
             return (Optional.ofNullable(getSnippet(snippetId, downloadContent)));
-        } catch (GitLabApiException glae) {
+        } catch (final GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
     }
@@ -166,12 +164,12 @@ public class SnippetsApi extends AbstractApi {
      * @return the created Snippet
      * @throws GitLabApiException if any exception occurs
      */
-    public Snippet createSnippet(String title, String fileName, String content) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    public Snippet createSnippet(final String title, final String fileName, final String content) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("title", title, true)
                 .withParam("file_name", fileName, true)
                 .withParam("content", content, true);
-        Response response = post(Response.Status.CREATED, formData, "snippets");
+        final Response response = post(Response.Status.CREATED, formData, "snippets");
         return (response.readEntity(Snippet.class));
     }
 
@@ -186,14 +184,14 @@ public class SnippetsApi extends AbstractApi {
      * @return the created Snippet
      * @throws GitLabApiException if any exception occurs
      */
-    public Snippet createSnippet(String title, String fileName, String content, Visibility visibility, String description) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    public Snippet createSnippet(final String title, final String fileName, final String content, final Visibility visibility, final String description) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("title", title, true)
                 .withParam("file_name", fileName, true)
                 .withParam("content", content, true)
                 .withParam("visibility", visibility)
                 .withParam("description", description);
-        Response response = post(Response.Status.CREATED, formData, "snippets");
+        final Response response = post(Response.Status.CREATED, formData, "snippets");
         return (response.readEntity(Snippet.class));
     }
 
@@ -205,7 +203,7 @@ public class SnippetsApi extends AbstractApi {
      * @param snippetId the snippet ID to remove
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteSnippet(Long snippetId) throws GitLabApiException {
+    public void deleteSnippet(final Long snippetId) throws GitLabApiException {
 
         if (snippetId == null) {
             throw new RuntimeException("snippetId can't be null");

--- a/src/main/java/org/gitlab4j/api/SystemHooksApi.java
+++ b/src/main/java/org/gitlab4j/api/SystemHooksApi.java
@@ -2,10 +2,8 @@ package org.gitlab4j.api;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.SystemHook;
 
@@ -14,7 +12,7 @@ import org.gitlab4j.api.models.SystemHook;
  */
 public class SystemHooksApi extends AbstractApi {
 
-    public SystemHooksApi(GitLabApi gitLabApi) {
+    public SystemHooksApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -41,8 +39,8 @@ public class SystemHooksApi extends AbstractApi {
      * @return the list of SystemHookEvent in the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public List<SystemHook> getSystemHooks(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "hooks");
+    public List<SystemHook> getSystemHooks(final int page, final int perPage) throws GitLabApiException {
+        final Response response = get(Response.Status.OK, getPageQueryParams(page, perPage), "hooks");
         return (response.readEntity(new GenericType<List<SystemHook>>() {}));
     }
 
@@ -55,7 +53,7 @@ public class SystemHooksApi extends AbstractApi {
      * @return a Pager of SystemHookEvent
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<SystemHook> getSystemHooks(int itemsPerPage) throws GitLabApiException {
+    public Pager<SystemHook> getSystemHooks(final int itemsPerPage) throws GitLabApiException {
         return (new Pager<SystemHook>(this, SystemHook.class, itemsPerPage, null, "hooks"));
     }
 
@@ -84,10 +82,10 @@ public class SystemHooksApi extends AbstractApi {
      * @return an SystemHookEvent instance with info on the added system hook
      * @throws GitLabApiException if any exception occurs
      */
-    public SystemHook addSystemHook(String url, String token, Boolean pushEvents,
-            Boolean tagPushEvents,  Boolean enableSslVerification) throws GitLabApiException {
+    public SystemHook addSystemHook(final String url, final String token, final Boolean pushEvents,
+            final Boolean tagPushEvents,  final Boolean enableSslVerification) throws GitLabApiException {
 
-        SystemHook systemHook = new SystemHook().withPushEvents(pushEvents)
+        final SystemHook systemHook = new SystemHook().withPushEvents(pushEvents)
             .withTagPushEvents(tagPushEvents)
             .withEnableSslVerification(enableSslVerification);
 
@@ -105,13 +103,13 @@ public class SystemHooksApi extends AbstractApi {
      * @return an SystemHookEvent instance with info on the added system hook
      * @throws GitLabApiException if any exception occurs
      */
-    public SystemHook addSystemHook(String url, String token, SystemHook systemHook) throws GitLabApiException {
+    public SystemHook addSystemHook(final String url, final String token, final SystemHook systemHook) throws GitLabApiException {
 
         if (url == null) {
             throw new RuntimeException("url cannot be null");
         }
 
-        GitLabApiForm formData = new GitLabApiForm()
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("url", url, true)
                 .withParam("token", token)
                 .withParam("push_events", systemHook.getPushEvents())
@@ -119,7 +117,7 @@ public class SystemHooksApi extends AbstractApi {
                 .withParam("merge_requests_events", systemHook.getMergeRequestsEvents())
                 .withParam("repository_update_events", systemHook.getRepositoryUpdateEvents())
                 .withParam("enable_ssl_verification", systemHook.getEnableSslVerification());
-        Response response = post(Response.Status.CREATED, formData, "hooks");
+        final Response response = post(Response.Status.CREATED, formData, "hooks");
         return (response.readEntity(SystemHook.class));
     }
 
@@ -131,7 +129,7 @@ public class SystemHooksApi extends AbstractApi {
      * @param hook the SystemHook instance to delete
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteSystemHook(SystemHook hook) throws GitLabApiException {
+    public void deleteSystemHook(final SystemHook hook) throws GitLabApiException {
 
         if (hook == null) {
             throw new RuntimeException("hook cannot be null");
@@ -148,13 +146,13 @@ public class SystemHooksApi extends AbstractApi {
      * @param hookId the ID of the system hook to delete
      * @throws GitLabApiException if any exception occurs
      */
-    public void deleteSystemHook(Long hookId) throws GitLabApiException {
+    public void deleteSystemHook(final Long hookId) throws GitLabApiException {
 
         if (hookId == null) {
             throw new RuntimeException("hookId cannot be null");
         }
 
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+        final Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
         delete(expectedStatus, null, "hooks", hookId);
     }
 
@@ -166,7 +164,7 @@ public class SystemHooksApi extends AbstractApi {
      * @param hook the SystemHookEvent instance to test
      * @throws GitLabApiException if any exception occurs
      */
-    public void testSystemHook(SystemHook hook) throws GitLabApiException {
+    public void testSystemHook(final SystemHook hook) throws GitLabApiException {
 
         if (hook == null) {
             throw new RuntimeException("hook cannot be null");
@@ -183,7 +181,7 @@ public class SystemHooksApi extends AbstractApi {
      * @param hookId the ID of the system hook to test
      * @throws GitLabApiException if any exception occurs
      */
-    public void testSystemHook(Long hookId) throws GitLabApiException {
+    public void testSystemHook(final Long hookId) throws GitLabApiException {
 
         if (hookId == null) {
             throw new RuntimeException("hookId cannot be null");

--- a/src/main/java/org/gitlab4j/api/TagsApi.java
+++ b/src/main/java/org/gitlab4j/api/TagsApi.java
@@ -5,11 +5,9 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.ProtectedTag;
@@ -19,426 +17,612 @@ import org.gitlab4j.api.utils.FileUtils;
 
 /**
  * This class provides an entry point to all the GitLab Tags and Protected Tags API calls.
+ *
  * @see <a href="https://docs.gitlab.com/ce/api/tags.html">Tags API at GitLab</a>
- * @see <a href="https://docs.gitlab.com/ce/api/protected_tags.html">Protected Tags API at GitLab</a>
+ * @see <a href="https://docs.gitlab.com/ce/api/protected_tags.html">Protected Tags API at
+ *     GitLab</a>
  */
 public class TagsApi extends AbstractApi {
 
-    public TagsApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public TagsApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return the list of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Tag> getTags(final Object projectIdOrPath) throws GitLabApiException {
+    return (getTags(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order and
+   * in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param page the page to get
+   * @param perPage the number of Tag instances per page
+   * @return the list of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Tag> getTags(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags");
+    return (response.readEntity(new GenericType<List<Tag>>() {}));
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the Pager of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<Tag> getTags(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<Tag>(
+        this,
+        Tag.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "tags"));
+  }
+
+  /**
+   * Get a Stream of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Stream of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<Tag> getTagsStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getTags(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param orderBy return tags ordered by name or updated fields. Default is updated
+   * @param sortOrder return tags sorted in asc or desc order. Default is desc
+   * @param search return list of tags matching the search criteria
+   * @return the list of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 11.8
+   */
+  public List<Tag> getTags(
+      final Object projectIdOrPath,
+      final TagOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search)
+      throws GitLabApiException {
+    return (getTags(projectIdOrPath, orderBy, sortOrder, search, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order and
+   * in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param orderBy return tags ordered by name or updated fields. Default is updated
+   * @param sortOrder return tags sorted in asc or desc order. Default is desc
+   * @param search return list of tags matching the search criteria
+   * @param page the page to get
+   * @param perPage the number of Tag instances per page
+   * @return the list of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 11.8
+   */
+  public List<Tag> getTags(
+      final Object projectIdOrPath,
+      final TagOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search,
+      final int page,
+      final int perPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("order_by", orderBy)
+            .withParam("sort", sortOrder)
+            .withParam("search", search)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags");
+    return (response.readEntity(new GenericType<List<Tag>>() {}));
+  }
+
+  /**
+   * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param orderBy return tags ordered by name or updated fields. Default is updated
+   * @param sortOrder return tags sorted in asc or desc order. Default is desc
+   * @param search return list of tags matching the search criteria
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the Pager of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 11.8
+   */
+  public Pager<Tag> getTags(
+      final Object projectIdOrPath,
+      final TagOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search,
+      final int itemsPerPage)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("order_by", orderBy)
+            .withParam("sort", sortOrder)
+            .withParam("search", search);
+    return (new Pager<Tag>(
+        this,
+        Tag.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "tags"));
+  }
+
+  /**
+   * Get a Stream of repository tags from a project, sorted by name in reverse alphabetical order.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param orderBy return tags ordered by name or updated fields. Default is updated
+   * @param sortOrder return tags sorted in asc or desc order. Default is desc
+   * @param search return list of tags matching the search criteria
+   * @return a Stream of tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 11.8
+   */
+  public Stream<Tag> getTagsStream(
+      final Object projectIdOrPath,
+      final TagOrderBy orderBy,
+      final SortOrder sortOrder,
+      final String search)
+      throws GitLabApiException {
+    return (getTags(projectIdOrPath, orderBy, sortOrder, search, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a specific repository tag determined by its name.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags/:tagName</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName the name of the tag to fetch the info for
+   * @return a Tag instance with info on the specified tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Tag getTag(final Object projectIdOrPath, final String tagName) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags",
+            urlEncode(tagName));
+    return (response.readEntity(Tag.class));
+  }
+
+  /**
+   * Get an Optional instance holding a Tag instance of a specific repository tag determined by its
+   * name.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags/:tagName</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName the name of the tag to fetch the info for
+   * @return an Optional instance with the specified project tag as the value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<Tag> getOptionalTag(final Object projectIdOrPath, final String tagName)
+      throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getTag(projectIdOrPath, tagName)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a tag on a particular ref of the given project.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName The name of the tag Must be unique for the project
+   * @param ref the git ref to place the tag on
+   * @return a Tag instance containing info on the newly created tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Tag createTag(final Object projectIdOrPath, final String tagName, final String ref)
+      throws GitLabApiException {
+    return (createTag(projectIdOrPath, tagName, ref, null, (String) null));
+  }
+
+  /**
+   * Creates a tag on a particular ref of the given project with optional message and release notes.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName The name of the tag Must be unique for the project
+   * @param ref the git ref to place the tag on
+   * @param message the message to included with the tag (optional)
+   * @param releaseNotes the release notes for the tag (optional)
+   * @return a Tag instance containing info on the newly created tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Tag createTag(
+      final Object projectIdOrPath,
+      final String tagName,
+      final String ref,
+      final String message,
+      final String releaseNotes)
+      throws GitLabApiException {
+
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("tag_name", tagName, true)
+            .withParam("ref", ref, true)
+            .withParam("message", message)
+            .withParam("release_description", releaseNotes);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags");
+    return (response.readEntity(Tag.class));
+  }
+
+  /**
+   * Creates a tag on a particular ref of a given project. A message and a File instance containing
+   * the release notes are optional. This method is the same as {@link #createTag(Object, String,
+   * String, String, String)}, but instead allows the release notes to be supplied in a file.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName the name of the tag, must be unique for the project
+   * @param ref the git ref to place the tag on
+   * @param message the message to included with the tag (optional)
+   * @param releaseNotesFile a whose contents are the release notes (optional)
+   * @return a Tag instance containing info on the newly created tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Tag createTag(
+      final Object projectIdOrPath,
+      final String tagName,
+      final String ref,
+      final String message,
+      final File releaseNotesFile)
+      throws GitLabApiException {
+
+    final String releaseNotes;
+    if (releaseNotesFile != null) {
+      try {
+        releaseNotes = FileUtils.readFileContents(releaseNotesFile);
+      } catch (final IOException ioe) {
+        throw (new GitLabApiException(ioe));
+      }
+    } else {
+      releaseNotes = null;
     }
 
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return the list of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Tag> getTags(Object projectIdOrPath) throws GitLabApiException {
-        return (getTags(projectIdOrPath, getDefaultPerPage()).all());
+    return (createTag(projectIdOrPath, tagName, ref, message, releaseNotes));
+  }
+
+  /**
+   * Deletes the tag from a project with the specified tag name.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/tags/:tag_name</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName The name of the tag to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteTag(final Object projectIdOrPath, final String tagName)
+      throws GitLabApiException {
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "repository",
+        "tags",
+        urlEncode(tagName));
+  }
+
+  /**
+   * Add release notes to the existing git tag.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags/:tagName/release</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName the name of a tag
+   * @param releaseNotes release notes with markdown support
+   * @return a Tag instance containing info on the newly created tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Release createRelease(
+      final Object projectIdOrPath, final String tagName, final String releaseNotes)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("description", releaseNotes);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags",
+            urlEncode(tagName),
+            "release");
+    return (response.readEntity(Release.class));
+  }
+
+  /**
+   * Updates the release notes of a given release.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/tags/:tagName/release</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param tagName the name of a tag
+   * @param releaseNotes release notes with markdown support
+   * @return a Tag instance containing info on the newly created tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Release updateRelease(
+      final Object projectIdOrPath, final String tagName, final String releaseNotes)
+      throws GitLabApiException {
+    final Form formData = new GitLabApiForm().withParam("description", releaseNotes);
+    final Response response =
+        putWithFormData(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "repository",
+            "tags",
+            urlEncode(tagName),
+            "release");
+    return (response.readEntity(Release.class));
+  }
+
+  /**
+   * Gets a list of protected tags from a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a List of protected tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProtectedTag> getProtectedTags(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProtectedTags(projectIdOrPath, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Gets a list of protected tags from a project and in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param page the page to get
+   * @param perPage the number of Tag instances per page
+   * @return a List of tags for the specified project ID and page range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ProtectedTag> getProtectedTags(
+      final Object projectIdOrPath, final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_tags");
+    return (response.readEntity(new GenericType<List<ProtectedTag>>() {}));
+  }
+
+  /**
+   * Get a Pager of protected tags for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the Pager of protected tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<ProtectedTag> getProtectedTags(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (new Pager<ProtectedTag>(
+        this,
+        ProtectedTag.class,
+        itemsPerPage,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "protected_tags"));
+  }
+
+  /**
+   * Get a Stream of protected tags for a project.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @return a Stream of protected tags for the specified project ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<ProtectedTag> getProtectedTagsStream(final Object projectIdOrPath)
+      throws GitLabApiException {
+    return (getProtectedTags(projectIdOrPath, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Gets a single protected tag or wildcard protected tag
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name the name of the tag or wildcard
+   * @return a ProtectedTag instance with info on the specified protected tag
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedTag getProtectedTag(final Object projectIdOrPath, final String name)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_tags",
+            urlEncode(name));
+    return (response.readEntity(ProtectedTag.class));
+  }
+
+  /**
+   * Get an Optional instance holding a protected tag or wildcard protected tag.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name the name of the tag or wildcard
+   * @return an Optional instance with the specified protected tag as the value
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Optional<ProtectedTag> getOptionalProtectedTag(
+      final Object projectIdOrPath, final String name) throws GitLabApiException {
+    try {
+      return (Optional.ofNullable(getProtectedTag(projectIdOrPath, name)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
     }
+  }
 
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param page the page to get
-     * @param perPage the number of Tag instances per page
-     * @return the list of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Tag> getTags(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags");
-        return (response.readEntity(new GenericType<List<Tag>>() { }));
-    }
+  /**
+   * Protects a single repository tag or several project repository tags using a wildcard protected
+   * tag.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name the name of the tag or wildcard
+   * @param createAccessLevel the access level allowed to create
+   * @return a ProtectedTag instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ProtectedTag protectTag(
+      final Object projectIdOrPath, final String name, final AccessLevel createAccessLevel)
+      throws GitLabApiException {
+    final Form formData =
+        new GitLabApiForm()
+            .withParam("name", name, true)
+            .withParam("create_access_level", createAccessLevel);
+    final Response response =
+        post(
+            Response.Status.OK,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "protected_tags");
+    return (response.readEntity(ProtectedTag.class));
+  }
 
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the Pager of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<Tag> getTags(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Tag>(this, Tag.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags"));
-    }
-
-    /**
-     * Get a Stream of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Stream of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<Tag> getTagsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getTags(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param orderBy return tags ordered by name or updated fields. Default is updated
-     * @param sortOrder return tags sorted in asc or desc order. Default is desc
-     * @param search return list of tags matching the search criteria
-     * @return the list of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 11.8
-     */
-    public List<Tag> getTags(Object projectIdOrPath, TagOrderBy orderBy, SortOrder sortOrder, String search) throws GitLabApiException {
-        return (getTags(projectIdOrPath, orderBy, sortOrder, search, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param orderBy return tags ordered by name or updated fields. Default is updated
-     * @param sortOrder return tags sorted in asc or desc order. Default is desc
-     * @param search return list of tags matching the search criteria
-     * @param page the page to get
-     * @param perPage the number of Tag instances per page
-     * @return the list of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 11.8
-     */
-    public List<Tag> getTags(Object projectIdOrPath, TagOrderBy orderBy, SortOrder sortOrder, String search, int page, int perPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("order_by", orderBy)
-                .withParam("sort", sortOrder)
-                .withParam("search", search)
-                .withParam(PAGE_PARAM,  page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags");
-        return (response.readEntity(new GenericType<List<Tag>>() { }));
-    }
-
-    /**
-     * Get a list of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param orderBy return tags ordered by name or updated fields. Default is updated
-     * @param sortOrder return tags sorted in asc or desc order. Default is desc
-     * @param search return list of tags matching the search criteria
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the Pager of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 11.8
-     */
-    public Pager<Tag> getTags(Object projectIdOrPath, TagOrderBy orderBy, SortOrder sortOrder, String search, int itemsPerPage) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
-                .withParam("order_by", orderBy)
-                .withParam("sort", sortOrder)
-                .withParam("search", search);
-        return (new Pager<Tag>(this, Tag.class, itemsPerPage, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags"));
-    }
-
-    /**
-     * Get a Stream of repository tags from a project, sorted by name in reverse alphabetical order.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param orderBy return tags ordered by name or updated fields. Default is updated
-     * @param sortOrder return tags sorted in asc or desc order. Default is desc
-     * @param search return list of tags matching the search criteria
-     * @return a Stream of tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 11.8
-     */
-    public Stream<Tag> getTagsStream(Object projectIdOrPath, TagOrderBy orderBy, SortOrder sortOrder, String search) throws GitLabApiException {
-        return (getTags(projectIdOrPath, orderBy, sortOrder, search, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a specific repository tag determined by its name.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags/:tagName</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName the name of the tag to fetch the info for
-     * @return a Tag instance with info on the specified tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Tag getTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName));
-        return (response.readEntity(Tag.class));
-    }
-
-    /**
-     * Get an Optional instance holding a Tag instance of a specific repository tag determined by its name.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/repository/tags/:tagName</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName the name of the tag to fetch the info for
-     * @return an Optional instance with the specified project tag as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<Tag> getOptionalTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getTag(projectIdOrPath, tagName)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a tag on a particular ref of the given project.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName The name of the tag Must be unique for the project
-     * @param ref the git ref to place the tag on
-     * @return a Tag instance containing info on the newly created tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Tag createTag(Object projectIdOrPath, String tagName, String ref) throws GitLabApiException {
-        return (createTag(projectIdOrPath, tagName, ref, null, (String)null));
-    }
-
-    /**
-     * Creates a tag on a particular ref of the given project with optional message and release notes.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName The name of the tag Must be unique for the project
-     * @param ref the git ref to place the tag on
-     * @param message the message to included with the tag (optional)
-     * @param releaseNotes the release notes for the tag (optional)
-     * @return a Tag instance containing info on the newly created tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Tag createTag(Object projectIdOrPath, String tagName, String ref, String message, String releaseNotes) throws GitLabApiException {
-
-        Form formData = new GitLabApiForm()
-                .withParam("tag_name", tagName, true)
-                .withParam("ref", ref, true)
-                .withParam("message", message)
-                .withParam("release_description", releaseNotes);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags");
-        return (response.readEntity(Tag.class));
-    }
-
-    /**
-     * Creates a tag on a particular ref of a given project. A message and a File instance containing the
-     * release notes are optional. This method is the same as {@link #createTag(Object, String, String, String, String)},
-     * but instead allows the release notes to be supplied in a file.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName the name of the tag, must be unique for the project
-     * @param ref the git ref to place the tag on
-     * @param message the message to included with the tag (optional)
-     * @param releaseNotesFile a whose contents are the release notes (optional)
-     * @return a Tag instance containing info on the newly created tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Tag createTag(Object projectIdOrPath, String tagName, String ref, String message, File releaseNotesFile) throws GitLabApiException {
-
-        String releaseNotes;
-        if (releaseNotesFile != null) {
-            try {
-                releaseNotes = FileUtils.readFileContents(releaseNotesFile);
-            } catch (IOException ioe) {
-                throw (new GitLabApiException(ioe));
-            }
-        } else {
-            releaseNotes = null;
-        }
-
-        return (createTag(projectIdOrPath, tagName, ref, message, releaseNotes));
-    }
-
-    /**
-     * Deletes the tag from a project with the specified tag name.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/repository/tags/:tag_name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName The name of the tag to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteTag(Object projectIdOrPath, String tagName) throws GitLabApiException {
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName));
-    }
-
-    /**
-     * Add release notes to the existing git tag.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/tags/:tagName/release</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName the name of a tag
-     * @param releaseNotes release notes with markdown support
-     * @return a Tag instance containing info on the newly created tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Release createRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("description", releaseNotes);
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName), "release");
-        return (response.readEntity(Release.class));
-    }
-
-    /**
-     * Updates the release notes of a given release.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/repository/tags/:tagName/release</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param tagName the name of a tag
-     * @param releaseNotes release notes with markdown support
-     * @return a Tag instance containing info on the newly created tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Release updateRelease(Object projectIdOrPath, String tagName, String releaseNotes) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("description", releaseNotes);
-        Response response = putWithFormData(Response.Status.OK, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "repository", "tags", urlEncode(tagName), "release");
-        return (response.readEntity(Release.class));
-    }
-
-    /**
-     * Gets a list of protected tags from a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a List of protected tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProtectedTag> getProtectedTags(Object projectIdOrPath) throws GitLabApiException {
-        return (getProtectedTags(projectIdOrPath, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Gets a list of protected tags from a project and in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param page the page to get
-     * @param perPage the number of Tag instances per page
-     * @return a List of tags for the specified project ID and page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ProtectedTag> getProtectedTags(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "protected_tags");
-        return (response.readEntity(new GenericType<List<ProtectedTag>>() { }));
-    }
-
-    /**
-     * Get a Pager of protected tags for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param itemsPerPage the number of Project instances that will be fetched per page
-     * @return the Pager of protected tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<ProtectedTag> getProtectedTags(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<ProtectedTag>(this, ProtectedTag.class, itemsPerPage, null, "projects", getProjectIdOrPath(projectIdOrPath), "protected_tags"));
-    }
-
-    /**
-     * Get a Stream of protected tags for a project.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @return a Stream of protected tags for the specified project ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<ProtectedTag> getProtectedTagsStream(Object projectIdOrPath) throws GitLabApiException {
-        return (getProtectedTags(projectIdOrPath, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Gets a single protected tag or wildcard protected tag
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name the name of the tag or wildcard
-     * @return a ProtectedTag instance with info on the specified protected tag
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedTag getProtectedTag(Object projectIdOrPath, String name) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "protected_tags", urlEncode(name));
-        return (response.readEntity(ProtectedTag.class));
-    }
-
-    /**
-     * Get an Optional instance holding a protected tag or wildcard protected tag.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name the name of the tag or wildcard
-     * @return an Optional instance with the specified protected tag as the value
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Optional<ProtectedTag> getOptionalProtectedTag(Object projectIdOrPath, String name) throws GitLabApiException {
-        try {
-            return (Optional.ofNullable(getProtectedTag(projectIdOrPath, name)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Protects a single repository tag or several project repository tags using a wildcard protected tag.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name the name of the tag or wildcard
-     * @param createAccessLevel the access level allowed to create
-     * @return a ProtectedTag instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ProtectedTag protectTag(Object projectIdOrPath, String name, AccessLevel createAccessLevel) throws GitLabApiException {
-        Form formData = new GitLabApiForm().withParam("name", name, true).withParam("create_access_level", createAccessLevel);
-        Response response = post(Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "protected_tags");
-        return (response.readEntity(ProtectedTag.class));
-    }
-
-    /**
-     * Unprotects the given protected tag or wildcard protected tag.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
-     *
-     * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
-     * @param name the name of the tag or wildcard
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void unprotectTag(Object projectIdOrPath, String name) throws GitLabApiException {
-        delete(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath), "protected_tags", urlEncode(name));
-    }
+  /**
+   * Unprotects the given protected tag or wildcard protected tag.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags/:name</code></pre>
+   *
+   * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or
+   *     path
+   * @param name the name of the tag or wildcard
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void unprotectTag(final Object projectIdOrPath, final String name)
+      throws GitLabApiException {
+    delete(
+        Response.Status.OK,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "protected_tags",
+        urlEncode(name));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/TodosApi.java
+++ b/src/main/java/org/gitlab4j/api/TodosApi.java
@@ -2,9 +2,7 @@ package org.gitlab4j.api;
 
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.models.Todo;
 
 /**
@@ -12,7 +10,7 @@ import org.gitlab4j.api.models.Todo;
  */
 public class TodosApi extends AbstractApi {
 
-    public TodosApi(GitLabApi gitLabApi) {
+    public TodosApi(final GitLabApi gitLabApi) {
         super(gitLabApi);
     }
 
@@ -37,7 +35,7 @@ public class TodosApi extends AbstractApi {
      * @return a Pager containing the pending Todos for the current user
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Todo> getPendingTodos(int itemsPerPage) throws GitLabApiException {
+    public Pager<Todo> getPendingTodos(final int itemsPerPage) throws GitLabApiException {
         return (getTodos(null, null, null, null, TodoState.PENDING, null, itemsPerPage));
     }
 
@@ -74,7 +72,7 @@ public class TodosApi extends AbstractApi {
      * @return a Pager containing the done Todos for the current user
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Todo> getDoneTodos(int itemsPerPage) throws GitLabApiException {
+    public Pager<Todo> getDoneTodos(final int itemsPerPage) throws GitLabApiException {
         return (getTodos(null, null, null, null, TodoState.DONE, null, itemsPerPage));
     }
 
@@ -104,7 +102,7 @@ public class TodosApi extends AbstractApi {
      * @return Stream of Todo instances
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Todo> getTodos(TodoAction action, Long authorId, Long projectId, Long groupId, TodoState state, TodoType type) throws GitLabApiException {
+    public List<Todo> getTodos(final TodoAction action, final Long authorId, final Long projectId, final Long groupId, final TodoState state, final TodoType type) throws GitLabApiException {
         return (getTodos(action, authorId, projectId, groupId, state, type, getDefaultPerPage()).all());
     }
 
@@ -122,7 +120,7 @@ public class TodosApi extends AbstractApi {
      * @return Stream of Todo instances
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Todo> getTodosStream(TodoAction action, Long authorId, Long projectId, Long groupId, TodoState state, TodoType type) throws GitLabApiException {
+    public Stream<Todo> getTodosStream(final TodoAction action, final Long authorId, final Long projectId, final Long groupId, final TodoState state, final TodoType type) throws GitLabApiException {
         return (getTodos(action, authorId, projectId, groupId, state, type, getDefaultPerPage()).stream());
     }
 
@@ -143,8 +141,8 @@ public class TodosApi extends AbstractApi {
      * @return a list of pages in todo for the specified range
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Todo> getTodos(TodoAction action, Long authorId, Long projectId, Long groupId, TodoState state, TodoType type, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
+    public Pager<Todo> getTodos(final TodoAction action, final Long authorId, final Long projectId, final Long groupId, final TodoState state, final TodoType type, final int itemsPerPage) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm()
                 .withParam("action", action, false)
                 .withParam("author_id", authorId, false)
                 .withParam("project_id", projectId, false)
@@ -164,9 +162,9 @@ public class TodosApi extends AbstractApi {
      * @return todo instance with info on the created page
      * @throws GitLabApiException if any exception occurs
      */
-    public Todo markAsDone(Long todoId) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm();
-        Response response = post(Response.Status.OK, formData, "todos", todoId, "mark_as_done");
+    public Todo markAsDone(final Long todoId) throws GitLabApiException {
+        final GitLabApiForm formData = new GitLabApiForm();
+        final Response response = post(Response.Status.OK, formData, "todos", todoId, "mark_as_done");
         return (response.readEntity(Todo.class));
     }
 
@@ -178,7 +176,7 @@ public class TodosApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public void markAllAsDone() throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm();
+        final GitLabApiForm formData = new GitLabApiForm();
         post(Response.Status.NO_CONTENT, formData, "todos", "mark_as_done");
     }
 }

--- a/src/main/java/org/gitlab4j/api/UserApi.java
+++ b/src/main/java/org/gitlab4j/api/UserApi.java
@@ -6,11 +6,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
+import jakarta.ws.rs.core.Form;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.CustomAttribute;
 import org.gitlab4j.api.models.Email;
@@ -29,1302 +27,1434 @@ import org.gitlab4j.api.utils.EmailChecker;
  */
 public class UserApi extends AbstractApi {
 
-    private boolean customAttributesEnabled = false;
-
-    public UserApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
-    }
-
-    /**
-     * Enables custom attributes to be returned when fetching User instances.
-     */
-    public void enableCustomAttributes() {
-        customAttributesEnabled = true;
-    }
-
-    /**
-     * Disables custom attributes to be returned when fetching User instances.
-     */
-    public void disableCustomAttributes() {
-        customAttributesEnabled = false;
-    }
-
-    /**
-     * <p>Get a list of users.</p>
-     *
-     * <strong>WARNING:</strong> Do not use this method to fetch users from https://gitlab.com,
-     * gitlab.com has many 1,000,000's of users and it will a long time to fetch all of them.
-     * Instead use {@link #getUsers(int itemsPerPage)} which will return a Pager of Group instances.
-     *
-     * <pre><code>GitLab Endpoint: GET /users</code></pre>
-     *
-     * @return a list of Users
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getUsers() throws GitLabApiException {
-
-        String url = this.gitLabApi.getGitLabServerUrl();
-        if (url.startsWith("https://gitlab.com")) {
-            GitLabApi.getLogger().warning("Fetching all users from " + url +
-                    " may take many minutes to complete, use Pager<User> getUsers(int) instead.");
-        }
-
-        return (getUsers(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of users using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /users</code></pre>
-     *
-     * @param page    the page to get
-     * @param perPage the number of users per page
-     * @return the list of Users in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getUsers(int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage, customAttributesEnabled), "users");
-        return (response.readEntity(new GenericType<List<User>>() {}));
-    }
-
-    /**
-     * Get a Pager of users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users</code></pre>
-     *
-     * @param itemsPerPage the number of User instances that will be fetched per page
-     * @return a Pager of User
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<User> getUsers(int itemsPerPage) throws GitLabApiException {
-        return (new Pager<User>(this, User.class, itemsPerPage, createGitLabApiForm().asMap(), "users"));
-    }
-
-    /**
-     * Get a Stream of users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users</code></pre>
-     *
-     * @return a Stream of Users.
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<User> getUsersStream() throws GitLabApiException {
-        return (getUsers(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of active users
-     *
-     * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
-     *
-     * @return a list of active Users
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getActiveUsers() throws GitLabApiException {
-        return (getActiveUsers(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of active users using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
-     *
-     * @param page the page to get
-     * @param perPage the number of users per page
-     * @return the list of active Users in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getActiveUsers(int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm()
-                .withParam("active", true)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "users");
-        return (response.readEntity(new GenericType<List<User>>() {}));
-    }
-
-    /**
-     * Get a Pager of active users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
-     *
-     * @param itemsPerPage the number of active User instances that will be fetched per page
-     * @return a Pager of active User
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<User> getActiveUsers(int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm().withParam("active", true);
-        return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
-    }
-
-    /**
-     * Get a Stream of active users
-     *
-     * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
-     *
-     * @return a Stream of active Users
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<User> getActiveUsersStream() throws GitLabApiException {
-        return (getActiveUsers(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Blocks the specified user. Available only for admin.
-     *
-     * <pre><code>GitLab Endpoint: POST /users/:id/block</code></pre>
-     *
-     * @param userId the ID of the user to block
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void blockUser(Long userId) throws GitLabApiException {
-        if (userId == null) {
-            throw new RuntimeException("userId cannot be null");
-        }
-
-        if (isApiVersion(ApiVersion.V3)) {
-            put(Response.Status.CREATED, null, "users", userId, "block");
-        } else {
-            post(Response.Status.CREATED, (Form) null, "users", userId, "block");
-        }
-    }
-
-    /**
-     * Unblocks the specified user. Available only for admin.
-     *
-     * <pre><code>GitLab Endpoint: POST /users/:id/unblock</code></pre>
-     *
-     * @param userId the ID of the user to unblock
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void unblockUser(Long userId) throws GitLabApiException {
-
-        if (userId == null) {
-            throw new RuntimeException("userId cannot be null");
-        }
-
-        if (isApiVersion(ApiVersion.V3)) {
-            put(Response.Status.CREATED, null, "users", userId, "unblock");
-        } else {
-            post(Response.Status.CREATED, (Form) null, "users", userId, "unblock");
-        }
-    }
-
-    /**
-     * Get a list of blocked users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
-     *
-     * @return a list of blocked Users
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getBlockedUsers() throws GitLabApiException {
-        return (getBlockedUsers(getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a list of blocked users using the specified page and per page settings.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
-     *
-     * @param page    the page to get
-     * @param perPage the number of users per page
-     * @return the list of blocked Users in the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> getblockedUsers(int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm()
-                .withParam("blocked", true)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "users");
-        return (response.readEntity(new GenericType<List<User>>() {}));
-    }
-
-    /**
-     * Get a Pager of blocked users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
-     *
-     * @param itemsPerPage the number of blocked User instances that will be fetched per page
-     * @return a Pager of blocked User
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<User> getBlockedUsers(int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm().withParam("blocked", true);
-        return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
-    }
-
-    /**
-     * Get a Stream of blocked users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
-     *
-     * @return a Stream of blocked Users
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<User> getBlockedUsersStream() throws GitLabApiException {
-        return (getBlockedUsers(getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id</code></pre>
-     *
-     * @param userId the ID of the user to get
-     * @return the User instance for the specified user ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User getUser(Long userId) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("with_custom_attributes", customAttributesEnabled);
-        Response response = get(Response.Status.OK, formData.asMap(), "users", userId);
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * Get a single user as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id</code></pre>
-     *
-     * @param userId the ID of the user to get
-     * @return the User for the specified user ID as an Optional instance
-     */
-    public Optional<User> getOptionalUser(Long userId) {
-        try {
-            return (Optional.ofNullable(getUser(userId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Lookup a user by username.  Returns null if not found.
-     *
-     * <p>NOTE: This is for admin users only.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /users?username=:username</code></pre>
-     *
-     * @param username the username of the user to get
-     * @return the User instance for the specified username, or null if not found
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User getUser(String username) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm()
-                .withParam("username", username, true)
-                .withParam(PAGE_PARAM, 1)
-                .withParam(PER_PAGE_PARAM, 1);
-        Response response = get(Response.Status.OK, formData.asMap(), "users");
-        List<User> users = response.readEntity(new GenericType<List<User>>() {});
-        return (users.isEmpty() ? null : users.get(0));
-    }
-
-    /**
-     * Lookup a user by username and return an Optional instance.
-     *
-     * <p>NOTE: This is for admin users only.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /users?username=:username</code></pre>
-     *
-     * @param username the username of the user to get
-     * @return the User for the specified username as an Optional instance
-     */
-    public Optional<User> getOptionalUser(String username) {
-        try {
-            return (Optional.ofNullable(getUser(username)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Lookup a user by email address.  Returns null if not found.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param email the email of the user to get
-     * @return the User instance for the specified email, or null if not found
-     * @throws GitLabApiException if any exception occurs
-     * @throws IllegalArgumentException if email is not valid
-     */
-    public User getUserByEmail(String email) throws GitLabApiException {
-
-        if (!EmailChecker.isValidEmail(email)) {
-            throw new IllegalArgumentException("email is not valid");
-        }
-
-        List<User> users = findUsers(email, 1, 1);
-        return (users.isEmpty() ? null : users.get(0));
-    }
-
-    /**
-     * Lookup a user by email address and returns an Optional with the User instance as the value.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param email the email of the user to get
-     * @return the User for the specified email as an Optional instance
-     */
-    public Optional<User> getOptionalUserByEmail(String email) {
-        try {
-            return (Optional.ofNullable(getUserByEmail(email)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Lookup a user by external UID.  Returns null if not found.
-     *
-     * <p>NOTE: This is for admin users only.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /users?extern_uid=:externalUid&amp;provider=:provider</code></pre>
-     *
-     * @param provider the provider of the external uid
-     * @param externalUid the external UID of the user
-     * @return the User instance for the specified external UID, or null if not found
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User getUserByExternalUid(String provider, String externalUid) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm()
-                .withParam("provider", provider, true)
-                .withParam("extern_uid", externalUid, true)
-                .withParam(PAGE_PARAM, 1)
-                .withParam(PER_PAGE_PARAM, 1);
-        Response response = get(Response.Status.OK, formData.asMap(), "users");
-        List<User> users = response.readEntity(new GenericType<List<User>>() {});
-        return (users.isEmpty() ? null : users.get(0));
-    }
-
-    /**
-     * Lookup a user by external UID and return an Optional instance.
-     *
-     * <p>NOTE: This is for admin users only.</p>
-     *
-     * <pre><code>GitLab Endpoint: GET /users?extern_uid=:externUid&amp;provider=:provider</code></pre>
-     *
-     * @param provider the provider of the external uid
-     * @param externalUid the external UID of the user
-     * @return the User for the specified external UID as an Optional instance
-     */
-    public Optional<User> getOptionalUserByExternalUid(String provider, String externalUid) {
-        try {
-            return (Optional.ofNullable(getUserByExternalUid(provider, externalUid)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Search users by Email or username
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param emailOrUsername the email or username to search for
-     * @return the User List with the email or username like emailOrUsername
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> findUsers(String emailOrUsername) throws GitLabApiException {
-        return (findUsers(emailOrUsername, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Search users by Email or username in the specified page range.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param emailOrUsername the email or username to search for
-     * @param page            the page to get
-     * @param perPage         the number of users per page
-     * @return the User List with the email or username like emailOrUsername in the specified page range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<User> findUsers(String emailOrUsername, int page, int perPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm()
-                .withParam("search", emailOrUsername, true)
-                .withParam(PAGE_PARAM, page)
-                .withParam(PER_PAGE_PARAM, perPage);
-        Response response = get(Response.Status.OK, formData.asMap(), "users");
-        return (response.readEntity(new GenericType<List<User>>() {
-        }));
-    }
-
-    /**
-     * Search users by Email or username and return a Pager
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param emailOrUsername the email or username to search for
-     * @param itemsPerPage    the number of Project instances that will be fetched per page
-     * @return the User Pager with the email or username like emailOrUsername
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<User> findUsers(String emailOrUsername, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = createGitLabApiForm().withParam("search", emailOrUsername, true);
-        return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
-    }
-
-    /**
-     * Search users by Email or username.
-     *
-     * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
-     *
-     * @param emailOrUsername the email or username to search for
-     * @return a Stream of User instances with the email or username like emailOrUsername
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<User> findUsersStream(String emailOrUsername) throws GitLabApiException {
-        return (findUsers(emailOrUsername, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * <p>Creates a new user. Note only administrators can create new users.
-     * Either password or reset_password should be specified (reset_password takes priority).</p>
-     *
-     * <p>If both the User object's projectsLimit and the parameter projectsLimit is specified
-     * the parameter will take precedence.</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /users</code></pre>
-     *
-     * <p>The following properties of the provided User instance can be set during creation:<pre><code> email (required) - Email
-     * username (required) - Username
-     * name (required) - Name
-     * skype (optional) - Skype ID
-     * linkedin (optional) - LinkedIn
-     * twitter (optional) - Twitter account
-     * websiteUrl (optional) - Website URL
-     * organization (optional) - Organization name
-     * projectsLimit (optional) - Number of projects user can create
-     * externUid (optional) - External UID
-     * provider (optional) - External provider name
-     * bio (optional) - User's biography
-     * location (optional) - User's location
-     * admin (optional) - User is admin - true or false (default)
-     * canCreateGroup (optional) - User can create groups - true or false
-     * skipConfirmation (optional) - Skip confirmation - true or false (default)
-     * external (optional) - Flags the user as external - true or false(default)
-     * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
-     * </code></pre>
-     *
-     * @param user          the User instance with the user info to create
-     * @param password      the password for the new user
-     * @param projectsLimit the maximum number of project
-     * @return created User instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link #createUser(User, CharSequence, boolean)}
-     */
-    @Deprecated
-    public User createUser(User user, CharSequence password, Integer projectsLimit) throws GitLabApiException {
-        Form formData = userToForm(user, projectsLimit, password, null, true);
-        Response response = post(Response.Status.CREATED, formData, "users");
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * <p>Creates a new user. Note only administrators can create new users.
-     * Either password or resetPassword should be specified (resetPassword takes priority).</p>
-     *
-     * <pre><code>GitLab Endpoint: POST /users</code></pre>
-     *
-     * <p>The following properties of the provided User instance can be set during creation:<pre><code> email (required) - Email
-     * username (required) - Username
-     * name (required) - Name
-     * skype (optional) - Skype ID
-     * linkedin (optional) - LinkedIn
-     * twitter (optional) - Twitter account
-     * websiteUrl (optional) - Website URL
-     * organization (optional) - Organization name
-     * projectsLimit (optional) - Number of projects user can create
-     * externUid (optional) - External UID
-     * provider (optional) - External provider name
-     * bio (optional) - User's biography
-     * location (optional) - User's location
-     * admin (optional) - User is admin - true or false (default)
-     * canCreateGroup (optional) - User can create groups - true or false
-     * skipConfirmation (optional) - Skip confirmation - true or false (default)
-     * external (optional) - Flags the user as external - true or false(default)
-     * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
-     * </code></pre>
-     *
-     * @param user          the User instance with the user info to create
-     * @param password      the password for the new user
-     * @param resetPassword whether to send a password reset link
-     * @return created User instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User createUser(User user, CharSequence password, boolean resetPassword) throws GitLabApiException {
-        Form formData = userToForm(user, null, password, resetPassword, true);
-        Response response = post(Response.Status.CREATED, formData, "users");
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * <p>Modifies an existing user. Only administrators can change attributes of a user.</p>
-     *
-     * <pre><code>GitLab Endpoint: PUT /users</code></pre>
-     *
-     * <p>The following properties of the provided User instance can be set during update:<pre><code> email (required) - Email
-     * username (required) - Username
-     * name (required) - Name
-     * skype (optional) - Skype ID
-     * linkedin (optional) - LinkedIn
-     * twitter (optional) - Twitter account
-     * websiteUrl (optional) - Website URL
-     * organization (optional) - Organization name
-     * projectsLimit (optional) - Number of projects user can create
-     * externUid (optional) - External UID
-     * provider (optional) - External provider name
-     * bio (optional) - User's biography
-     * location (optional) - User's location
-     * admin (optional) - User is admin - true or false (default)
-     * canCreateGroup (optional) - User can create groups - true or false
-     * skipConfirmation (optional) - Skip confirmation - true or false (default)
-     * external (optional) - Flags the user as external - true or false(default)
-     * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
-     * </code></pre>
-     *
-     * @param user     the User instance with the user info to modify
-     * @param password the new password for the user
-     * @return the modified User instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User updateUser(User user, CharSequence password) throws GitLabApiException {
-        Form form = userToForm(user, null, password, false, false);
-        Response response = put(Response.Status.OK, form.asMap(), "users", user.getId());
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * Modifies an existing user. Only administrators can change attributes of a user.
-     *
-     * <pre><code>GitLab Endpoint: PUT /users/:id</code></pre>
-     *
-     * <p>The following properties of the provided User instance can be set during update:<pre><code> email (required) - Email
-     * username (required) - Username
-     * name (required) - Name
-     * skype (optional) - Skype ID
-     * linkedin (optional) - LinkedIn
-     * twitter (optional) - Twitter account
-     * websiteUrl (optional) - Website URL
-     * organization (optional) - Organization name
-     * projectsLimit (optional) - Number of projects user can create
-     * externUid (optional) - External UID
-     * provider (optional) - External provider name
-     * bio (optional) - User's biography
-     * location (optional) - User's location
-     * admin (optional) - User is admin - true or false (default)
-     * canCreateGroup (optional) - User can create groups - true or false
-     * skipConfirmation (optional) - Skip confirmation - true or false (default)
-     * external (optional) - Flags the user as external - true or false(default)
-     * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
-     * </code></pre>
-     *
-     * @param user          the User instance with the user info to modify
-     * @param password      the new password for the user
-     * @param projectsLimit the maximum number of project
-     * @return the modified User instance
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in version 6.0, replaced by {@link #updateUser(User, CharSequence)}
-     */
-    @Deprecated
-    public User modifyUser(User user, CharSequence password, Integer projectsLimit) throws GitLabApiException {
-        Form form = userToForm(user, projectsLimit, password, false, false);
-        Response response = put(Response.Status.OK, form.asMap(), "users", user.getId());
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * Deletes a user. Available only for administrators.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /users/:id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteUser(Object userIdOrUsername) throws GitLabApiException {
-        deleteUser(userIdOrUsername, null);
-    }
-
-    /**
-     * Deletes a user. Available only for administrators.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /users/:id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param hardDelete If true, contributions that would usually be moved to the
-     *                   ghost user will be deleted instead, as well as groups owned solely by this user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteUser(Object userIdOrUsername, Boolean hardDelete) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("hard_delete ", hardDelete);
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, formData.asMap(), "users", getUserIdOrUsername(userIdOrUsername));
-    }
-
-    /**
-     * Get currently authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: GET /user</code></pre>
-     *
-     * @return the User instance for the currently authenticated user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User getCurrentUser() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "user");
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * Get a list of currently authenticated user's SSH keys.
-     *
-     * <pre><code>GitLab Endpoint: GET /user/keys</code></pre>
-     *
-     * @return a list of currently authenticated user's SSH keys
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<SshKey> getSshKeys() throws GitLabApiException {
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(), "user", "keys");
-        return (response.readEntity(new GenericType<List<SshKey>>() {}));
-    }
-
-    /**
-     * Get a list of a specified user's SSH keys. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/keys</code></pre>
-     *
-     * @param userId the user ID to get the SSH keys for
-     * @return a list of a specified user's SSH keys
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<SshKey> getSshKeys(Long userId) throws GitLabApiException {
-
-        if (userId == null) {
-            throw new RuntimeException("userId cannot be null");
-        }
-
-        Response response = get(Response.Status.OK, getDefaultPerPageParam(), "users", userId, "keys");
-        List<SshKey> keys = response.readEntity(new GenericType<List<SshKey>>() {});
-
-        if (keys != null) {
-            keys.forEach(key -> key.setUserId(userId));
-        }
-
-        return (keys);
-    }
-
-    /**
-     * Get a single SSH Key.
-     *
-     * <pre><code>GitLab Endpoint: GET /user/keys/:key_id</code></pre>
-     *
-     * @param keyId the ID of the SSH key.
-     * @return an SshKey instance holding the info on the SSH key specified by keyId
-     * @throws GitLabApiException if any exception occurs
-     */
-    public SshKey getSshKey(Long keyId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "user", "keys", keyId);
-        return (response.readEntity(SshKey.class));
-    }
-
-    /**
-     * Get a single SSH Key as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /user/keys/:key_id</code></pre>
-     *
-     * @param keyId the ID of the SSH key
-     * @return an SshKey as an Optional instance holding the info on the SSH key specified by keyId
-     */
-    public Optional<SshKey> getOptionalSshKey(Long keyId) {
-        try {
-            return (Optional.ofNullable(getSshKey(keyId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new key owned by the currently authenticated user.
-     *
-     * <pre><code>GitLab Endpoint: POST /user/keys</code></pre>
-     *
-     * @param title the new SSH Key's title
-     * @param key   the new SSH key
-     * @return an SshKey instance with info on the added SSH key
-     * @throws GitLabApiException if any exception occurs
-     */
-    public SshKey addSshKey(String title, String key) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("title", title).withParam("key", key);
-        Response response = post(Response.Status.CREATED, formData, "user", "keys");
-        return (response.readEntity(SshKey.class));
-    }
-
-    /**
-     * Create new key owned by specified user. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: POST /users/:id/keys</code></pre>
-     *
-     * @param userId the ID of the user to add the SSH key for
-     * @param title  the new SSH Key's title
-     * @param key    the new SSH key
-     * @return an SshKey instance with info on the added SSH key
-     * @throws GitLabApiException if any exception occurs
-     */
-    public SshKey addSshKey(Long userId, String title, String key) throws GitLabApiException {
-
-        if (userId == null) {
-            throw new RuntimeException("userId cannot be null");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("title", title).withParam("key", key);
-        Response response = post(Response.Status.CREATED, formData, "users", userId, "keys");
-        SshKey sshKey = response.readEntity(SshKey.class);
-        if (sshKey != null) {
-            sshKey.setUserId(userId);
-        }
-
-        return (sshKey);
-    }
-
-    /**
-     * Deletes key owned by currently authenticated user. This is an idempotent function and calling it
-     * on a key that is already deleted or not available results in success.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /user/keys/:key_id</code></pre>
-     *
-     * @param keyId the key ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteSshKey(Long keyId) throws GitLabApiException {
-
-        if (keyId == null) {
-            throw new RuntimeException("keyId cannot be null");
-        }
-
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "user", "keys", keyId);
-    }
-
-    /**
-     * Deletes key owned by a specified user. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /users/:id/keys/:key_id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param keyId  the key ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteSshKey(Object userIdOrUsername, Long keyId) throws GitLabApiException {
-
-        if (keyId == null) {
-            throw new RuntimeException("keyId cannot be null");
-        }
-
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "users", getUserIdOrUsername(userIdOrUsername), "keys", keyId);
-    }
-
-    /**
-     * Get a list of a specified user's impersonation tokens.  Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/impersonation_tokens</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @return a list of a specified user's impersonation tokens
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ImpersonationToken> getImpersonationTokens(Object userIdOrUsername) throws GitLabApiException {
-        return (getImpersonationTokens(userIdOrUsername, null));
-    }
-
-    /**
-     * Get a list of a specified user's impersonation tokens.  Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/impersonation_tokens</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param state  the state of impersonation tokens to list (ALL, ACTIVE, INACTIVE)
-     * @return a list of a specified user's impersonation tokens
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<ImpersonationToken> getImpersonationTokens(Object userIdOrUsername, ImpersonationState state) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("state", state)
-                .withParam(PER_PAGE_PARAM, getDefaultPerPage());
-        Response response = get(Response.Status.OK, formData.asMap(), "users", getUserIdOrUsername(userIdOrUsername), "impersonation_tokens");
-        return (response.readEntity(new GenericType<List<ImpersonationToken>>() {}));
-    }
-
-    /**
-     * Get an impersonation token of a user.  Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/impersonation_tokens/:impersonation_token_id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param tokenId the impersonation token ID to get
-     * @return the specified impersonation token
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ImpersonationToken getImpersonationToken(Object userIdOrUsername, Long tokenId) throws GitLabApiException {
-
-        if (tokenId == null) {
-            throw new RuntimeException("tokenId cannot be null");
-        }
-
-        Response response = get(Response.Status.OK, null, "users", getUserIdOrUsername(userIdOrUsername), "impersonation_tokens", tokenId);
-        return (response.readEntity(ImpersonationToken.class));
-    }
-
-    /**
-     * Get an impersonation token of a user as an Optional instance. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:user_id/impersonation_tokens/:impersonation_token_id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param tokenId the impersonation token ID to get
-     * @return the specified impersonation token as an Optional instance
-     */
-    public Optional<ImpersonationToken> getOptionalImpersonationToken(Object userIdOrUsername, Long tokenId) {
-        try {
-            return (Optional.ofNullable(getImpersonationToken(userIdOrUsername, tokenId)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Create an impersonation token.  Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: POST /users/:user_id/impersonation_tokens</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param name the name of the impersonation token, required
-     * @param expiresAt the expiration date of the impersonation token, optional
-     * @param scopes an array of scopes of the impersonation token
-     * @return the created ImpersonationToken instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public ImpersonationToken createImpersonationToken(Object userIdOrUsername, String name, Date expiresAt, Scope[] scopes) throws GitLabApiException {
-
-        if (scopes == null || scopes.length == 0) {
-            throw new RuntimeException("scopes cannot be null or empty");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("name", name, true)
-                .withParam("expires_at", expiresAt);
-
-        for (Scope scope : scopes) {
-            formData.withParam("scopes[]", scope.toString());
-        }
-
-        Response response = post(Response.Status.CREATED, formData, "users", getUserIdOrUsername(userIdOrUsername), "impersonation_tokens");
-        return (response.readEntity(ImpersonationToken.class));
-    }
-
-    /**
-     * Revokes an impersonation token. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /users/:user_id/impersonation_tokens/:impersonation_token_id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param tokenId the impersonation token ID to revoke
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void revokeImpersonationToken(Object userIdOrUsername, Long tokenId) throws GitLabApiException {
-
-        if (tokenId == null) {
-            throw new RuntimeException("tokenId cannot be null");
-        }
-
-        Response.Status expectedStatus = (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
-        delete(expectedStatus, null, "users", getUserIdOrUsername(userIdOrUsername), "impersonation_tokens", tokenId);
-    }
-
-    /**
-     * Populate the REST form with data from the User instance.
-     *
-     * @param user          the User instance to populate the Form instance with
-     * @param projectsLimit the maximum number of projects the user is allowed (optional)
-     * @param password      the password, required when creating a new user
-     * @param create        whether the form is being populated to create a new user
-     * @return the populated Form instance
-     */
-    Form userToForm(User user, Integer projectsLimit, CharSequence password, Boolean resetPassword, boolean create) {
-
-        if (create) {
-            if ((password == null || password.toString().trim().isEmpty()) && !resetPassword) {
-                throw new IllegalArgumentException("either password or reset_password must be set");
-            }
-        }
-
-        projectsLimit = (projectsLimit == null) ? user.getProjectsLimit() : projectsLimit;
-        String skipConfirmationFeildName = create ? "skip_confirmation" : "skip_reconfirmation";
-
-        return (new GitLabApiForm()
-                .withParam("email", user.getEmail(), create)
-                .withParam("password", password, false)
-                .withParam("reset_password", resetPassword, false)
-                .withParam("username", user.getUsername(), create)
-                .withParam("name", user.getName(), create)
-                .withParam("skype", user.getSkype(), false)
-                .withParam("linkedin", user.getLinkedin(), false)
-                .withParam("twitter", user.getTwitter(), false)
-                .withParam("website_url", user.getWebsiteUrl(), false)
-                .withParam("organization", user.getOrganization(), false)
-                .withParam("projects_limit", projectsLimit, false)
-                .withParam("extern_uid", user.getExternUid(), false)
-                .withParam("provider", user.getProvider(), false)
-                .withParam("bio", user.getBio(), false)
-                .withParam("location", user.getLocation(), false)
-                .withParam("admin", user.getIsAdmin(), false)
-                .withParam("theme_id", user.getThemeId(), false)
-                .withParam("color_scheme_id", user.getColorSchemeId(), false)
-                .withParam("can_create_group", user.getCanCreateGroup(), false)
-                .withParam(skipConfirmationFeildName, user.getSkipConfirmation(), false)
-                .withParam("external", user.getExternal(), false)
-                .withParam("shared_runners_minutes_limit", user.getSharedRunnersMinutesLimit(), false));
-    }
-
-    /**
-     * Creates custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param customAttribute the custom attribute to set
-     * @return the created CustomAttribute
-     * @throws GitLabApiException on failure while setting customAttributes
-     */
-    public CustomAttribute createCustomAttribute(final Object userIdOrUsername, final CustomAttribute customAttribute) throws GitLabApiException {
-        if (Objects.isNull(customAttribute)) {
-            throw new IllegalArgumentException("CustomAttributes can't be null");
-        }
-        return createCustomAttribute(userIdOrUsername, customAttribute.getKey(), customAttribute.getValue());
-    }
-
-    /**
-     * Creates custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param key for the customAttribute
-     * @param value  or the customAttribute
-     * @return the created CustomAttribute
-     * @throws GitLabApiException on failure while setting customAttributes
-     */
-    public CustomAttribute createCustomAttribute(final Object userIdOrUsername, final String key, final String value) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key can't be null or empty");
-        }
-        if (Objects.isNull(value) || value.trim().isEmpty()) {
-            throw new IllegalArgumentException("Value can't be null or empty");
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
-        Response response = put(Response.Status.OK, formData.asMap(),
-                "users", getUserIdOrUsername(userIdOrUsername), "custom_attributes", key);
-        return (response.readEntity(CustomAttribute.class));
-    }
-
-    /**
-     * Change custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param customAttribute the custome attribute to change
-     * @return the changed CustomAttribute
-     * @throws GitLabApiException on failure while changing customAttributes
-     */
-    public CustomAttribute changeCustomAttribute(final Object userIdOrUsername, final CustomAttribute customAttribute) throws GitLabApiException {
-
-        if (Objects.isNull(customAttribute)) {
-            throw new IllegalArgumentException("CustomAttributes can't be null");
-        }
-
-        //changing & creating custom attributes is the same call in gitlab api
-        // -> https://docs.gitlab.com/ce/api/custom_attributes.html#set-custom-attribute
-        return createCustomAttribute(userIdOrUsername, customAttribute.getKey(), customAttribute.getValue());
-    }
-
-    /**
-     * Changes custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param key    for the customAttribute
-     * @param value  for the customAttribute
-     * @return changedCustomAttribute
-     * @throws GitLabApiException on failure while changing customAttributes
-     */
-    public CustomAttribute changeCustomAttribute(final Object userIdOrUsername, final String key, final String value) throws GitLabApiException {
-        return createCustomAttribute(userIdOrUsername, key, value);
-    }
-
-    /**
-     * Delete a custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param customAttribute to remove
-     * @throws GitLabApiException on failure while deleting customAttributes
-     */
-    public void deleteCustomAttribute(final Object userIdOrUsername, final CustomAttribute customAttribute) throws GitLabApiException {
-        if (Objects.isNull(customAttribute)) {
-            throw new IllegalArgumentException("customAttributes can't be null");
-        }
-
-        deleteCustomAttribute(userIdOrUsername, customAttribute.getKey());
-    }
-
-    /**
-     * Delete a custom attribute for the given user
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param key    of the customAttribute to remove
-     * @throws GitLabApiException on failure while deleting customAttributes
-     */
-    public void deleteCustomAttribute(final Object userIdOrUsername, final String key) throws GitLabApiException {
-
-        if (Objects.isNull(key) || key.trim().isEmpty()) {
-            throw new IllegalArgumentException("Key can't be null or empty");
-        }
-
-        delete(Response.Status.OK, null, "users", getUserIdOrUsername(userIdOrUsername), "custom_attributes", key);
-    }
-
-    /**
-     * Creates a GitLabApiForm instance that will optionally include the
-     * with_custom_attributes query param if enabled.
-     *
-     * @return a GitLabApiForm instance that will optionally include the
-     * with_custom_attributes query param if enabled
-     */
-    private GitLabApiForm createGitLabApiForm() {
-        GitLabApiForm formData = new GitLabApiForm();
-        return (customAttributesEnabled ? formData.withParam("with_custom_attributes", true) : formData);
-    }
-
-    /**
-     * Uploads and sets the user's avatar for the specified user.
-     *
-     * <pre><code>PUT /users/:id</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param avatarFile the File instance of the avatar file to upload
-     * @return the updated User instance
-     * @throws GitLabApiException if any exception occurs
-     */
-    public User setUserAvatar(final Object userIdOrUsername, File avatarFile) throws GitLabApiException {
-        Response response = putUpload(Response.Status.OK, "avatar", avatarFile,  "users", getUserIdOrUsername(userIdOrUsername));
-        return (response.readEntity(User.class));
-    }
-
-    /**
-     * Get a list of emails for the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/emails</code></pre>
-     *
-     * @return a List of Email instances for the current user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Email> getEmails() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "user", "emails");
-        return (response.readEntity(new GenericType<List<Email>>() {}));
-    }
-
-    /**
-     * Get a list of a specified user’s emails. Available only for admin users.
-     *
-     * <pre><code>GitLab Endpoint: GET /user/:id/emails</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @return a List of Email instances for the specified user
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<Email> getEmails(final Object userIdOrUsername) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "users", getUserIdOrUsername(userIdOrUsername), "emails");
-        return (response.readEntity(new GenericType<List<Email>>() {}));
-    }
-
-    /**
-     * Add an email to the current user's emails.
-     *
-     * <pre><code>GitLab Endpoint: POST /user/:id/emails</code></pre>
-     *
-     * @param email the email address to add
-     * @return the Email instance for the added email
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Email addEmail(String email) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("email", email, true);
-        Response response = post(Response.Status.CREATED, formData, "user", "emails");
-        return (response.readEntity(Email.class));
-    }
-
-    /**
-     * Get a single Email instance specified by he email ID
-     *
-     * <pre><code>GitLab Endpoint: GET /user/emails/:emailId</code></pre>
-     *
-     * @param emailId the email ID to get
-     * @return the Email instance for the provided email ID
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Email getEmail(final Long emailId) throws GitLabApiException {
-        Response response = get(Response.Status.CREATED, null, "user", "emails", emailId);
-        return (response.readEntity(Email.class));
-    }
-
-    /**
-     * Add an email to the user's emails.
-     *
-     * <pre><code>GitLab Endpoint: POST /user/:id/emails</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param email the email address to add
-     * @param skipConfirmation skip confirmation and assume e-mail is verified - true or false (default)
-     * @return the Email instance for the added email
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Email addEmail(final Object userIdOrUsername, String email, Boolean skipConfirmation) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("email", email, true)
-                .withParam("skip_confirmation ", skipConfirmation);
-        Response response = post(Response.Status.CREATED, formData, "users", getUserIdOrUsername(userIdOrUsername), "emails");
-        return (response.readEntity(Email.class));
-    }
-
-    /**
-     * Deletes an email belonging to the current user.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /user/emails/:emailId</code></pre>
-     *
-     * @param emailId the email ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteEmail(final Long emailId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "user", "emails", emailId);
-    }
-
-    /**
-     * Deletes a user's email
-     *
-     * <pre><code>GitLab Endpoint: DELETE /user/:id/emails/:emailId</code></pre>
-     *
-     * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
-     * @param emailId the email ID to delete
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteEmail(final Object userIdOrUsername, final Long emailId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "users", getUserIdOrUsername(userIdOrUsername), "emails", emailId);
-    }
-
-    /**
-     * Get all GPG keys for the current user.
-     *
-     * <pre><code>GitLab Endpoint: GET /user/gpg_keys</code></pre>
-     *
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<GpgKey> listGpgKeys() throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "user", "gpg_keys");
-        return (response.readEntity(new GenericType<List<GpgKey>>() {}));
-    }
-
-    /**
-     * Add a GPG key for the current user
-     *
-     * <pre><code>GitLab Endpoint: POST /user/gpg_keys</code></pre>
-     *
-     * @param key the ASCII-armored exported public GPG key to add
-     * @throws GitLabApiException if any exception occurs
-     */
-    public GpgKey addGpgKey(final String key) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("key", key, true);
-        Response response = post(Response.Status.CREATED, formData, "user", "gpg_keys");
-        return (response.readEntity(GpgKey.class));
-    }
-
-    /**
-     * Remove a specific GPG key for the current user
-     *
-     * <pre><code>GitLab Endpoint: DELETE /user/gpg_keys/:keyId</code></pre>
-     *
-     * @param keyId the key ID  in the form if an Long(ID)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteGpgKey(final Long keyId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "user", "gpg_keys", keyId);
-    }
-
-    /**
-     * Get all GPG keys for a given user.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/gpg_keys</code></pre>
-     *
-     * @param userId the user in the form of an Long(ID)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<GpgKey> listGpgKeys(final Long userId) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "users", userId, "gpg_keys");
-        return (response.readEntity(new GenericType<List<GpgKey>>() {}));
-    }
-
-    /**
-     * Add a GPG key for a specific user
-     *
-     * <pre><code>GitLab Endpoint: POST /users/:id/gpg_keys</code></pre>
-     *
-     * @param userId the user in the form of an Long(ID)
-     * @param key the ASCII-armored exported public GPG key to add
-     * @throws GitLabApiException if any exception occurs
-     */
-    public GpgKey addGpgKey(final Long userId, final String key) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("key", key, true);
-        Response response = post(Response.Status.CREATED, formData, "users", userId, "gpg_keys");
-        return (response.readEntity(GpgKey.class));
-    }
-
-    /**
-     * Remove a specific GPG key for a specific user
-     *
-     * <pre><code>GitLab Endpoint: DELETE /users/:id/gpg_keys/:keyId</code></pre>
-     *
-     * @param userId the user in the form of an Long(ID)
-     * @param keyId the key ID  in the form if an Long(ID)
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deleteGpgKey(final Long userId, final Long keyId) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "users", userId, "gpg_keys", keyId);
-    }
-
-    /**
-     * Lists all projects and groups a user is a member of. (admin only)
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/memberships</code></pre>
-     *
-     * @param userId the ID of the user to get the memberships for
-     * @return the list of memberships of the given user
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 12.8
-     */
-    public List<Membership> getMemberships(Long userId) throws GitLabApiException {
-        return getMemberships(userId, getDefaultPerPage()).all();
-    }
-
-    /**
-     * Returns a Pager that lists all projects and groups a user is a member of. (admin only)
-     *
-     * This allows lazy-fetching of huge numbers of memberships.
-     *
-     * <pre><code>GitLab Endpoint: GET /users/:id/memberships</code></pre>
-     *
-     * @param userId the ID of the user to get the memberships for
-     * @param itemsPerPage the number of Membership instances that will be fetched per page
-     * @return a Pager of user's memberships
-     * @throws GitLabApiException if any exception occurs
-     * @since GitLab 12.8
-     */
-    public Pager<Membership> getMemberships(Long userId, int itemsPerPage) throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm();
-        return (new Pager<>(this, Membership.class, itemsPerPage, formData.asMap(), "users", userId, "memberships"));
-    }
+  private boolean customAttributesEnabled = false;
+
+  public UserApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /** Enables custom attributes to be returned when fetching User instances. */
+  public void enableCustomAttributes() {
+    customAttributesEnabled = true;
+  }
+
+  /** Disables custom attributes to be returned when fetching User instances. */
+  public void disableCustomAttributes() {
+    customAttributesEnabled = false;
+  }
+
+  /**
+   * Get a list of users. <strong>WARNING:</strong> Do not use this method to fetch users from
+   * https://gitlab.com, gitlab.com has many 1,000,000's of users and it will a long time to fetch
+   * all of them. Instead use {@link #getUsers(int itemsPerPage)} which will return a Pager of Group
+   * instances.
+   *
+   * <pre><code>GitLab Endpoint: GET /users</code></pre>
+   *
+   * @return a list of Users
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getUsers() throws GitLabApiException {
+
+    final String url = this.gitLabApi.getGitLabServerUrl();
+    if (url.startsWith("https://gitlab.com")) {
+      GitLabApi.getLogger()
+          .warning(
+              "Fetching all users from "
+                  + url
+                  + " may take many minutes to complete, use Pager<User> getUsers(int) instead.");
+    }
+
+    return (getUsers(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of users using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /users</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of users per page
+   * @return the list of Users in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getUsers(final int page, final int perPage) throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage, customAttributesEnabled),
+            "users");
+    return (response.readEntity(new GenericType<List<User>>() {}));
+  }
+
+  /**
+   * Get a Pager of users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users</code></pre>
+   *
+   * @param itemsPerPage the number of User instances that will be fetched per page
+   * @return a Pager of User
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<User> getUsers(final int itemsPerPage) throws GitLabApiException {
+    return (new Pager<User>(
+        this, User.class, itemsPerPage, createGitLabApiForm().asMap(), "users"));
+  }
+
+  /**
+   * Get a Stream of users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users</code></pre>
+   *
+   * @return a Stream of Users.
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<User> getUsersStream() throws GitLabApiException {
+    return (getUsers(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of active users
+   *
+   * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
+   *
+   * @return a list of active Users
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getActiveUsers() throws GitLabApiException {
+    return (getActiveUsers(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of active users using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of users per page
+   * @return the list of active Users in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getActiveUsers(final int page, final int perPage) throws GitLabApiException {
+    final GitLabApiForm formData =
+        createGitLabApiForm()
+            .withParam("active", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users");
+    return (response.readEntity(new GenericType<List<User>>() {}));
+  }
+
+  /**
+   * Get a Pager of active users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
+   *
+   * @param itemsPerPage the number of active User instances that will be fetched per page
+   * @return a Pager of active User
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<User> getActiveUsers(final int itemsPerPage) throws GitLabApiException {
+    final GitLabApiForm formData = createGitLabApiForm().withParam("active", true);
+    return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
+  }
+
+  /**
+   * Get a Stream of active users
+   *
+   * <pre><code>GitLab Endpoint: GET /users?active=true</code></pre>
+   *
+   * @return a Stream of active Users
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<User> getActiveUsersStream() throws GitLabApiException {
+    return (getActiveUsers(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Blocks the specified user. Available only for admin.
+   *
+   * <pre><code>GitLab Endpoint: POST /users/:id/block</code></pre>
+   *
+   * @param userId the ID of the user to block
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void blockUser(final Long userId) throws GitLabApiException {
+    if (userId == null) {
+      throw new RuntimeException("userId cannot be null");
+    }
+
+    if (isApiVersion(ApiVersion.V3)) {
+      put(Response.Status.CREATED, null, "users", userId, "block");
+    } else {
+      post(Response.Status.CREATED, (Form) null, "users", userId, "block");
+    }
+  }
+
+  /**
+   * Unblocks the specified user. Available only for admin.
+   *
+   * <pre><code>GitLab Endpoint: POST /users/:id/unblock</code></pre>
+   *
+   * @param userId the ID of the user to unblock
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void unblockUser(final Long userId) throws GitLabApiException {
+
+    if (userId == null) {
+      throw new RuntimeException("userId cannot be null");
+    }
+
+    if (isApiVersion(ApiVersion.V3)) {
+      put(Response.Status.CREATED, null, "users", userId, "unblock");
+    } else {
+      post(Response.Status.CREATED, (Form) null, "users", userId, "unblock");
+    }
+  }
+
+  /**
+   * Get a list of blocked users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
+   *
+   * @return a list of blocked Users
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getBlockedUsers() throws GitLabApiException {
+    return (getBlockedUsers(getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a list of blocked users using the specified page and per page settings.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
+   *
+   * @param page the page to get
+   * @param perPage the number of users per page
+   * @return the list of blocked Users in the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> getblockedUsers(final int page, final int perPage) throws GitLabApiException {
+    final GitLabApiForm formData =
+        createGitLabApiForm()
+            .withParam("blocked", true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users");
+    return (response.readEntity(new GenericType<List<User>>() {}));
+  }
+
+  /**
+   * Get a Pager of blocked users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
+   *
+   * @param itemsPerPage the number of blocked User instances that will be fetched per page
+   * @return a Pager of blocked User
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<User> getBlockedUsers(final int itemsPerPage) throws GitLabApiException {
+    final GitLabApiForm formData = createGitLabApiForm().withParam("blocked", true);
+    return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
+  }
+
+  /**
+   * Get a Stream of blocked users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?blocked=true</code></pre>
+   *
+   * @return a Stream of blocked Users
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<User> getBlockedUsersStream() throws GitLabApiException {
+    return (getBlockedUsers(getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id</code></pre>
+   *
+   * @param userId the ID of the user to get
+   * @return the User instance for the specified user ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User getUser(final Long userId) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("with_custom_attributes", customAttributesEnabled);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users", userId);
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Get a single user as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id</code></pre>
+   *
+   * @param userId the ID of the user to get
+   * @return the User for the specified user ID as an Optional instance
+   */
+  public Optional<User> getOptionalUser(final Long userId) {
+    try {
+      return (Optional.ofNullable(getUser(userId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Lookup a user by username. Returns null if not found.
+   *
+   * <p>NOTE: This is for admin users only.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?username=:username</code></pre>
+   *
+   * @param username the username of the user to get
+   * @return the User instance for the specified username, or null if not found
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User getUser(final String username) throws GitLabApiException {
+    final GitLabApiForm formData =
+        createGitLabApiForm()
+            .withParam("username", username, true)
+            .withParam(PAGE_PARAM, 1)
+            .withParam(PER_PAGE_PARAM, 1);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users");
+    final List<User> users = response.readEntity(new GenericType<List<User>>() {});
+    return (users.isEmpty() ? null : users.get(0));
+  }
+
+  /**
+   * Lookup a user by username and return an Optional instance.
+   *
+   * <p>NOTE: This is for admin users only.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?username=:username</code></pre>
+   *
+   * @param username the username of the user to get
+   * @return the User for the specified username as an Optional instance
+   */
+  public Optional<User> getOptionalUser(final String username) {
+    try {
+      return (Optional.ofNullable(getUser(username)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Lookup a user by email address. Returns null if not found.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param email the email of the user to get
+   * @return the User instance for the specified email, or null if not found
+   * @throws GitLabApiException if any exception occurs
+   * @throws IllegalArgumentException if email is not valid
+   */
+  public User getUserByEmail(final String email) throws GitLabApiException {
+
+    if (!EmailChecker.isValidEmail(email)) {
+      throw new IllegalArgumentException("email is not valid");
+    }
+
+    final List<User> users = findUsers(email, 1, 1);
+    return (users.isEmpty() ? null : users.get(0));
+  }
+
+  /**
+   * Lookup a user by email address and returns an Optional with the User instance as the value.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param email the email of the user to get
+   * @return the User for the specified email as an Optional instance
+   */
+  public Optional<User> getOptionalUserByEmail(final String email) {
+    try {
+      return (Optional.ofNullable(getUserByEmail(email)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Lookup a user by external UID. Returns null if not found.
+   *
+   * <p>NOTE: This is for admin users only.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?extern_uid=:externalUid&amp;provider=:provider</code>
+   * </pre>
+   *
+   * @param provider the provider of the external uid
+   * @param externalUid the external UID of the user
+   * @return the User instance for the specified external UID, or null if not found
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User getUserByExternalUid(final String provider, final String externalUid)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        createGitLabApiForm()
+            .withParam("provider", provider, true)
+            .withParam("extern_uid", externalUid, true)
+            .withParam(PAGE_PARAM, 1)
+            .withParam(PER_PAGE_PARAM, 1);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users");
+    final List<User> users = response.readEntity(new GenericType<List<User>>() {});
+    return (users.isEmpty() ? null : users.get(0));
+  }
+
+  /**
+   * Lookup a user by external UID and return an Optional instance.
+   *
+   * <p>NOTE: This is for admin users only.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?extern_uid=:externUid&amp;provider=:provider</code>
+   * </pre>
+   *
+   * @param provider the provider of the external uid
+   * @param externalUid the external UID of the user
+   * @return the User for the specified external UID as an Optional instance
+   */
+  public Optional<User> getOptionalUserByExternalUid(
+      final String provider, final String externalUid) {
+    try {
+      return (Optional.ofNullable(getUserByExternalUid(provider, externalUid)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Search users by Email or username
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param emailOrUsername the email or username to search for
+   * @return the User List with the email or username like emailOrUsername
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> findUsers(final String emailOrUsername) throws GitLabApiException {
+    return (findUsers(emailOrUsername, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Search users by Email or username in the specified page range.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param emailOrUsername the email or username to search for
+   * @param page the page to get
+   * @param perPage the number of users per page
+   * @return the User List with the email or username like emailOrUsername in the specified page
+   *     range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<User> findUsers(final String emailOrUsername, final int page, final int perPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        createGitLabApiForm()
+            .withParam("search", emailOrUsername, true)
+            .withParam(PAGE_PARAM, page)
+            .withParam(PER_PAGE_PARAM, perPage);
+    final Response response = get(Response.Status.OK, formData.asMap(), "users");
+    return (response.readEntity(new GenericType<List<User>>() {}));
+  }
+
+  /**
+   * Search users by Email or username and return a Pager
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param emailOrUsername the email or username to search for
+   * @param itemsPerPage the number of Project instances that will be fetched per page
+   * @return the User Pager with the email or username like emailOrUsername
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<User> findUsers(final String emailOrUsername, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = createGitLabApiForm().withParam("search", emailOrUsername, true);
+    return (new Pager<User>(this, User.class, itemsPerPage, formData.asMap(), "users"));
+  }
+
+  /**
+   * Search users by Email or username.
+   *
+   * <pre><code>GitLab Endpoint: GET /users?search=:email_or_username</code></pre>
+   *
+   * @param emailOrUsername the email or username to search for
+   * @return a Stream of User instances with the email or username like emailOrUsername
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<User> findUsersStream(final String emailOrUsername) throws GitLabApiException {
+    return (findUsers(emailOrUsername, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Creates a new user. Note only administrators can create new users. Either password or
+   * reset_password should be specified (reset_password takes priority).
+   *
+   * <p>If both the User object's projectsLimit and the parameter projectsLimit is specified the
+   * parameter will take precedence.
+   *
+   * <pre><code>GitLab Endpoint: POST /users</code></pre>
+   *
+   * <p>The following properties of the provided User instance can be set during creation:
+   *
+   * <pre><code> email (required) - Email
+   * username (required) - Username
+   * name (required) - Name
+   * skype (optional) - Skype ID
+   * linkedin (optional) - LinkedIn
+   * twitter (optional) - Twitter account
+   * websiteUrl (optional) - Website URL
+   * organization (optional) - Organization name
+   * projectsLimit (optional) - Number of projects user can create
+   * externUid (optional) - External UID
+   * provider (optional) - External provider name
+   * bio (optional) - User's biography
+   * location (optional) - User's location
+   * admin (optional) - User is admin - true or false (default)
+   * canCreateGroup (optional) - User can create groups - true or false
+   * skipConfirmation (optional) - Skip confirmation - true or false (default)
+   * external (optional) - Flags the user as external - true or false(default)
+   * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
+   * </code></pre>
+   *
+   * @param user the User instance with the user info to create
+   * @param password the password for the new user
+   * @param projectsLimit the maximum number of project
+   * @return created User instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #createUser(User, CharSequence,
+   *     boolean)}
+   */
+  @Deprecated
+  public User createUser(final User user, final CharSequence password, final Integer projectsLimit)
+      throws GitLabApiException {
+    final Form formData = userToForm(user, projectsLimit, password, null, true);
+    final Response response = post(Response.Status.CREATED, formData, "users");
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Creates a new user. Note only administrators can create new users. Either password or
+   * resetPassword should be specified (resetPassword takes priority).
+   *
+   * <pre><code>GitLab Endpoint: POST /users</code></pre>
+   *
+   * <p>The following properties of the provided User instance can be set during creation:
+   *
+   * <pre><code> email (required) - Email
+   * username (required) - Username
+   * name (required) - Name
+   * skype (optional) - Skype ID
+   * linkedin (optional) - LinkedIn
+   * twitter (optional) - Twitter account
+   * websiteUrl (optional) - Website URL
+   * organization (optional) - Organization name
+   * projectsLimit (optional) - Number of projects user can create
+   * externUid (optional) - External UID
+   * provider (optional) - External provider name
+   * bio (optional) - User's biography
+   * location (optional) - User's location
+   * admin (optional) - User is admin - true or false (default)
+   * canCreateGroup (optional) - User can create groups - true or false
+   * skipConfirmation (optional) - Skip confirmation - true or false (default)
+   * external (optional) - Flags the user as external - true or false(default)
+   * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
+   * </code></pre>
+   *
+   * @param user the User instance with the user info to create
+   * @param password the password for the new user
+   * @param resetPassword whether to send a password reset link
+   * @return created User instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User createUser(final User user, final CharSequence password, final boolean resetPassword)
+      throws GitLabApiException {
+    final Form formData = userToForm(user, null, password, resetPassword, true);
+    final Response response = post(Response.Status.CREATED, formData, "users");
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Modifies an existing user. Only administrators can change attributes of a user.
+   *
+   * <pre><code>GitLab Endpoint: PUT /users</code></pre>
+   *
+   * <p>The following properties of the provided User instance can be set during update:
+   *
+   * <pre><code> email (required) - Email
+   * username (required) - Username
+   * name (required) - Name
+   * skype (optional) - Skype ID
+   * linkedin (optional) - LinkedIn
+   * twitter (optional) - Twitter account
+   * websiteUrl (optional) - Website URL
+   * organization (optional) - Organization name
+   * projectsLimit (optional) - Number of projects user can create
+   * externUid (optional) - External UID
+   * provider (optional) - External provider name
+   * bio (optional) - User's biography
+   * location (optional) - User's location
+   * admin (optional) - User is admin - true or false (default)
+   * canCreateGroup (optional) - User can create groups - true or false
+   * skipConfirmation (optional) - Skip confirmation - true or false (default)
+   * external (optional) - Flags the user as external - true or false(default)
+   * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
+   * </code></pre>
+   *
+   * @param user the User instance with the user info to modify
+   * @param password the new password for the user
+   * @return the modified User instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User updateUser(final User user, final CharSequence password) throws GitLabApiException {
+    final Form form = userToForm(user, null, password, false, false);
+    final Response response = put(Response.Status.OK, form.asMap(), "users", user.getId());
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Modifies an existing user. Only administrators can change attributes of a user.
+   *
+   * <pre><code>GitLab Endpoint: PUT /users/:id</code></pre>
+   *
+   * <p>The following properties of the provided User instance can be set during update:
+   *
+   * <pre><code> email (required) - Email
+   * username (required) - Username
+   * name (required) - Name
+   * skype (optional) - Skype ID
+   * linkedin (optional) - LinkedIn
+   * twitter (optional) - Twitter account
+   * websiteUrl (optional) - Website URL
+   * organization (optional) - Organization name
+   * projectsLimit (optional) - Number of projects user can create
+   * externUid (optional) - External UID
+   * provider (optional) - External provider name
+   * bio (optional) - User's biography
+   * location (optional) - User's location
+   * admin (optional) - User is admin - true or false (default)
+   * canCreateGroup (optional) - User can create groups - true or false
+   * skipConfirmation (optional) - Skip confirmation - true or false (default)
+   * external (optional) - Flags the user as external - true or false(default)
+   * sharedRunnersMinutesLimit (optional) - Pipeline minutes quota for this user
+   * </code></pre>
+   *
+   * @param user the User instance with the user info to modify
+   * @param password the new password for the user
+   * @param projectsLimit the maximum number of project
+   * @return the modified User instance
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in version 6.0, replaced by {@link #updateUser(User, CharSequence)}
+   */
+  @Deprecated
+  public User modifyUser(final User user, final CharSequence password, final Integer projectsLimit)
+      throws GitLabApiException {
+    final Form form = userToForm(user, projectsLimit, password, false, false);
+    final Response response = put(Response.Status.OK, form.asMap(), "users", user.getId());
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Deletes a user. Available only for administrators.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /users/:id</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteUser(final Object userIdOrUsername) throws GitLabApiException {
+    deleteUser(userIdOrUsername, null);
+  }
+
+  /**
+   * Deletes a user. Available only for administrators.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /users/:id</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param hardDelete If true, contributions that would usually be moved to the ghost user will be
+   *     deleted instead, as well as groups owned solely by this user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteUser(final Object userIdOrUsername, final Boolean hardDelete)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("hard_delete ", hardDelete);
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, formData.asMap(), "users", getUserIdOrUsername(userIdOrUsername));
+  }
+
+  /**
+   * Get currently authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: GET /user</code></pre>
+   *
+   * @return the User instance for the currently authenticated user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User getCurrentUser() throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "user");
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Get a list of currently authenticated user's SSH keys.
+   *
+   * <pre><code>GitLab Endpoint: GET /user/keys</code></pre>
+   *
+   * @return a list of currently authenticated user's SSH keys
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<SshKey> getSshKeys() throws GitLabApiException {
+    final Response response = get(Response.Status.OK, getDefaultPerPageParam(), "user", "keys");
+    return (response.readEntity(new GenericType<List<SshKey>>() {}));
+  }
+
+  /**
+   * Get a list of a specified user's SSH keys. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/keys</code></pre>
+   *
+   * @param userId the user ID to get the SSH keys for
+   * @return a list of a specified user's SSH keys
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<SshKey> getSshKeys(final Long userId) throws GitLabApiException {
+
+    if (userId == null) {
+      throw new RuntimeException("userId cannot be null");
+    }
+
+    final Response response =
+        get(Response.Status.OK, getDefaultPerPageParam(), "users", userId, "keys");
+    final List<SshKey> keys = response.readEntity(new GenericType<List<SshKey>>() {});
+
+    if (keys != null) {
+      keys.forEach(key -> key.setUserId(userId));
+    }
+
+    return (keys);
+  }
+
+  /**
+   * Get a single SSH Key.
+   *
+   * <pre><code>GitLab Endpoint: GET /user/keys/:key_id</code></pre>
+   *
+   * @param keyId the ID of the SSH key.
+   * @return an SshKey instance holding the info on the SSH key specified by keyId
+   * @throws GitLabApiException if any exception occurs
+   */
+  public SshKey getSshKey(final Long keyId) throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "user", "keys", keyId);
+    return (response.readEntity(SshKey.class));
+  }
+
+  /**
+   * Get a single SSH Key as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /user/keys/:key_id</code></pre>
+   *
+   * @param keyId the ID of the SSH key
+   * @return an SshKey as an Optional instance holding the info on the SSH key specified by keyId
+   */
+  public Optional<SshKey> getOptionalSshKey(final Long keyId) {
+    try {
+      return (Optional.ofNullable(getSshKey(keyId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a new key owned by the currently authenticated user.
+   *
+   * <pre><code>GitLab Endpoint: POST /user/keys</code></pre>
+   *
+   * @param title the new SSH Key's title
+   * @param key the new SSH key
+   * @return an SshKey instance with info on the added SSH key
+   * @throws GitLabApiException if any exception occurs
+   */
+  public SshKey addSshKey(final String title, final String key) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("title", title).withParam("key", key);
+    final Response response = post(Response.Status.CREATED, formData, "user", "keys");
+    return (response.readEntity(SshKey.class));
+  }
+
+  /**
+   * Create new key owned by specified user. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: POST /users/:id/keys</code></pre>
+   *
+   * @param userId the ID of the user to add the SSH key for
+   * @param title the new SSH Key's title
+   * @param key the new SSH key
+   * @return an SshKey instance with info on the added SSH key
+   * @throws GitLabApiException if any exception occurs
+   */
+  public SshKey addSshKey(final Long userId, final String title, final String key)
+      throws GitLabApiException {
+
+    if (userId == null) {
+      throw new RuntimeException("userId cannot be null");
+    }
+
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("title", title).withParam("key", key);
+    final Response response = post(Response.Status.CREATED, formData, "users", userId, "keys");
+    final SshKey sshKey = response.readEntity(SshKey.class);
+    if (sshKey != null) {
+      sshKey.setUserId(userId);
+    }
+
+    return (sshKey);
+  }
+
+  /**
+   * Deletes key owned by currently authenticated user. This is an idempotent function and calling
+   * it on a key that is already deleted or not available results in success.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /user/keys/:key_id</code></pre>
+   *
+   * @param keyId the key ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteSshKey(final Long keyId) throws GitLabApiException {
+
+    if (keyId == null) {
+      throw new RuntimeException("keyId cannot be null");
+    }
+
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "user", "keys", keyId);
+  }
+
+  /**
+   * Deletes key owned by a specified user. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /users/:id/keys/:key_id</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param keyId the key ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteSshKey(final Object userIdOrUsername, final Long keyId)
+      throws GitLabApiException {
+
+    if (keyId == null) {
+      throw new RuntimeException("keyId cannot be null");
+    }
+
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(expectedStatus, null, "users", getUserIdOrUsername(userIdOrUsername), "keys", keyId);
+  }
+
+  /**
+   * Get a list of a specified user's impersonation tokens. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/impersonation_tokens</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @return a list of a specified user's impersonation tokens
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ImpersonationToken> getImpersonationTokens(final Object userIdOrUsername)
+      throws GitLabApiException {
+    return (getImpersonationTokens(userIdOrUsername, null));
+  }
+
+  /**
+   * Get a list of a specified user's impersonation tokens. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/impersonation_tokens</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param state the state of impersonation tokens to list (ALL, ACTIVE, INACTIVE)
+   * @return a list of a specified user's impersonation tokens
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<ImpersonationToken> getImpersonationTokens(
+      final Object userIdOrUsername, final ImpersonationState state) throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("state", state)
+            .withParam(PER_PAGE_PARAM, getDefaultPerPage());
+    final Response response =
+        get(
+            Response.Status.OK,
+            formData.asMap(),
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "impersonation_tokens");
+    return (response.readEntity(new GenericType<List<ImpersonationToken>>() {}));
+  }
+
+  /**
+   * Get an impersonation token of a user. Available only for admin users.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /users/:user_id/impersonation_tokens/:impersonation_token_id</code>
+   * </pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param tokenId the impersonation token ID to get
+   * @return the specified impersonation token
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ImpersonationToken getImpersonationToken(final Object userIdOrUsername, final Long tokenId)
+      throws GitLabApiException {
+
+    if (tokenId == null) {
+      throw new RuntimeException("tokenId cannot be null");
+    }
+
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "impersonation_tokens",
+            tokenId);
+    return (response.readEntity(ImpersonationToken.class));
+  }
+
+  /**
+   * Get an impersonation token of a user as an Optional instance. Available only for admin users.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: GET /users/:user_id/impersonation_tokens/:impersonation_token_id</code>
+   * </pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param tokenId the impersonation token ID to get
+   * @return the specified impersonation token as an Optional instance
+   */
+  public Optional<ImpersonationToken> getOptionalImpersonationToken(
+      final Object userIdOrUsername, final Long tokenId) {
+    try {
+      return (Optional.ofNullable(getImpersonationToken(userIdOrUsername, tokenId)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Create an impersonation token. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: POST /users/:user_id/impersonation_tokens</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param name the name of the impersonation token, required
+   * @param expiresAt the expiration date of the impersonation token, optional
+   * @param scopes an array of scopes of the impersonation token
+   * @return the created ImpersonationToken instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public ImpersonationToken createImpersonationToken(
+      final Object userIdOrUsername, final String name, final Date expiresAt, final Scope[] scopes)
+      throws GitLabApiException {
+
+    if (scopes == null || scopes.length == 0) {
+      throw new RuntimeException("scopes cannot be null or empty");
+    }
+
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("name", name, true).withParam("expires_at", expiresAt);
+
+    for (final Scope scope : scopes) {
+      formData.withParam("scopes[]", scope.toString());
+    }
+
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "impersonation_tokens");
+    return (response.readEntity(ImpersonationToken.class));
+  }
+
+  /**
+   * Revokes an impersonation token. Available only for admin users.
+   *
+   * <pre>
+   * <code>GitLab Endpoint: DELETE /users/:user_id/impersonation_tokens/:impersonation_token_id</code>
+   * </pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param tokenId the impersonation token ID to revoke
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void revokeImpersonationToken(final Object userIdOrUsername, final Long tokenId)
+      throws GitLabApiException {
+
+    if (tokenId == null) {
+      throw new RuntimeException("tokenId cannot be null");
+    }
+
+    final Response.Status expectedStatus =
+        (isApiVersion(ApiVersion.V3) ? Response.Status.OK : Response.Status.NO_CONTENT);
+    delete(
+        expectedStatus,
+        null,
+        "users",
+        getUserIdOrUsername(userIdOrUsername),
+        "impersonation_tokens",
+        tokenId);
+  }
+
+  /**
+   * Populate the REST form with data from the User instance.
+   *
+   * @param user the User instance to populate the Form instance with
+   * @param projectsLimit the maximum number of projects the user is allowed (optional)
+   * @param password the password, required when creating a new user
+   * @param create whether the form is being populated to create a new user
+   * @return the populated Form instance
+   */
+  Form userToForm(
+      final User user,
+      Integer projectsLimit,
+      final CharSequence password,
+      final Boolean resetPassword,
+      final boolean create) {
+
+    if (create) {
+      if ((password == null || password.toString().trim().isEmpty()) && !resetPassword) {
+        throw new IllegalArgumentException("either password or reset_password must be set");
+      }
+    }
+
+    projectsLimit = (projectsLimit == null) ? user.getProjectsLimit() : projectsLimit;
+    final String skipConfirmationFeildName = create ? "skip_confirmation" : "skip_reconfirmation";
+
+    return (new GitLabApiForm()
+        .withParam("email", user.getEmail(), create)
+        .withParam("password", password, false)
+        .withParam("reset_password", resetPassword, false)
+        .withParam("username", user.getUsername(), create)
+        .withParam("name", user.getName(), create)
+        .withParam("skype", user.getSkype(), false)
+        .withParam("linkedin", user.getLinkedin(), false)
+        .withParam("twitter", user.getTwitter(), false)
+        .withParam("website_url", user.getWebsiteUrl(), false)
+        .withParam("organization", user.getOrganization(), false)
+        .withParam("projects_limit", projectsLimit, false)
+        .withParam("extern_uid", user.getExternUid(), false)
+        .withParam("provider", user.getProvider(), false)
+        .withParam("bio", user.getBio(), false)
+        .withParam("location", user.getLocation(), false)
+        .withParam("admin", user.getIsAdmin(), false)
+        .withParam("theme_id", user.getThemeId(), false)
+        .withParam("color_scheme_id", user.getColorSchemeId(), false)
+        .withParam("can_create_group", user.getCanCreateGroup(), false)
+        .withParam(skipConfirmationFeildName, user.getSkipConfirmation(), false)
+        .withParam("external", user.getExternal(), false)
+        .withParam("shared_runners_minutes_limit", user.getSharedRunnersMinutesLimit(), false));
+  }
+
+  /**
+   * Creates custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param customAttribute the custom attribute to set
+   * @return the created CustomAttribute
+   * @throws GitLabApiException on failure while setting customAttributes
+   */
+  public CustomAttribute createCustomAttribute(
+      final Object userIdOrUsername, final CustomAttribute customAttribute)
+      throws GitLabApiException {
+    if (Objects.isNull(customAttribute)) {
+      throw new IllegalArgumentException("CustomAttributes can't be null");
+    }
+    return createCustomAttribute(
+        userIdOrUsername, customAttribute.getKey(), customAttribute.getValue());
+  }
+
+  /**
+   * Creates custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param key for the customAttribute
+   * @param value or the customAttribute
+   * @return the created CustomAttribute
+   * @throws GitLabApiException on failure while setting customAttributes
+   */
+  public CustomAttribute createCustomAttribute(
+      final Object userIdOrUsername, final String key, final String value)
+      throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key can't be null or empty");
+    }
+    if (Objects.isNull(value) || value.trim().isEmpty()) {
+      throw new IllegalArgumentException("Value can't be null or empty");
+    }
+
+    final GitLabApiForm formData = new GitLabApiForm().withParam("value", value);
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "custom_attributes",
+            key);
+    return (response.readEntity(CustomAttribute.class));
+  }
+
+  /**
+   * Change custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param customAttribute the custome attribute to change
+   * @return the changed CustomAttribute
+   * @throws GitLabApiException on failure while changing customAttributes
+   */
+  public CustomAttribute changeCustomAttribute(
+      final Object userIdOrUsername, final CustomAttribute customAttribute)
+      throws GitLabApiException {
+
+    if (Objects.isNull(customAttribute)) {
+      throw new IllegalArgumentException("CustomAttributes can't be null");
+    }
+
+    // changing & creating custom attributes is the same call in gitlab api
+    // -> https://docs.gitlab.com/ce/api/custom_attributes.html#set-custom-attribute
+    return createCustomAttribute(
+        userIdOrUsername, customAttribute.getKey(), customAttribute.getValue());
+  }
+
+  /**
+   * Changes custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param key for the customAttribute
+   * @param value for the customAttribute
+   * @return changedCustomAttribute
+   * @throws GitLabApiException on failure while changing customAttributes
+   */
+  public CustomAttribute changeCustomAttribute(
+      final Object userIdOrUsername, final String key, final String value)
+      throws GitLabApiException {
+    return createCustomAttribute(userIdOrUsername, key, value);
+  }
+
+  /**
+   * Delete a custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param customAttribute to remove
+   * @throws GitLabApiException on failure while deleting customAttributes
+   */
+  public void deleteCustomAttribute(
+      final Object userIdOrUsername, final CustomAttribute customAttribute)
+      throws GitLabApiException {
+    if (Objects.isNull(customAttribute)) {
+      throw new IllegalArgumentException("customAttributes can't be null");
+    }
+
+    deleteCustomAttribute(userIdOrUsername, customAttribute.getKey());
+  }
+
+  /**
+   * Delete a custom attribute for the given user
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param key of the customAttribute to remove
+   * @throws GitLabApiException on failure while deleting customAttributes
+   */
+  public void deleteCustomAttribute(final Object userIdOrUsername, final String key)
+      throws GitLabApiException {
+
+    if (Objects.isNull(key) || key.trim().isEmpty()) {
+      throw new IllegalArgumentException("Key can't be null or empty");
+    }
+
+    delete(
+        Response.Status.OK,
+        null,
+        "users",
+        getUserIdOrUsername(userIdOrUsername),
+        "custom_attributes",
+        key);
+  }
+
+  /**
+   * Creates a GitLabApiForm instance that will optionally include the with_custom_attributes query
+   * param if enabled.
+   *
+   * @return a GitLabApiForm instance that will optionally include the with_custom_attributes query
+   *     param if enabled
+   */
+  private GitLabApiForm createGitLabApiForm() {
+    final GitLabApiForm formData = new GitLabApiForm();
+    return (customAttributesEnabled
+        ? formData.withParam("with_custom_attributes", true)
+        : formData);
+  }
+
+  /**
+   * Uploads and sets the user's avatar for the specified user.
+   *
+   * <pre><code>PUT /users/:id</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param avatarFile the File instance of the avatar file to upload
+   * @return the updated User instance
+   * @throws GitLabApiException if any exception occurs
+   */
+  public User setUserAvatar(final Object userIdOrUsername, final File avatarFile)
+      throws GitLabApiException {
+    final Response response =
+        putUpload(
+            Response.Status.OK,
+            "avatar",
+            avatarFile,
+            "users",
+            getUserIdOrUsername(userIdOrUsername));
+    return (response.readEntity(User.class));
+  }
+
+  /**
+   * Get a list of emails for the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/emails</code></pre>
+   *
+   * @return a List of Email instances for the current user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Email> getEmails() throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "user", "emails");
+    return (response.readEntity(new GenericType<List<Email>>() {}));
+  }
+
+  /**
+   * Get a list of a specified user’s emails. Available only for admin users.
+   *
+   * <pre><code>GitLab Endpoint: GET /user/:id/emails</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @return a List of Email instances for the specified user
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<Email> getEmails(final Object userIdOrUsername) throws GitLabApiException {
+    final Response response =
+        get(Response.Status.OK, null, "users", getUserIdOrUsername(userIdOrUsername), "emails");
+    return (response.readEntity(new GenericType<List<Email>>() {}));
+  }
+
+  /**
+   * Add an email to the current user's emails.
+   *
+   * <pre><code>GitLab Endpoint: POST /user/:id/emails</code></pre>
+   *
+   * @param email the email address to add
+   * @return the Email instance for the added email
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Email addEmail(final String email) throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("email", email, true);
+    final Response response = post(Response.Status.CREATED, formData, "user", "emails");
+    return (response.readEntity(Email.class));
+  }
+
+  /**
+   * Get a single Email instance specified by he email ID
+   *
+   * <pre><code>GitLab Endpoint: GET /user/emails/:emailId</code></pre>
+   *
+   * @param emailId the email ID to get
+   * @return the Email instance for the provided email ID
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Email getEmail(final Long emailId) throws GitLabApiException {
+    final Response response = get(Response.Status.CREATED, null, "user", "emails", emailId);
+    return (response.readEntity(Email.class));
+  }
+
+  /**
+   * Add an email to the user's emails.
+   *
+   * <pre><code>GitLab Endpoint: POST /user/:id/emails</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param email the email address to add
+   * @param skipConfirmation skip confirmation and assume e-mail is verified - true or false
+   *     (default)
+   * @return the Email instance for the added email
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Email addEmail(
+      final Object userIdOrUsername, final String email, final Boolean skipConfirmation)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("email", email, true)
+            .withParam("skip_confirmation ", skipConfirmation);
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "users",
+            getUserIdOrUsername(userIdOrUsername),
+            "emails");
+    return (response.readEntity(Email.class));
+  }
+
+  /**
+   * Deletes an email belonging to the current user.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /user/emails/:emailId</code></pre>
+   *
+   * @param emailId the email ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteEmail(final Long emailId) throws GitLabApiException {
+    delete(Response.Status.NO_CONTENT, null, "user", "emails", emailId);
+  }
+
+  /**
+   * Deletes a user's email
+   *
+   * <pre><code>GitLab Endpoint: DELETE /user/:id/emails/:emailId</code></pre>
+   *
+   * @param userIdOrUsername the user in the form of an Long(ID), String(username), or User instance
+   * @param emailId the email ID to delete
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteEmail(final Object userIdOrUsername, final Long emailId)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "users",
+        getUserIdOrUsername(userIdOrUsername),
+        "emails",
+        emailId);
+  }
+
+  /**
+   * Get all GPG keys for the current user.
+   *
+   * <pre><code>GitLab Endpoint: GET /user/gpg_keys</code></pre>
+   *
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<GpgKey> listGpgKeys() throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "user", "gpg_keys");
+    return (response.readEntity(new GenericType<List<GpgKey>>() {}));
+  }
+
+  /**
+   * Add a GPG key for the current user
+   *
+   * <pre><code>GitLab Endpoint: POST /user/gpg_keys</code></pre>
+   *
+   * @param key the ASCII-armored exported public GPG key to add
+   * @throws GitLabApiException if any exception occurs
+   */
+  public GpgKey addGpgKey(final String key) throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("key", key, true);
+    final Response response = post(Response.Status.CREATED, formData, "user", "gpg_keys");
+    return (response.readEntity(GpgKey.class));
+  }
+
+  /**
+   * Remove a specific GPG key for the current user
+   *
+   * <pre><code>GitLab Endpoint: DELETE /user/gpg_keys/:keyId</code></pre>
+   *
+   * @param keyId the key ID in the form if an Long(ID)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteGpgKey(final Long keyId) throws GitLabApiException {
+    delete(Response.Status.NO_CONTENT, null, "user", "gpg_keys", keyId);
+  }
+
+  /**
+   * Get all GPG keys for a given user.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/gpg_keys</code></pre>
+   *
+   * @param userId the user in the form of an Long(ID)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<GpgKey> listGpgKeys(final Long userId) throws GitLabApiException {
+    final Response response = get(Response.Status.OK, null, "users", userId, "gpg_keys");
+    return (response.readEntity(new GenericType<List<GpgKey>>() {}));
+  }
+
+  /**
+   * Add a GPG key for a specific user
+   *
+   * <pre><code>GitLab Endpoint: POST /users/:id/gpg_keys</code></pre>
+   *
+   * @param userId the user in the form of an Long(ID)
+   * @param key the ASCII-armored exported public GPG key to add
+   * @throws GitLabApiException if any exception occurs
+   */
+  public GpgKey addGpgKey(final Long userId, final String key) throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm().withParam("key", key, true);
+    final Response response = post(Response.Status.CREATED, formData, "users", userId, "gpg_keys");
+    return (response.readEntity(GpgKey.class));
+  }
+
+  /**
+   * Remove a specific GPG key for a specific user
+   *
+   * <pre><code>GitLab Endpoint: DELETE /users/:id/gpg_keys/:keyId</code></pre>
+   *
+   * @param userId the user in the form of an Long(ID)
+   * @param keyId the key ID in the form if an Long(ID)
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deleteGpgKey(final Long userId, final Long keyId) throws GitLabApiException {
+    delete(Response.Status.NO_CONTENT, null, "users", userId, "gpg_keys", keyId);
+  }
+
+  /**
+   * Lists all projects and groups a user is a member of. (admin only)
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/memberships</code></pre>
+   *
+   * @param userId the ID of the user to get the memberships for
+   * @return the list of memberships of the given user
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 12.8
+   */
+  public List<Membership> getMemberships(final Long userId) throws GitLabApiException {
+    return getMemberships(userId, getDefaultPerPage()).all();
+  }
+
+  /**
+   * Returns a Pager that lists all projects and groups a user is a member of. (admin only)
+   *
+   * <p>This allows lazy-fetching of huge numbers of memberships.
+   *
+   * <pre><code>GitLab Endpoint: GET /users/:id/memberships</code></pre>
+   *
+   * @param userId the ID of the user to get the memberships for
+   * @param itemsPerPage the number of Membership instances that will be fetched per page
+   * @return a Pager of user's memberships
+   * @throws GitLabApiException if any exception occurs
+   * @since GitLab 12.8
+   */
+  public Pager<Membership> getMemberships(final Long userId, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData = new GitLabApiForm();
+    return (new Pager<>(
+        this, Membership.class, itemsPerPage, formData.asMap(), "users", userId, "memberships"));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/WikisApi.java
+++ b/src/main/java/org/gitlab4j/api/WikisApi.java
@@ -23,260 +23,328 @@
 
 package org.gitlab4j.api;
 
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Response;
 import java.io.File;
 import java.io.IOException;
 import java.net.URL;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Response;
-
 import org.gitlab4j.api.models.WikiAttachment;
 import org.gitlab4j.api.models.WikiPage;
 
 /**
- * This class implements the client side API for the GitLab Wikis API.
- * See <a href="https://docs.gitlab.com/ce/api/wikis.html">Wikis API at GitLab</a> for more information.
+ * This class implements the client side API for the GitLab Wikis API. See <a
+ * href="https://docs.gitlab.com/ce/api/wikis.html">Wikis API at GitLab</a> for more information.
  */
 public class WikisApi extends AbstractApi {
 
-    public WikisApi(GitLabApi gitLabApi) {
-        super(gitLabApi);
+  public WikisApi(final GitLabApi gitLabApi) {
+    super(gitLabApi);
+  }
+
+  /**
+   * Get a list of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a list of pages in the project's wiki
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<WikiPage> getPages(final Object projectIdOrPath) throws GitLabApiException {
+    return (getPages(projectIdOrPath, false, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param itemsPerPage the number of WikiPage instances that will be fetched per page
+   * @return a Pager of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<WikiPage> getPages(final Object projectIdOrPath, final int itemsPerPage)
+      throws GitLabApiException {
+    return (getPages(projectIdOrPath, false, itemsPerPage));
+  }
+
+  /**
+   * Get a Stream of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @return a Pager of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<WikiPage> getPagesStream(final Object projectIdOrPath) throws GitLabApiException {
+    return (getPages(projectIdOrPath, false, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a list of pages in project wiki for the specified page.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param page the page to get
+   * @param perPage the number of wiki-pages per page
+   * @return a list of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   * @deprecated Will be removed in a future release, use {@link #getPages(Object, boolean, int)}
+   */
+  public List<WikiPage> getPages(final Object projectIdOrPath, final int page, final int perPage)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            getPageQueryParams(page, perPage),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "wikis");
+    return response.readEntity(new GenericType<List<WikiPage>>() {});
+  }
+
+  /**
+   * Get a List of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param withContent if true the results will include the pages content
+   * @return a List of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public List<WikiPage> getPages(final Object projectIdOrPath, final boolean withContent)
+      throws GitLabApiException {
+    return (getPages(projectIdOrPath, withContent, getDefaultPerPage()).all());
+  }
+
+  /**
+   * Get a Pager of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param withContent if true the results will include the pages content
+   * @param itemsPerPage the number of WikiPage instances that will be fetched per page
+   * @return a Pager of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Pager<WikiPage> getPages(
+      final Object projectIdOrPath, final boolean withContent, final int itemsPerPage)
+      throws GitLabApiException {
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("with_content", (withContent ? 1 : 0));
+    return (new Pager<WikiPage>(
+        this,
+        WikiPage.class,
+        itemsPerPage,
+        formData.asMap(),
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "wikis"));
+  }
+
+  /**
+   * Get a Stream of pages in project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param withContent if true the results will include the pages content
+   * @return a Stream of pages in project's wiki for the specified range
+   * @throws GitLabApiException if any exception occurs
+   */
+  public Stream<WikiPage> getPagesStream(final Object projectIdOrPath, final boolean withContent)
+      throws GitLabApiException {
+    return (getPages(projectIdOrPath, withContent, getDefaultPerPage()).stream());
+  }
+
+  /**
+   * Get a single page of project wiki.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis/:slug</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param slug the slug of the project's wiki page
+   * @return the specified project Snippet
+   * @throws GitLabApiException if any exception occurs
+   */
+  public WikiPage getPage(final Object projectIdOrPath, final String slug)
+      throws GitLabApiException {
+    final Response response =
+        get(
+            Response.Status.OK,
+            null,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "wikis",
+            slug);
+    return (response.readEntity(WikiPage.class));
+  }
+
+  /**
+   * Get a single page of project wiki as an Optional instance.
+   *
+   * <pre><code>GitLab Endpoint: GET /projects/:id/wikis/:slug</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param slug the slug of the project's wiki page
+   * @return the specified project Snippet as an Optional instance
+   */
+  public Optional<WikiPage> getOptionalPage(final Object projectIdOrPath, final String slug) {
+    try {
+      return (Optional.ofNullable(getPage(projectIdOrPath, slug)));
+    } catch (final GitLabApiException glae) {
+      return (GitLabApi.createOptionalFromException(glae));
+    }
+  }
+
+  /**
+   * Creates a new project wiki page. The user must have permission to create new wiki page.
+   *
+   * <pre><code>GitLab Endpoint: POST /projects/:id/wikis</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param title the title of a snippet, required
+   * @param content the content of a wiki page, required
+   * @return a WikiPage instance with info on the created page
+   * @throws GitLabApiException if any exception occurs
+   */
+  public WikiPage createPage(final Object projectIdOrPath, final String title, final String content)
+      throws GitLabApiException {
+    // one of title or content is required
+    final GitLabApiForm formData =
+        new GitLabApiForm().withParam("title", title).withParam("content", content);
+
+    final Response response =
+        post(
+            Response.Status.CREATED,
+            formData,
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "wikis");
+    return (response.readEntity(WikiPage.class));
+  }
+
+  /**
+   * Updates an existing project wiki page. The user must have permission to change an existing wiki
+   * page.
+   *
+   * <pre><code>GitLab Endpoint: PUT /projects/:id/wikis/:slug</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param slug the slug of the project's wiki page, required
+   * @param title the title of a snippet, optional
+   * @param content the content of a page, optional. Either title or content must be supplied.
+   * @return a WikiPage instance with info on the updated page
+   * @throws GitLabApiException if any exception occurs
+   */
+  public WikiPage updatePage(
+      final Object projectIdOrPath, final String slug, final String title, final String content)
+      throws GitLabApiException {
+
+    final GitLabApiForm formData =
+        new GitLabApiForm()
+            .withParam("title", title)
+            .withParam("slug", slug, true)
+            .withParam("content", content);
+
+    final Response response =
+        put(
+            Response.Status.OK,
+            formData.asMap(),
+            "projects",
+            getProjectIdOrPath(projectIdOrPath),
+            "wikis",
+            slug);
+    return (response.readEntity(WikiPage.class));
+  }
+
+  /**
+   * Deletes an existing project wiki page. This is an idempotent function and deleting a
+   * non-existent page does not cause an error.
+   *
+   * <pre><code>GitLab Endpoint: DELETE /projects/:id/wikis/:slug</code></pre>
+   *
+   * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project
+   *     instance
+   * @param slug the slug of the project's wiki page
+   * @throws GitLabApiException if any exception occurs
+   */
+  public void deletePage(final Object projectIdOrPath, final String slug)
+      throws GitLabApiException {
+    delete(
+        Response.Status.NO_CONTENT,
+        null,
+        "projects",
+        getProjectIdOrPath(projectIdOrPath),
+        "wikis",
+        slug);
+  }
+
+  /**
+   * Uploads a file to the attachment folder inside the wiki’s repository. The attachment folder is
+   * the uploads folder.
+   *
+   * <pre><code>POST /projects/:id/wikis/attachments</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param fileToUpload the File instance of the file to upload, required
+   * @return a FileUpload instance with information on the just uploaded file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public WikiAttachment uploadAttachment(final Object projectIdOrPath, final File fileToUpload)
+      throws GitLabApiException {
+    return (uploadAttachment(projectIdOrPath, fileToUpload, null));
+  }
+
+  /**
+   * Uploads a file to the attachment folder inside the wiki’s repository. The attachment folder is
+   * the uploads folder.
+   *
+   * <pre><code>POST /projects/:id/wikis/attachments</code></pre>
+   *
+   * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or
+   *     Project instance, required
+   * @param fileToUpload the File instance of the file to upload, required
+   * @param branch the name of the branch, defaults to the wiki repository default branch, optional
+   * @return a FileUpload instance with information on the just uploaded file
+   * @throws GitLabApiException if any exception occurs
+   */
+  public WikiAttachment uploadAttachment(
+      final Object projectIdOrPath, final File fileToUpload, final String branch)
+      throws GitLabApiException {
+
+    final URL url;
+    try {
+      url =
+          getApiClient()
+              .getApiUrl("projects", getProjectIdOrPath(projectIdOrPath), "wikis", "attachments");
+    } catch (final IOException ioe) {
+      throw new GitLabApiException(ioe);
     }
 
-    /**
-     * Get a list of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a list of pages in the project's wiki
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<WikiPage> getPages(Object projectIdOrPath) throws GitLabApiException {
-        return (getPages(projectIdOrPath, false, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param itemsPerPage the number of WikiPage instances that will be fetched per page
-     * @return a Pager of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<WikiPage> getPages(Object projectIdOrPath, int itemsPerPage) throws GitLabApiException {
-	return (getPages(projectIdOrPath, false, itemsPerPage));
-    }
-
-    /**
-     * Get a Stream of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @return a Pager of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<WikiPage> getPagesStream(Object projectIdOrPath) throws GitLabApiException {
-	return (getPages(projectIdOrPath, false, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a list of pages in project wiki for the specified page.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param page the page to get
-     * @param perPage the number of wiki-pages per page
-     * @return a list of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     * @deprecated Will be removed in a future release, use {@link #getPages(Object, boolean, int)}
-     */
-    public List<WikiPage> getPages(Object projectIdOrPath, int page, int perPage) throws GitLabApiException {
-        Response response = get(Response.Status.OK, getPageQueryParams(page, perPage),
-                "projects", getProjectIdOrPath(projectIdOrPath), "wikis");
-        return response.readEntity(new GenericType<List<WikiPage>>() {});
-    }
-
-    /**
-     * Get a List of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param withContent if true the results will include the pages content
-     * @return a List of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public List<WikiPage> getPages(Object projectIdOrPath, boolean withContent) throws GitLabApiException {
-	return (getPages(projectIdOrPath, withContent, getDefaultPerPage()).all());
-    }
-
-    /**
-     * Get a Pager of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param withContent if true the results will include the pages content
-     * @param itemsPerPage the number of WikiPage instances that will be fetched per page
-     * @return a Pager of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Pager<WikiPage> getPages(Object projectIdOrPath, boolean withContent, int itemsPerPage) throws GitLabApiException {
-	GitLabApiForm formData = new GitLabApiForm().withParam("with_content", (withContent ? 1 : 0));
-	return (new Pager<WikiPage>(this, WikiPage.class, itemsPerPage, formData.asMap(), 
-            "projects", getProjectIdOrPath(projectIdOrPath), "wikis"));
-    }
-
-    /**
-     * Get a Stream of pages in project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param withContent if true the results will include the pages content
-     * @return a Stream of pages in project's wiki for the specified range
-     * @throws GitLabApiException if any exception occurs
-     */
-    public Stream<WikiPage> getPagesStream(Object projectIdOrPath, boolean withContent) throws GitLabApiException {
-	return (getPages(projectIdOrPath, withContent, getDefaultPerPage()).stream());
-    }
-
-    /**
-     * Get a single page of project wiki.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis/:slug</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param slug the slug of the project's wiki page
-     * @return the specified project Snippet
-     * @throws GitLabApiException if any exception occurs
-     */
-    public WikiPage getPage(Object projectIdOrPath, String slug) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null,
-                "projects", getProjectIdOrPath(projectIdOrPath), "wikis", slug);
-        return (response.readEntity(WikiPage.class));
-    }
-
-    /**
-     * Get a single page of project wiki as an Optional instance.
-     *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/wikis/:slug</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param slug the slug of the project's wiki page
-     * @return the specified project Snippet as an Optional instance
-     */
-    public Optional<WikiPage> getOptionalPage(Object projectIdOrPath, String slug) {
-        try {
-            return (Optional.ofNullable(getPage(projectIdOrPath, slug)));
-        } catch (GitLabApiException glae) {
-            return (GitLabApi.createOptionalFromException(glae));
-        }
-    }
-
-    /**
-     * Creates a new project wiki page. The user must have permission to create new wiki page.
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/wikis</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param title the title of a snippet, required
-     * @param content the content of a wiki page, required
-     * @return a WikiPage instance with info on the created page
-     * @throws GitLabApiException if any exception occurs
-     */
-    public WikiPage createPage(Object projectIdOrPath, String title, String content) throws GitLabApiException {
-        // one of title or content is required
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title)
-                .withParam("content", content);
-
-        Response response = post(Response.Status.CREATED, formData,
-                "projects", getProjectIdOrPath(projectIdOrPath), "wikis");
-        return (response.readEntity(WikiPage.class));
-    }
-
-    /**
-     * Updates an existing project wiki page. The user must have permission to change an existing wiki page.
-     *
-     * <pre><code>GitLab Endpoint: PUT /projects/:id/wikis/:slug</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param slug the slug of the project's wiki page, required
-     * @param title the title of a snippet, optional
-     * @param content the content of a page, optional. Either title or content must be supplied.
-     * @return a WikiPage instance with info on the updated page
-     * @throws GitLabApiException if any exception occurs
-     */
-    public WikiPage updatePage(Object projectIdOrPath, String slug, String title, String content) throws GitLabApiException {
-
-        GitLabApiForm formData = new GitLabApiForm()
-                .withParam("title", title)
-                .withParam("slug", slug, true)
-                .withParam("content", content);
-
-        Response response = put(Response.Status.OK, formData.asMap(), "projects", getProjectIdOrPath(projectIdOrPath), "wikis", slug);
-        return (response.readEntity(WikiPage.class));
-    }
-
-    /**
-     * Deletes an existing project wiki page. This is an idempotent function and deleting a non-existent page does
-     * not cause an error.
-     *
-     * <pre><code>GitLab Endpoint: DELETE /projects/:id/wikis/:slug</code></pre>
-     *
-     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
-     * @param slug the slug of the project's wiki page
-     * @throws GitLabApiException if any exception occurs
-     */
-    public void deletePage(Object projectIdOrPath, String slug) throws GitLabApiException {
-        delete(Response.Status.NO_CONTENT, null, "projects", getProjectIdOrPath(projectIdOrPath), "wikis", slug);
-    }
-
-    /**
-     * Uploads a file to the attachment folder inside the wiki’s repository. The attachment folder is the uploads folder.
-     *
-     * <pre><code>POST /projects/:id/wikis/attachments</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param fileToUpload the File instance of the file to upload, required
-     * @return a FileUpload instance with information on the just uploaded file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public WikiAttachment uploadAttachment(Object projectIdOrPath, File fileToUpload) throws GitLabApiException {
-        return (uploadAttachment(projectIdOrPath, fileToUpload, null));
-    }
-
-    /**
-     * Uploads a file to the attachment folder inside the wiki’s repository. The attachment folder is the uploads folder.
-     *
-     * <pre><code>POST /projects/:id/wikis/attachments</code></pre>
-     *
-     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
-     * @param fileToUpload the File instance of the file to upload, required
-     * @param branch the name of the branch, defaults to the wiki repository default branch, optional
-     * @return a FileUpload instance with information on the just uploaded file
-     * @throws GitLabApiException if any exception occurs
-     */
-    public WikiAttachment uploadAttachment(Object projectIdOrPath, File fileToUpload, String branch) throws GitLabApiException {
-
-        URL url;
-        try {
-            url = getApiClient().getApiUrl("projects", getProjectIdOrPath(projectIdOrPath), "wikis", "attachments");
-        } catch (IOException ioe) {
-            throw new GitLabApiException(ioe);
-        }
-
-        GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch);
-        Response response = upload(Response.Status.CREATED, "file", fileToUpload, null, formData, url);
-        return (response.readEntity(WikiAttachment.class));
-    }
+    final GitLabApiForm formData = new GitLabApiForm().withParam("branch", branch);
+    final Response response =
+        upload(Response.Status.CREATED, "file", fileToUpload, null, formData, url);
+    return (response.readEntity(WikiAttachment.class));
+  }
 }

--- a/src/main/java/org/gitlab4j/api/systemhooks/SystemHookManager.java
+++ b/src/main/java/org/gitlab4j/api/systemhooks/SystemHookManager.java
@@ -7,7 +7,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.HookManager;
@@ -181,7 +181,7 @@ public class SystemHookManager implements HookManager {
 
     /**
      * Verifies the provided Event and fires it off to the registered listeners.
-     * 
+     *
      * @param event the Event instance to handle
      * @throws GitLabApiException if the event is not supported
      */
@@ -217,7 +217,7 @@ public class SystemHookManager implements HookManager {
 
     /**
      * Fire the event to the registered listeners.
-     * 
+     *
      * @param event the SystemHookEvent instance to fire to the registered event listeners
      * @throws GitLabApiException if the event is not supported
      */

--- a/src/main/java/org/gitlab4j/api/utils/FileUtils.java
+++ b/src/main/java/org/gitlab4j/api/utils/FileUtils.java
@@ -8,7 +8,7 @@ import java.nio.file.Files;
 import java.util.Base64;
 import java.util.Scanner;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.Constants.Encoding;
 
@@ -21,7 +21,7 @@ public class FileUtils {
      * Creates a File that is unique in the specified directory. If the specified
      * filename exists in the directory, "-#" will be appended to the filename until
      * a unique filename can be created.
-     * 
+     *
      * @param directory the directory to create the file in
      * @param filename the base filename with extension
      * @return a File that is unique in the specified directory
@@ -53,7 +53,7 @@ public class FileUtils {
 
     /**
      * Get the filename from the "Content-Disposition" header of a JAX-RS response.
-     * 
+     *
      * @param response the JAX-RS Response instance  to get the "Content-Disposition" header filename from
      * @return the filename from the "Content-Disposition" header of a JAX-RS response, or null
      * if the "Content-Disposition" header is not present in the response
@@ -66,10 +66,10 @@ public class FileUtils {
 
         return (disposition.replaceFirst("(?i)^.*filename=\"([^\"]+)\".*$", "$1"));
     }
- 
+
     /**
      * Reads the contents of a File to a String.
-     * 
+     *
      * @param file the File instance to read the contents from
      * @return the contents of file as a String
      * @throws IOException if any errors occur while opening or reading the file
@@ -79,7 +79,7 @@ public class FileUtils {
         try (Scanner in = new Scanner(file)) {
             in.useDelimiter("\\Z");
             return (in.next());
-        }       
+        }
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/utils/HttpRequestUtils.java
+++ b/src/main/java/org/gitlab4j/api/utils/HttpRequestUtils.java
@@ -1,37 +1,36 @@
 package org.gitlab4j.api.utils;
 
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.util.Enumeration;
 
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-
 public class HttpRequestUtils {
 
     /**
      * Build a String containing a very short multi-line dump of an HTTP request.
-     * 
+     *
      * @param fromMethod the method that this method was called from
      * @param request the HTTP request build the request dump from
      * @return a String containing a very short multi-line dump of the HTTP request
      */
-    public static String getShortRequestDump(String fromMethod, HttpServletRequest request) {
+    public static String getShortRequestDump(final String fromMethod, final HttpServletRequest request) {
         return (getShortRequestDump(fromMethod, false, request));
     }
 
     /**
      * Build a String containing a short multi-line dump of an HTTP request.
-     * 
+     *
      * @param fromMethod the method that this method was called from
      * @param request the HTTP request build the request dump from
      * @param includeHeaders if true will include the HTTP headers in the dump
      * @return a String containing a short multi-line dump of the HTTP request
      */
-    public static String getShortRequestDump(String fromMethod, boolean includeHeaders, HttpServletRequest request) {
+    public static String getShortRequestDump(final String fromMethod, final boolean includeHeaders, final HttpServletRequest request) {
 
-        StringBuilder dump = new StringBuilder();
+        final StringBuilder dump = new StringBuilder();
         dump.append("Timestamp     : ").append(ISO8601.getTimestamp()).append("\n");
         dump.append("fromMethod    : ").append(fromMethod).append("\n");
         dump.append("Method        : ").append(request.getMethod()).append('\n');
@@ -46,9 +45,9 @@ public class HttpRequestUtils {
 
         if (includeHeaders) {
             dump.append("Headers       :\n");
-            Enumeration<String> headers = request.getHeaderNames();
+            final Enumeration<String> headers = request.getHeaderNames();
             while (headers.hasMoreElements()) {
-                String header = headers.nextElement();
+                final String header = headers.nextElement();
                 dump.append("\t").append(header).append(": ").append(request.getHeader(header)).append('\n');
             }
         }
@@ -58,45 +57,45 @@ public class HttpRequestUtils {
 
     /**
      * Build a String containing a multi-line dump of an HTTP request.
-     * 
+     *
      * @param fromMethod the method that this method was called from
      * @param request the HTTP request build the request dump from
      * @param includePostData if true will include the POST data in the dump
      * @return a String containing a multi-line dump of the HTTP request, If an error occurs,
      * the message from the exception will be returned
      */
-    public static String getRequestDump(String fromMethod, HttpServletRequest request, boolean includePostData) {
+    public static String getRequestDump(final String fromMethod, final HttpServletRequest request, final boolean includePostData) {
 
-        String shortDump = getShortRequestDump(fromMethod, request);
-        StringBuilder buf = new StringBuilder(shortDump);
+        final String shortDump = getShortRequestDump(fromMethod, request);
+        final StringBuilder buf = new StringBuilder(shortDump);
         try {
 
             buf.append("\nAttributes:\n");
-            Enumeration<String> attrs = request.getAttributeNames();
+            final Enumeration<String> attrs = request.getAttributeNames();
             while (attrs.hasMoreElements()) {
-                String attr = attrs.nextElement();
+                final String attr = attrs.nextElement();
                 buf.append("\t").append(attr).append(": ").append(request.getAttribute(attr)).append('\n');
             }
 
             buf.append("\nHeaders:\n");
-            Enumeration<String> headers = request.getHeaderNames();
+            final Enumeration<String> headers = request.getHeaderNames();
             while (headers.hasMoreElements()) {
-                String header = headers.nextElement();
+                final String header = headers.nextElement();
                 buf.append("\t").append(header).append(": ").append(request.getHeader(header)).append('\n');
             }
 
             buf.append("\nParameters:\n");
-            Enumeration<String> params = request.getParameterNames();
+            final Enumeration<String> params = request.getParameterNames();
             while (params.hasMoreElements()) {
-                String param = params.nextElement();
+                final String param = params.nextElement();
                 buf.append("\t").append(param).append(": ").append(request.getParameter(param)).append('\n');
             }
 
             buf.append("\nCookies:\n");
-            Cookie[] cookies = request.getCookies();
+            final Cookie[] cookies = request.getCookies();
             if (cookies != null) {
-                for (Cookie cookie : cookies) {
-                    String cstr = "\t" + cookie.getDomain() + "." + cookie.getPath() + "." + cookie.getName() + ": " + cookie.getValue() + "\n";
+                for (final Cookie cookie : cookies) {
+                    final String cstr = "\t" + cookie.getDomain() + "." + cookie.getPath() + "." + cookie.getName() + ": " + cookie.getValue() + "\n";
                     buf.append(cstr);
                 }
             }
@@ -107,33 +106,33 @@ public class HttpRequestUtils {
 
             return (buf.toString());
 
-        } catch (IOException e) {
+        } catch (final IOException e) {
             return e.getMessage();
         }
     }
 
     /**
      * Reads the POST data from a request into a String and returns it.
-     * 
+     *
      * @param request the HTTP request containing the POST data
      * @return the POST data as a String instance
      * @throws IOException if any error occurs while reading the POST data
      */
-    public static String getPostDataAsString(HttpServletRequest request) throws IOException {
+    public static String getPostDataAsString(final HttpServletRequest request) throws IOException {
 
-        try (InputStreamReader reader = new InputStreamReader(request.getInputStream(), "UTF-8")) {
+        try (final InputStreamReader reader = new InputStreamReader(request.getInputStream(), "UTF-8")) {
             return (getReaderContentAsString(reader));
         }
     }
 
     /**
      * Reads the content of a Reader instance and returns it as a String.
-     * 
+     *
      * @param reader the Reader instance to read the data from
      * @return the content of a Reader instance as a String
      * @throws IOException if any error occurs while reading the POST data
      */
-    public static String getReaderContentAsString(Reader reader) throws IOException {
+    public static String getReaderContentAsString(final Reader reader) throws IOException {
 
         int count;
         final char[] buffer = new char[2048];
@@ -147,11 +146,11 @@ public class HttpRequestUtils {
 
     /**
      * Masks the PRIVATE-TOKEN header value with "********".
-     * 
+     *
      * @param s a String containing HTTP request info, usually logging info
      * @return a String with the PRIVATE-TOKEN header value masked with asterisks
      */
-    public static String maskPrivateToken(String s) {
+    public static String maskPrivateToken(final String s) {
 
         if (s == null || s.isEmpty()) {
             return (s);

--- a/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
+++ b/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
@@ -11,9 +11,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.TimeZone;
 
-import javax.ws.rs.Produces;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.ext.ContextResolver;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.ext.ContextResolver;
 
 import org.gitlab4j.api.models.User;
 import org.glassfish.jersey.jackson.internal.jackson.jaxrs.json.JacksonJaxbJsonProvider;
@@ -81,7 +81,7 @@ public class JacksonJson extends JacksonJaxbJsonProvider implements ContextResol
 
     /**
      * Gets the ObjectMapper contained by this instance.
-     * 
+     *
      * @return the ObjectMapper contained by this instance
      */
     public ObjectMapper getObjectMapper() {
@@ -230,7 +230,7 @@ public class JacksonJson extends JacksonJaxbJsonProvider implements ContextResol
 
     /**
      * Marshals the supplied object out as a formatted JSON string.
-     * 
+     *
      * @param <T> the generics type for the provided object
      * @param object the object to output as a JSON string
      * @return a String containing the JSON for the specified object

--- a/src/main/java/org/gitlab4j/api/utils/MaskingLoggingFilter.java
+++ b/src/main/java/org/gitlab4j/api/utils/MaskingLoggingFilter.java
@@ -1,5 +1,15 @@
 package org.gitlab4j.api.utils;
 
+import jakarta.annotation.Priority;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.client.ClientRequestContext;
+import jakarta.ws.rs.client.ClientRequestFilter;
+import jakarta.ws.rs.client.ClientResponseContext;
+import jakarta.ws.rs.client.ClientResponseFilter;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.ext.WriterInterceptor;
+import jakarta.ws.rs.ext.WriterInterceptorContext;
 import java.io.BufferedInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.FilterOutputStream;
@@ -18,344 +28,365 @@ import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.annotation.Priority;
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.client.ClientRequestContext;
-import javax.ws.rs.client.ClientRequestFilter;
-import javax.ws.rs.client.ClientResponseContext;
-import javax.ws.rs.client.ClientResponseFilter;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.ext.WriterInterceptor;
-import javax.ws.rs.ext.WriterInterceptorContext;
-
 import org.glassfish.jersey.message.MessageUtils;
 
-
 /**
- * This class logs request and response info masking HTTP header values that are known to
- * contain sensitive information.
+ * This class logs request and response info masking HTTP header values that are known to contain
+ * sensitive information.
  *
- * This class was patterned after org.glassfish.jersey.logging.LoggingInterceptor, but written in
+ * <p>This class was patterned after org.glassfish.jersey.logging.LoggingInterceptor, but written in
  * such a way that it could be sub-classed and have its behavior modified.
  */
 @Priority(Integer.MIN_VALUE)
-public class MaskingLoggingFilter implements ClientRequestFilter, ClientResponseFilter, WriterInterceptor {
+public class MaskingLoggingFilter
+    implements ClientRequestFilter, ClientResponseFilter, WriterInterceptor {
 
-    /**
-     * Default list of header names that should be masked.
-     */
-    public static final List<String> DEFAULT_MASKED_HEADER_NAMES = 
-            Collections.unmodifiableList(Arrays.asList("PRIVATE-TOKEN", "Authorization", "Proxy-Authorization"));
+  /** Default list of header names that should be masked. */
+  public static final List<String> DEFAULT_MASKED_HEADER_NAMES =
+      Collections.unmodifiableList(
+          Arrays.asList("PRIVATE-TOKEN", "Authorization", "Proxy-Authorization"));
 
-    /**
-     * Prefix for request log entries.
-     */
-    protected static final String REQUEST_PREFIX = "> ";
- 
-    /**
-     * Prefix for response log entries.
-     */
-    protected static final String RESPONSE_PREFIX = "< ";
+  /** Prefix for request log entries. */
+  protected static final String REQUEST_PREFIX = "> ";
 
-    /**
-     * Prefix that marks the beginning of a request or response section. 
-     */
-    protected static final String SECTION_PREFIX = "- ";
+  /** Prefix for response log entries. */
+  protected static final String RESPONSE_PREFIX = "< ";
 
-    /**
-     * Property name for the entity stream property
-     */
-    protected static final String ENTITY_STREAM_PROPERTY = MaskingLoggingFilter.class.getName() + ".entityStream";
+  /** Prefix that marks the beginning of a request or response section. */
+  protected static final String SECTION_PREFIX = "- ";
 
-    /**
-     * Property name for the logging record id property
-     */
-    protected static final String LOGGING_ID_PROPERTY = MaskingLoggingFilter.class.getName() + ".id";
+  /** Property name for the entity stream property */
+  protected static final String ENTITY_STREAM_PROPERTY =
+      MaskingLoggingFilter.class.getName() + ".entityStream";
 
-    protected final Logger logger;
-    protected final Level level;
-    protected final int maxEntitySize;
-    protected final AtomicLong _id = new AtomicLong(0);
-    protected Set<String> maskedHeaderNames = new HashSet<String>();
+  /** Property name for the logging record id property */
+  protected static final String LOGGING_ID_PROPERTY = MaskingLoggingFilter.class.getName() + ".id";
 
-    /**
-     * Creates a masking logging filter for the specified logger with entity logging disabled.
-     *
-     * @param logger the logger to log messages to
-     * @param level level at which the messages will be logged
-     */
-    public MaskingLoggingFilter(final Logger logger, final Level level) {
-        this(logger, level, 0, null);
+  protected final Logger logger;
+  protected final Level level;
+  protected final int maxEntitySize;
+  protected final AtomicLong _id = new AtomicLong(0);
+  protected Set<String> maskedHeaderNames = new HashSet<String>();
+
+  /**
+   * Creates a masking logging filter for the specified logger with entity logging disabled.
+   *
+   * @param logger the logger to log messages to
+   * @param level level at which the messages will be logged
+   */
+  public MaskingLoggingFilter(final Logger logger, final Level level) {
+    this(logger, level, 0, null);
+  }
+
+  /**
+   * Creates a masking logging filter for the specified logger.
+   *
+   * @param logger the logger to log messages to
+   * @param level level at which the messages will be logged
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   */
+  public MaskingLoggingFilter(final Logger logger, final Level level, final int maxEntitySize) {
+    this(logger, level, maxEntitySize, null);
+  }
+
+  /**
+   * Creates a masking logging filter for the specified logger with entity logging disabled.
+   *
+   * @param logger the logger to log messages to
+   * @param level level at which the messages will be logged
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public MaskingLoggingFilter(
+      final Logger logger, final Level level, final List<String> maskedHeaderNames) {
+    this(logger, level, 0, maskedHeaderNames);
+  }
+
+  /**
+   * Creates a masking logging filter for the specified logger.
+   *
+   * @param logger the logger to log messages to
+   * @param level level at which the messages will be logged
+   * @param maxEntitySize maximum number of entity bytes to be logged. When logging if the
+   *     maxEntitySize is reached, the entity logging will be truncated at maxEntitySize and
+   *     "...more..." will be added at the end of the log entry. If maxEntitySize is &lt;= 0, entity
+   *     logging will be disabled
+   * @param maskedHeaderNames a list of header names that should have the values masked
+   */
+  public MaskingLoggingFilter(
+      final Logger logger,
+      final Level level,
+      final int maxEntitySize,
+      final List<String> maskedHeaderNames) {
+    this.logger = logger;
+    this.level = level;
+    this.maxEntitySize = maxEntitySize;
+
+    if (maskedHeaderNames != null) {
+      maskedHeaderNames.forEach(h -> this.maskedHeaderNames.add(h.toLowerCase()));
     }
+  }
 
-    /**
-     * Creates a masking logging filter for the specified logger.
-     *
-     * @param logger the logger to log messages to
-     * @param level level at which the messages will be logged
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     */
-    public MaskingLoggingFilter(final Logger logger, final Level level, final int maxEntitySize) {
-        this(logger, level, maxEntitySize, null);
+  /**
+   * Set the list of header names to mask values for. If null, will clear the header names to mask.
+   *
+   * @param maskedHeaderNames a list of header names that should have the values masked, if null,
+   *     will clear the header names to mask
+   */
+  public void setMaskedHeaderNames(final List<String> maskedHeaderNames) {
+    this.maskedHeaderNames.clear();
+    if (maskedHeaderNames != null) {
+      maskedHeaderNames.forEach(
+          h -> {
+            addMaskedHeaderName(h);
+          });
     }
+  }
 
-    /**
-     * Creates a masking logging filter for the specified logger with entity logging disabled.
-     *
-     * @param logger the logger to log messages to
-     * @param level level at which the messages will be logged
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public MaskingLoggingFilter(final Logger logger, final Level level, final List<String> maskedHeaderNames) {
-        this(logger, level, 0, maskedHeaderNames);
+  /**
+   * Add a header name to the list of masked header names.
+   *
+   * @param maskedHeaderName the masked header name to add
+   */
+  public void addMaskedHeaderName(String maskedHeaderName) {
+    if (maskedHeaderName != null) {
+      maskedHeaderName = maskedHeaderName.trim();
+      if (maskedHeaderName.length() > 0) {
+        maskedHeaderNames.add(maskedHeaderName.toLowerCase());
+      }
     }
+  }
 
-    /**
-     * Creates a masking logging filter for the specified logger.
-     *
-     * @param logger the logger to log messages to
-     * @param level level at which the messages will be logged
-     * @param maxEntitySize maximum number of entity bytes to be logged.  When logging if the maxEntitySize
-     * is reached, the entity logging  will be truncated at maxEntitySize and "...more..." will be added at
-     * the end of the log entry. If maxEntitySize is &lt;= 0, entity logging will be disabled
-     * @param maskedHeaderNames a list of header names that should have the values masked
-     */
-    public MaskingLoggingFilter(final Logger logger, final Level level, final int maxEntitySize, final List<String> maskedHeaderNames) {
-        this.logger = logger;
-        this.level = level;
-        this.maxEntitySize = maxEntitySize;
-
-        if (maskedHeaderNames != null) {
-            maskedHeaderNames.forEach(h -> this.maskedHeaderNames.add(h.toLowerCase()));
-        }
+  protected void log(final StringBuilder sb) {
+    if (logger != null) {
+      logger.log(level, sb.toString());
     }
+  }
 
-    /**
-     * Set the list of header names to mask values for. If null, will clear the header names to mask.
-     *
-     * @param maskedHeaderNames a list of header names that should have the values masked, if null, will clear
-     * the header names to mask
-     */
-    public void setMaskedHeaderNames(final List<String> maskedHeaderNames) {
-        this.maskedHeaderNames.clear();
-        if (maskedHeaderNames != null) {
-            maskedHeaderNames.forEach(h -> {
-                addMaskedHeaderName(h);
-            });
-        }
-    }
+  protected StringBuilder appendId(final StringBuilder sb, final long id) {
+    sb.append(Long.toString(id)).append(' ');
+    return (sb);
+  }
 
-    /**
-     * Add a header name to the list of masked header names.
-     *
-     * @param maskedHeaderName the masked header name to add
-     */
-    public void addMaskedHeaderName(String maskedHeaderName) {
-        if (maskedHeaderName != null) {
-            maskedHeaderName = maskedHeaderName.trim();
-            if (maskedHeaderName.length() > 0) {
-               maskedHeaderNames.add(maskedHeaderName.toLowerCase());
-            }
-        }
-    }
+  protected void printRequestLine(
+      final StringBuilder sb,
+      final String note,
+      final long id,
+      final String method,
+      final URI uri) {
+    appendId(sb, id)
+        .append(SECTION_PREFIX)
+        .append(note)
+        .append(" on thread ")
+        .append(Thread.currentThread().getName())
+        .append('\n');
+    appendId(sb, id)
+        .append(REQUEST_PREFIX)
+        .append(method)
+        .append(' ')
+        .append(uri.toASCIIString())
+        .append('\n');
+  }
 
-    protected void log(final StringBuilder sb) {
-        if (logger != null) {
-            logger.log(level, sb.toString());
-        }
-    }
+  protected void printResponseLine(
+      final StringBuilder sb, final String note, final long id, final int status) {
+    appendId(sb, id)
+        .append(SECTION_PREFIX)
+        .append(note)
+        .append(" on thread ")
+        .append(Thread.currentThread().getName())
+        .append('\n');
+    appendId(sb, id).append(RESPONSE_PREFIX).append(Integer.toString(status)).append('\n');
+  }
 
-    protected StringBuilder appendId(final StringBuilder sb, final long id) {
-        sb.append(Long.toString(id)).append(' ');
-        return (sb);
-    }
+  protected Set<Entry<String, List<String>>> getSortedHeaders(
+      final Set<Entry<String, List<String>>> headers) {
+    final TreeSet<Entry<String, List<String>>> sortedHeaders =
+        new TreeSet<Entry<String, List<String>>>(
+            (Entry<String, List<String>> o1, Entry<String, List<String>> o2) ->
+                o1.getKey().compareToIgnoreCase(o2.getKey()));
+    sortedHeaders.addAll(headers);
+    return sortedHeaders;
+  }
 
-    protected void printRequestLine(final StringBuilder sb, final String note, final long id, final String method, final URI uri) {
-        appendId(sb, id).append(SECTION_PREFIX)
-                .append(note)
-                .append(" on thread ").append(Thread.currentThread().getName())
-                .append('\n');
-        appendId(sb, id).append(REQUEST_PREFIX).append(method).append(' ')
-                .append(uri.toASCIIString()).append('\n');
-    }
+  /**
+   * Logs each of the HTTP headers, masking the value of the header if the header key is in the list
+   * of masked header names.
+   *
+   * @param sb the StringBuilder to build up the logging info in
+   * @param id the ID for the logging line
+   * @param prefix the logging line prefix character
+   * @param headers a MultiValue map holding the header keys and values
+   */
+  protected void printHeaders(
+      final StringBuilder sb,
+      final long id,
+      final String prefix,
+      final MultivaluedMap<String, String> headers) {
 
-    protected void printResponseLine(final StringBuilder sb, final String note, final long id, final int status) {
-        appendId(sb, id).append(SECTION_PREFIX)
-                .append(note)
-                .append(" on thread ").append(Thread.currentThread().getName()).append('\n');
-        appendId(sb, id).append(RESPONSE_PREFIX)
-                .append(Integer.toString(status))
-                .append('\n');
-    }
+    getSortedHeaders(headers.entrySet())
+        .forEach(
+            h -> {
+              final List<?> values = h.getValue();
+              final String header = h.getKey();
+              final boolean isMaskedHeader = maskedHeaderNames.contains(header.toLowerCase());
 
-    protected Set<Entry<String, List<String>>> getSortedHeaders(final Set<Entry<String, List<String>>> headers) {
-        final TreeSet<Entry<String, List<String>>> sortedHeaders = new TreeSet<Entry<String, List<String>>>(
-                (Entry<String, List<String>> o1, Entry<String, List<String>> o2) -> o1.getKey().compareToIgnoreCase(o2.getKey()));
-        sortedHeaders.addAll(headers);
-        return sortedHeaders;
-    }
+              if (values.size() == 1) {
+                final String value = (isMaskedHeader ? "********" : values.get(0).toString());
+                appendId(sb, id)
+                    .append(prefix)
+                    .append(header)
+                    .append(": ")
+                    .append(value)
+                    .append('\n');
+              } else {
 
-    /**
-     * Logs each of the HTTP headers, masking the value of the header if the header key is
-     * in the list of masked header names.
-     * 
-     * @param sb the StringBuilder to build up the logging info in
-     * @param id the ID for the logging line
-     * @param prefix the logging line prefix character
-     * @param headers a MultiValue map holding the header keys and values
-     */
-    protected void printHeaders(final StringBuilder sb,
-                              final long id,
-                              final String prefix,
-                              final MultivaluedMap<String, String> headers) {
- 
-        getSortedHeaders(headers.entrySet()).forEach(h -> {
-
-            final List<?> values = h.getValue();
-            final String header = h.getKey();
-            final boolean isMaskedHeader = maskedHeaderNames.contains(header.toLowerCase());
-
-            if (values.size() == 1) {
-                String value = (isMaskedHeader ? "********" : values.get(0).toString());
-                appendId(sb, id).append(prefix).append(header).append(": ").append(value).append('\n');
-            } else {
-                
                 final StringBuilder headerBuf = new StringBuilder();
                 for (final Object value : values) {
-                    if (headerBuf.length() == 0) {
-                        headerBuf.append(", ");
-                    }
+                  if (headerBuf.length() == 0) {
+                    headerBuf.append(", ");
+                  }
 
-                    headerBuf.append(isMaskedHeader ? "********" : value.toString());
+                  headerBuf.append(isMaskedHeader ? "********" : value.toString());
                 }
-        
-                appendId(sb, id).append(prefix).append(header).append(": ").append(headerBuf.toString()).append('\n');
-            }
-        });
+
+                appendId(sb, id)
+                    .append(prefix)
+                    .append(header)
+                    .append(": ")
+                    .append(headerBuf.toString())
+                    .append('\n');
+              }
+            });
+  }
+
+  protected void buildEntityLogString(
+      final StringBuilder sb, final byte[] entity, final int entitySize, final Charset charset) {
+
+    sb.append(new String(entity, 0, Math.min(entitySize, maxEntitySize), charset));
+    if (entitySize > maxEntitySize) {
+      sb.append("...more...");
     }
-    
-    protected void buildEntityLogString(StringBuilder sb, byte[] entity, int entitySize, Charset charset) {
 
-        sb.append(new String(entity, 0, Math.min(entitySize, maxEntitySize), charset));
-        if (entitySize > maxEntitySize) {
-            sb.append("...more...");
-        }
+    sb.append('\n');
+  }
 
-        sb.append('\n');
+  private InputStream logResponseEntity(
+      final StringBuilder sb, InputStream stream, final Charset charset) throws IOException {
+
+    if (maxEntitySize <= 0) {
+      return (stream);
     }
 
-    private InputStream logResponseEntity(final StringBuilder sb, InputStream stream, final Charset charset) throws IOException {
+    if (!stream.markSupported()) {
+      stream = new BufferedInputStream(stream);
+    }
 
-        if (maxEntitySize <= 0) {
-            return (stream);
-        }
+    stream.mark(maxEntitySize + 1);
+    final byte[] entity = new byte[maxEntitySize + 1];
+    final int entitySize = stream.read(entity);
+    buildEntityLogString(sb, entity, entitySize, charset);
+    stream.reset();
+    return stream;
+  }
 
-        if (!stream.markSupported()) {
-            stream = new BufferedInputStream(stream);
-        }
+  @Override
+  public void filter(final ClientRequestContext requestContext) throws IOException {
 
-        stream.mark(maxEntitySize + 1);
-        final byte[] entity = new byte[maxEntitySize + 1];
-        final int entitySize = stream.read(entity);
-        buildEntityLogString(sb, entity, entitySize, charset);
-        stream.reset();
-        return stream;
+    if (!logger.isLoggable(level)) {
+      return;
+    }
+
+    final long id = _id.incrementAndGet();
+    requestContext.setProperty(LOGGING_ID_PROPERTY, id);
+
+    final StringBuilder sb = new StringBuilder();
+    printRequestLine(
+        sb, "Sending client request", id, requestContext.getMethod(), requestContext.getUri());
+    printHeaders(sb, id, REQUEST_PREFIX, requestContext.getStringHeaders());
+
+    if (requestContext.hasEntity() && maxEntitySize > 0) {
+      final OutputStream stream = new LoggingStream(sb, requestContext.getEntityStream());
+      requestContext.setEntityStream(stream);
+      requestContext.setProperty(ENTITY_STREAM_PROPERTY, stream);
+    } else {
+      log(sb);
+    }
+  }
+
+  @Override
+  public void filter(final ClientRequestContext requestContext, final ClientResponseContext responseContext)
+      throws IOException {
+
+    if (!logger.isLoggable(level)) {
+      return;
+    }
+
+    final Object requestId = requestContext.getProperty(LOGGING_ID_PROPERTY);
+    final long id = requestId != null ? (Long) requestId : _id.incrementAndGet();
+
+    final StringBuilder sb = new StringBuilder();
+    printResponseLine(sb, "Received server response", id, responseContext.getStatus());
+    printHeaders(sb, id, RESPONSE_PREFIX, responseContext.getHeaders());
+
+    if (responseContext.hasEntity() && maxEntitySize > 0) {
+      responseContext.setEntityStream(
+          logResponseEntity(
+              sb,
+              responseContext.getEntityStream(),
+              MessageUtils.getCharset(responseContext.getMediaType())));
+    }
+
+    log(sb);
+  }
+
+  @Override
+  public void aroundWriteTo(final WriterInterceptorContext context)
+      throws IOException, WebApplicationException {
+
+    final LoggingStream stream = (LoggingStream) context.getProperty(ENTITY_STREAM_PROPERTY);
+    context.proceed();
+    if (stream == null) {
+      return;
+    }
+
+    final MediaType mediaType = context.getMediaType();
+    if (mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE)
+        || mediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
+      log(stream.getStringBuilder(MessageUtils.getCharset(mediaType)));
+    }
+  }
+
+  /**
+   * This class is responsible for logging the request entities, it will truncate at maxEntitySize
+   * and add "...more..." to the end of the entity log string.
+   */
+  protected class LoggingStream extends FilterOutputStream {
+
+    private final StringBuilder sb;
+    private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+
+    LoggingStream(final StringBuilder sb, final OutputStream out) {
+      super(out);
+      this.sb = sb;
+    }
+
+    StringBuilder getStringBuilder(final Charset charset) {
+      final byte[] entity = outputStream.toByteArray();
+      buildEntityLogString(sb, entity, entity.length, charset);
+      return (sb);
     }
 
     @Override
-    public void filter(ClientRequestContext requestContext) throws IOException {
+    public void write(final int i) throws IOException {
 
-        if (!logger.isLoggable(level)) {
-            return;
-        }
+      if (outputStream.size() <= maxEntitySize) {
+        outputStream.write(i);
+      }
 
-        final long id = _id.incrementAndGet();
-        requestContext.setProperty(LOGGING_ID_PROPERTY, id);
-
-        final StringBuilder sb = new StringBuilder();
-        printRequestLine(sb, "Sending client request", id, requestContext.getMethod(), requestContext.getUri());
-        printHeaders(sb, id, REQUEST_PREFIX, requestContext.getStringHeaders());
-
-        if (requestContext.hasEntity() && maxEntitySize > 0) {
-            final OutputStream stream = new LoggingStream(sb, requestContext.getEntityStream());
-            requestContext.setEntityStream(stream);
-            requestContext.setProperty(ENTITY_STREAM_PROPERTY, stream);
-        } else {
-            log(sb);
-        }
+      out.write(i);
     }
-
-    @Override
-    public void filter(ClientRequestContext requestContext, ClientResponseContext responseContext) throws IOException {
-
-        if (!logger.isLoggable(level)) {
-            return;
-        }
-
-        final Object requestId = requestContext.getProperty(LOGGING_ID_PROPERTY);
-        final long id = requestId != null ? (Long) requestId : _id.incrementAndGet();
-
-        final StringBuilder sb = new StringBuilder();
-        printResponseLine(sb, "Received server response", id, responseContext.getStatus());
-        printHeaders(sb, id, RESPONSE_PREFIX, responseContext.getHeaders());
- 
-        if (responseContext.hasEntity() && maxEntitySize > 0) {
-            responseContext.setEntityStream(logResponseEntity(sb, responseContext.getEntityStream(), 
-                    MessageUtils.getCharset(responseContext.getMediaType())));
-        }
-
-        log(sb);
-    }
-
-    @Override
-    public void aroundWriteTo(WriterInterceptorContext context) throws IOException, WebApplicationException {
-
-        final LoggingStream stream = (LoggingStream) context.getProperty(ENTITY_STREAM_PROPERTY);
-        context.proceed();
-        if (stream == null) {
-            return;
-        }
-        
-        MediaType mediaType = context.getMediaType();
-        if (mediaType.isCompatible(MediaType.APPLICATION_JSON_TYPE) ||
-                mediaType.isCompatible(MediaType.APPLICATION_FORM_URLENCODED_TYPE)) {
-            log(stream.getStringBuilder(MessageUtils.getCharset(mediaType)));
-        }
-
-    }
-
-    /**
-     * This class is responsible for logging the request entities, it will truncate at maxEntitySize
-     * and add "...more..." to the end of the entity log string.
-     */
-    protected class LoggingStream extends FilterOutputStream {
-
-        private final StringBuilder sb;
-        private final ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
-
-        LoggingStream(StringBuilder sb, OutputStream out) {
-            super(out);
-            this.sb = sb;
-        }
-
-        StringBuilder getStringBuilder(Charset charset) {
-            final byte[] entity = outputStream.toByteArray();
-            buildEntityLogString(sb, entity, entity.length, charset);
-            return (sb);
-        }
-
-        @Override
-        public void write(final int i) throws IOException {
-
-            if (outputStream.size() <= maxEntitySize) {
-                outputStream.write(i);
-            }
-
-            out.write(i);
-        }
-    }
+  }
 }

--- a/src/main/java/org/gitlab4j/api/utils/Oauth2LoginStreamingOutput.java
+++ b/src/main/java/org/gitlab4j/api/utils/Oauth2LoginStreamingOutput.java
@@ -7,8 +7,8 @@ import java.io.OutputStreamWriter;
 import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 
-import javax.ws.rs.WebApplicationException;
-import javax.ws.rs.core.StreamingOutput;
+import jakarta.ws.rs.WebApplicationException;
+import jakarta.ws.rs.core.StreamingOutput;
 
 /**
  * This StreamingOutput implementation is utilized to send a OAuth2 token request

--- a/src/test/java/org/gitlab4j/api/JsonUtils.java
+++ b/src/test/java/org/gitlab4j/api/JsonUtils.java
@@ -1,147 +1,164 @@
 package org.gitlab4j.api;
 
-import java.io.BufferedReader;
-import java.io.IOException;
-import java.io.InputStreamReader;
-import java.io.Reader;
-import java.util.List;
-import java.util.Map;
-
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonMappingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.MapperFeature;
 import com.fasterxml.jackson.databind.SerializationFeature;
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.io.Reader;
+import java.util.List;
+import java.util.Map;
+import org.gitlab4j.api.utils.JacksonJson;
 
 public class JsonUtils {
-    
-    private static JacksonJson jacksonJson;
-    static {
-        jacksonJson = new JacksonJson();
-        jacksonJson.getObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
-        jacksonJson.getObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+
+  private static final JacksonJson jacksonJson;
+
+  static {
+    jacksonJson = new JacksonJson();
+    jacksonJson.getObjectMapper().configure(SerializationFeature.ORDER_MAP_ENTRIES_BY_KEYS, true);
+    jacksonJson.getObjectMapper().configure(MapperFeature.SORT_PROPERTIES_ALPHABETICALLY, true);
+  }
+
+  static JsonNode readTreeFromMap(final Map<String, Object> map)
+      throws JsonParseException, JsonMappingException, IOException {
+    final String jsonString = jacksonJson.getObjectMapper().writeValueAsString(map);
+    return (jacksonJson.readTree(jsonString));
+  }
+
+  static JsonNode readTreeFromString(final String jsonString)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.readTree(jsonString));
+  }
+
+  static JsonNode readTreeFromResource(final String filename)
+      throws JsonParseException, JsonMappingException, IOException {
+    final InputStreamReader reader =
+        new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
+    return (jacksonJson.readTree(reader));
+  }
+
+  static <T> T unmarshalResource(final Class<T> returnType, final String filename)
+      throws JsonParseException, JsonMappingException, IOException {
+    final InputStreamReader reader =
+        new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
+    return (jacksonJson.unmarshal(returnType, reader));
+  }
+
+  static <T> List<T> unmarshalResourceList(final Class<T> returnType, final String filename)
+      throws JsonParseException, JsonMappingException, IOException {
+    final InputStreamReader reader =
+        new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
+    return (JsonUtils.unmarshalList(returnType, reader));
+  }
+
+  static <T> Map<String, T> unmarshalResourceMap(final Class<T> returnType, final String filename)
+      throws JsonParseException, JsonMappingException, IOException {
+    final InputStreamReader reader =
+        new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
+    return (jacksonJson.unmarshalMap(returnType, reader));
+  }
+
+  static <T> T unmarshal(final Class<T> returnType, final Reader reader)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshal(returnType, reader));
+  }
+
+  static <T> T unmarshal(final Class<T> returnType, final JsonNode tree)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshal(returnType, tree));
+  }
+
+  public static <T> T unmarshal(final Class<T> returnType, final String json)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshal(returnType, json));
+  }
+
+  static <T> List<T> unmarshalList(final Class<T> returnType, final Reader reader)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshalList(returnType, reader));
+  }
+
+  static <T> List<T> unmarshalList(final Class<T> returnType, final String json)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshalList(returnType, json));
+  }
+
+  static <T> Map<String, T> unmarshalMap(final Class<T> returnType, final Reader reader)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshalMap(returnType, reader));
+  }
+
+  static <T> Map<String, T> unmarshalMap(final Class<T> returnType, final String json)
+      throws JsonParseException, JsonMappingException, IOException {
+    return (jacksonJson.unmarshalMap(returnType, json));
+  }
+
+  static <T> boolean compareJson(final T apiObject, final String filename) throws IOException {
+    final InputStreamReader reader =
+        new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
+    return (compareJson(apiObject, reader));
+  }
+
+  static <T> boolean compareJson(final T apiObject, final InputStreamReader reader) throws IOException {
+
+    final String objectJson = jacksonJson.marshal(apiObject);
+    final JsonNode tree1 = jacksonJson.getObjectMapper().readTree(objectJson.getBytes());
+    final JsonNode tree2 = jacksonJson.getObjectMapper().readTree(reader);
+
+    final boolean sameJson = tree1.equals(tree2);
+    if (!sameJson) {
+      System.err.println("JSON did not match:");
+      sortedDump(tree1);
+      sortedDump(tree2);
     }
 
-    static JsonNode readTreeFromMap(Map<String, Object> map) throws JsonParseException, JsonMappingException, IOException {
-	String jsonString = jacksonJson.getObjectMapper().writeValueAsString(map);
-        return (jacksonJson.readTree(jsonString));
-    }
-    
-    static JsonNode readTreeFromString(String jsonString) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.readTree(jsonString));
-    }
+    return (sameJson);
+  }
 
-    static JsonNode readTreeFromResource(String filename) throws JsonParseException, JsonMappingException, IOException {
-        InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
-        return (jacksonJson.readTree(reader));
-    }
+  static <T> boolean compareJson(final T apiObject, final T apiObject1) throws IOException {
 
-    static <T> T unmarshalResource(Class<T> returnType, String filename) throws JsonParseException, JsonMappingException, IOException {
-        InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
-        return (jacksonJson.unmarshal(returnType, reader));
+    final String objectJson = jacksonJson.marshal(apiObject);
+    final String object1Json = jacksonJson.marshal(apiObject1);
+    final JsonNode tree1 = jacksonJson.getObjectMapper().readTree(objectJson.getBytes());
+    final JsonNode tree2 = jacksonJson.getObjectMapper().readTree(object1Json.getBytes());
+
+    final boolean sameJson = tree1.equals(tree2);
+    if (!sameJson) {
+      System.err.println("JSON did not match:");
+      sortedDump(tree1);
+      sortedDump(tree2);
     }
 
-    static <T> List<T> unmarshalResourceList(Class<T> returnType,  String filename) throws JsonParseException, JsonMappingException, IOException {
-        InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
-        return (JsonUtils.unmarshalList(returnType, reader));
+    return (sameJson);
+  }
+
+  static void sortedDump(final JsonNode node) throws JsonProcessingException {
+    System.err.println(sortedJsonString(node));
+    System.err.flush();
+  }
+
+  static String sortedJsonString(final JsonNode node) throws JsonProcessingException {
+    final Object obj = jacksonJson.getObjectMapper().treeToValue(node, Object.class);
+    return (jacksonJson.getObjectMapper().writeValueAsString(obj));
+  }
+
+  public static String readResource(final String filename) throws IOException {
+
+    final InputStreamReader reader = new InputStreamReader(GitLabApi.class.getResourceAsStream(filename));
+    final StringBuilder stringBuilder = new StringBuilder();
+
+    try (final BufferedReader br = new BufferedReader(reader)) {
+      String line;
+      while ((line = br.readLine()) != null) {
+        stringBuilder.append(line).append("\n");
+      }
     }
 
-    static <T> Map<String, T> unmarshalResourceMap(Class<T> returnType, String filename) throws JsonParseException, JsonMappingException, IOException {
-        InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
-        return (jacksonJson.unmarshalMap(returnType, reader));
-    }
-
-    static <T> T unmarshal(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshal(returnType, reader));
-    }
-
-    static <T> T unmarshal(Class<T> returnType, JsonNode tree) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshal(returnType, tree));
-    }
-
-    static <T> T unmarshal(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshal(returnType, json));
-    }
-
-    static <T> List<T> unmarshalList(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshalList(returnType, reader));
-    }
-
-    static <T> List<T> unmarshalList(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshalList(returnType, json));
-    }
-
-    static <T> Map<String, T> unmarshalMap(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshalMap(returnType, reader));
-    }
-
-    static <T> Map<String, T> unmarshalMap(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
-        return (jacksonJson.unmarshalMap(returnType, json));
-    }
-
-    static <T> boolean compareJson(T apiObject, String filename) throws IOException {
-        InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
-        return (compareJson(apiObject, reader));
-    }
-
-    static <T> boolean compareJson(T apiObject, InputStreamReader reader) throws IOException {
-
-        String objectJson = jacksonJson.marshal(apiObject);
-        JsonNode tree1 = jacksonJson.getObjectMapper().readTree(objectJson.getBytes());
-        JsonNode tree2 = jacksonJson.getObjectMapper().readTree(reader);
-
-        boolean sameJson = tree1.equals(tree2);
-        if (!sameJson) {
-            System.err.println("JSON did not match:");
-            sortedDump(tree1);
-            sortedDump(tree2);
-        }
-
-        return (sameJson);
-    }
-
-    static <T> boolean compareJson(T apiObject, T apiObject1) throws IOException {
-
-        String objectJson = jacksonJson.marshal(apiObject);
-        String object1Json = jacksonJson.marshal(apiObject1);
-        JsonNode tree1 = jacksonJson.getObjectMapper().readTree(objectJson.getBytes());
-        JsonNode tree2 = jacksonJson.getObjectMapper().readTree(object1Json.getBytes());
-
-        boolean sameJson = tree1.equals(tree2);
-        if (!sameJson) {
-            System.err.println("JSON did not match:");
-            sortedDump(tree1);
-            sortedDump(tree2);
-        }
-
-        return (sameJson);
-    }
-
-    static void sortedDump(final JsonNode node) throws JsonProcessingException {
-        System.err.println(sortedJsonString(node));
-        System.err.flush();
-    }
-
-    static String sortedJsonString(final JsonNode node) throws JsonProcessingException {
-        final Object obj = jacksonJson.getObjectMapper().treeToValue(node, Object.class);
-        return (jacksonJson.getObjectMapper().writeValueAsString(obj));
-    }
-
-    static String readResource(String filename) throws IOException {
-
-        InputStreamReader reader = new InputStreamReader(GitLabApi.class.getResourceAsStream(filename));
-        StringBuilder stringBuilder = new StringBuilder();
-
-        try (BufferedReader br = new BufferedReader(reader)) {
-            String line;
-            while ((line = br.readLine()) != null) {
-                stringBuilder.append(line).append("\n");
-            }
-        }
-
-        return (stringBuilder.toString());
-    }
+    return (stringBuilder.toString());
+  }
 }

--- a/src/test/java/org/gitlab4j/api/MockResponse.java
+++ b/src/test/java/org/gitlab4j/api/MockResponse.java
@@ -9,19 +9,19 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
-import javax.ws.rs.core.EntityTag;
-import javax.ws.rs.core.GenericType;
-import javax.ws.rs.core.Link;
-import javax.ws.rs.core.Link.Builder;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.NewCookie;
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.EntityTag;
+import jakarta.ws.rs.core.GenericType;
+import jakarta.ws.rs.core.Link;
+import jakarta.ws.rs.core.Link.Builder;
+import jakarta.ws.rs.core.MediaType;
+import jakarta.ws.rs.core.MultivaluedMap;
+import jakarta.ws.rs.core.NewCookie;
+import jakarta.ws.rs.core.Response;
 
 /**
  * This class can be used as a concrete mock to test the individual APIs
  * getXxxxx() methods without the need to have a GitLab server available.
- * 
+ *
  * Supports getXxxxx() methods that return a List of items, single items,
  * Optional items, and Pagers of items.
  */
@@ -144,7 +144,7 @@ public class MockResponse extends Response {
     /**************************************************************************************************
      * The remaining methods are stubbed so we can create an instance of this class. They are simply
      * stubs, but needed to do this because the Mockito Spy annotation does not work without JAXB
-     * on Java 11+ and did not wish to pull in the JAXB module even for testing. 
+     * on Java 11+ and did not wish to pull in the JAXB module even for testing.
      **************************************************************************************************/
 
     @Override

--- a/src/test/java/org/gitlab4j/api/MockServletInputStream.java
+++ b/src/test/java/org/gitlab4j/api/MockServletInputStream.java
@@ -2,8 +2,8 @@ package org.gitlab4j.api;
 
 import java.io.IOException;
 
-import javax.servlet.ReadListener;
-import javax.servlet.ServletInputStream;
+import jakarta.servlet.ReadListener;
+import jakarta.servlet.ServletInputStream;
 
 public class MockServletInputStream extends ServletInputStream {
 

--- a/src/test/java/org/gitlab4j/api/TestCommitDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestCommitDiscussionsApi.java
@@ -7,12 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.Discussion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,47 +21,52 @@ import org.mockito.Mockito;
 
 public class TestCommitDiscussionsApi implements Constants {
 
-    private static final String COMMIT_SHA = "abcdef1234567890";
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  private static final String COMMIT_SHA = "abcdef1234567890";
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(Discussion.class,  null,  "commit-discussions.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+    response = new MockResponse(Discussion.class, null, "commit-discussions.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetCommitDiscussionsByList() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getCommitDiscussions(1L, COMMIT_SHA);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "commit-discussions.json"));
-    }
+  @Test
+  public void testGetCommitDiscussionsByList() throws Exception {
+    final List<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getCommitDiscussions(1L, COMMIT_SHA);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "commit-discussions.json"));
+  }
 
-    @Test
-    public void testGetCommitDiscussionsByListWithMaxItems() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getCommitDiscussions(1L, COMMIT_SHA, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "commit-discussions.json"));
-    }
+  @Test
+  public void testGetCommitDiscussionsByListWithMaxItems() throws Exception {
+    final List<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getCommitDiscussions(1L, COMMIT_SHA, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "commit-discussions.json"));
+  }
 
-    @Test
-    public void testGetCommitDiscussionsByPager() throws Exception {
-        Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getCommitDiscussionsPager(1L, COMMIT_SHA, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions.all(), "commit-discussions.json"));
-    }
+  @Test
+  public void testGetCommitDiscussionsByPager() throws Exception {
+    final Pager<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getCommitDiscussionsPager(1L, COMMIT_SHA, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions.all(), "commit-discussions.json"));
+  }
 
-    @Test
-    public void testGetCommitDiscussionsByStream() throws Exception {
-        Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getCommitDiscussionsStream(1L, COMMIT_SHA);
-        assertNotNull(stream);
-        List<Discussion> discussions = stream.collect(Collectors.toList());
-        assertTrue(compareJson(discussions, "commit-discussions.json"));
-    }
+  @Test
+  public void testGetCommitDiscussionsByStream() throws Exception {
+    final Stream<Discussion> stream =
+        new DiscussionsApi(gitLabApi).getCommitDiscussionsStream(1L, COMMIT_SHA);
+    assertNotNull(stream);
+    final List<Discussion> discussions = stream.collect(Collectors.toList());
+    assertTrue(compareJson(discussions, "commit-discussions.json"));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestCommitsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestCommitsApi.java
@@ -15,7 +15,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.Comment;

--- a/src/test/java/org/gitlab4j/api/TestEpicDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestEpicDiscussionsApi.java
@@ -7,12 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.Discussion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,46 +21,48 @@ import org.mockito.Mockito;
 
 public class TestEpicDiscussionsApi implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(Discussion.class,  null,  "epic-discussions.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+    response = new MockResponse(Discussion.class, null, "epic-discussions.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetEpicDiscussionsByList() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussions(1L, 1L);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "epic-discussions.json"));
-    }
+  @Test
+  public void testGetEpicDiscussionsByList() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussions(1L, 1L);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "epic-discussions.json"));
+  }
 
-    @Test
-    public void testGetEpicDiscussionsByListWithMaxItems() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussions(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "epic-discussions.json"));
-    }
+  @Test
+  public void testGetEpicDiscussionsByListWithMaxItems() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussions(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "epic-discussions.json"));
+  }
 
-    @Test
-    public void testGetEpicDiscussionsByPager() throws Exception {
-        Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getEpicDiscussionsPager(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions.all(), "epic-discussions.json"));
-    }
+  @Test
+  public void testGetEpicDiscussionsByPager() throws Exception {
+    final Pager<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getEpicDiscussionsPager(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions.all(), "epic-discussions.json"));
+  }
 
-    @Test
-    public void testGetEpicDiscussionsByStream() throws Exception {
-        Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getEpicDiscussionsStream(1L, 1L);
-        assertNotNull(stream);
-        List<Discussion> discussions = stream.collect(Collectors.toList());
-        assertTrue(compareJson(discussions, "epic-discussions.json"));
-    }
+  @Test
+  public void testGetEpicDiscussionsByStream() throws Exception {
+    final Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getEpicDiscussionsStream(1L, 1L);
+    assertNotNull(stream);
+    final List<Discussion> discussions = stream.collect(Collectors.toList());
+    assertTrue(compareJson(discussions, "epic-discussions.json"));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestExternalStatusCheckApi.java
+++ b/src/test/java/org/gitlab4j/api/TestExternalStatusCheckApi.java
@@ -7,13 +7,11 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.ExternalStatusCheck;
 import org.gitlab4j.api.models.ExternalStatusCheckStatus;
 import org.junit.jupiter.api.BeforeEach;
@@ -25,77 +23,87 @@ import org.mockito.Mockito;
 
 public class TestExternalStatusCheckApi implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-        openMocks(this);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+  }
 
-    @Test
-    public void testGetExternalStatusChecks() throws Exception {
-        initGetExternalStatusChecks();
-        List<ExternalStatusCheck> result = new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecks(6L);
-        assertNotNull(result);
-        assertTrue(compareJson(result, "external-status-checks.json"));
-    }
+  @Test
+  public void testGetExternalStatusChecks() throws Exception {
+    initGetExternalStatusChecks();
+    final List<ExternalStatusCheck> result =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecks(6L);
+    assertNotNull(result);
+    assertTrue(compareJson(result, "external-status-checks.json"));
+  }
 
-    @Test
-    public void testGetExternalStatusChecksByPager() throws Exception {
-        initGetExternalStatusChecks();
-        Pager<ExternalStatusCheck> pager = new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecks(6L, 20);
-        assertNotNull(pager);
-        assertTrue(compareJson(pager.all(), "external-status-checks.json"));
-    }
+  @Test
+  public void testGetExternalStatusChecksByPager() throws Exception {
+    initGetExternalStatusChecks();
+    final Pager<ExternalStatusCheck> pager =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecks(6L, 20);
+    assertNotNull(pager);
+    assertTrue(compareJson(pager.all(), "external-status-checks.json"));
+  }
 
-    @Test
-    public void testGetExternalStatusChecksByStream() throws Exception {
-        initGetExternalStatusChecks();
-        Stream<ExternalStatusCheck> stream = new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecksStream(6L);
-        assertNotNull(stream);
-        List<ExternalStatusCheck> list = stream.collect(Collectors.toList());
-        assertTrue(compareJson(list, "external-status-checks.json"));
-    }
+  @Test
+  public void testGetExternalStatusChecksByStream() throws Exception {
+    initGetExternalStatusChecks();
+    final Stream<ExternalStatusCheck> stream =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusChecksStream(6L);
+    assertNotNull(stream);
+    final List<ExternalStatusCheck> list = stream.collect(Collectors.toList());
+    assertTrue(compareJson(list, "external-status-checks.json"));
+  }
 
-    private void initGetExternalStatusChecks() throws Exception, IOException {
-        response = new MockResponse(ExternalStatusCheck.class, null, "external-status-checks.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  private void initGetExternalStatusChecks() throws Exception, IOException {
+    response = new MockResponse(ExternalStatusCheck.class, null, "external-status-checks.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetExternalStatusCheckStatuses() throws Exception {
-        initGetExternalStatusCheckStatuses();
-        List<ExternalStatusCheckStatus> result = new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatuses(6L, 23L);
-        assertNotNull(result);
-        assertTrue(compareJson(result, "external-status-check-statuses.json"));
-    }
+  @Test
+  public void testGetExternalStatusCheckStatuses() throws Exception {
+    initGetExternalStatusCheckStatuses();
+    final List<ExternalStatusCheckStatus> result =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatuses(6L, 23L);
+    assertNotNull(result);
+    assertTrue(compareJson(result, "external-status-check-statuses.json"));
+  }
 
-    @Test
-    public void testGetExternalStatusCheckStatusesByPager() throws Exception {
-        initGetExternalStatusCheckStatuses();
-        Pager<ExternalStatusCheckStatus> pager = new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatuses(6L, 23L, 20);
-        assertNotNull(pager);
-        assertTrue(compareJson(pager.all(), "external-status-check-statuses.json"));
-    }
+  @Test
+  public void testGetExternalStatusCheckStatusesByPager() throws Exception {
+    initGetExternalStatusCheckStatuses();
+    final Pager<ExternalStatusCheckStatus> pager =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatuses(6L, 23L, 20);
+    assertNotNull(pager);
+    assertTrue(compareJson(pager.all(), "external-status-check-statuses.json"));
+  }
 
-    @Test
-    public void testGetExternalStatusCheckStatusesByStream() throws Exception {
-        initGetExternalStatusCheckStatuses();
-        Stream<ExternalStatusCheckStatus> stream = new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatusesStream(6L, 23L);
-        assertNotNull(stream);
-        List<ExternalStatusCheckStatus> list = stream.collect(Collectors.toList());
-        assertTrue(compareJson(list, "external-status-check-statuses.json"));
-    }
+  @Test
+  public void testGetExternalStatusCheckStatusesByStream() throws Exception {
+    initGetExternalStatusCheckStatuses();
+    final Stream<ExternalStatusCheckStatus> stream =
+        new ExternalStatusCheckApi(gitLabApi).getExternalStatusCheckStatusesStream(6L, 23L);
+    assertNotNull(stream);
+    final List<ExternalStatusCheckStatus> list = stream.collect(Collectors.toList());
+    assertTrue(compareJson(list, "external-status-check-statuses.json"));
+  }
 
-    private void initGetExternalStatusCheckStatuses() throws Exception, IOException {
-        response = new MockResponse(ExternalStatusCheckStatus.class, null, "external-status-check-statuses.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  private void initGetExternalStatusCheckStatuses() throws Exception, IOException {
+    response =
+        new MockResponse(
+            ExternalStatusCheckStatus.class, null, "external-status-check-statuses.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiEvents.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiEvents.java
@@ -14,8 +14,8 @@ import static org.mockito.Mockito.mock;
 
 import java.util.logging.Level;
 
-import javax.servlet.ServletInputStream;
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.ServletInputStream;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.gitlab4j.api.systemhooks.MergeRequestSystemHookEvent;
 import org.gitlab4j.api.systemhooks.ProjectSystemHookEvent;

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiException.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiException.java
@@ -10,7 +10,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.util.List;
 import java.util.Map;
 
-import javax.ws.rs.core.Response.Status;
+import jakarta.ws.rs.core.Response.Status;
 
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.Visibility;

--- a/src/test/java/org/gitlab4j/api/TestGroupApi.java
+++ b/src/test/java/org/gitlab4j/api/TestGroupApi.java
@@ -10,7 +10,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AccessRequest;

--- a/src/test/java/org/gitlab4j/api/TestIssueDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestIssueDiscussionsApi.java
@@ -7,12 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.Discussion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,46 +21,48 @@ import org.mockito.Mockito;
 
 public class TestIssueDiscussionsApi implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(Discussion.class,  null,  "issue-discussions.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+    response = new MockResponse(Discussion.class, null, "issue-discussions.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetIssueDiscussionsByList() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getIssueDiscussions(1L, 1L);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "issue-discussions.json"));
-    }
+  @Test
+  public void testGetIssueDiscussionsByList() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getIssueDiscussions(1L, 1L);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "issue-discussions.json"));
+  }
 
-    @Test
-    public void testGetIssueDiscussionsByListWithMaxItems() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getIssueDiscussions(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "issue-discussions.json"));
-    }
+  @Test
+  public void testGetIssueDiscussionsByListWithMaxItems() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getIssueDiscussions(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "issue-discussions.json"));
+  }
 
-    @Test
-    public void testGetIssueDiscussionsByPager() throws Exception {
-        Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getIssueDiscussionsPager(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions.all(), "issue-discussions.json"));
-    }
+  @Test
+  public void testGetIssueDiscussionsByPager() throws Exception {
+    final Pager<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getIssueDiscussionsPager(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions.all(), "issue-discussions.json"));
+  }
 
-    @Test
-    public void testGetIssueDiscussionsByStream() throws Exception {
-        Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getIssueDiscussionsStream(1L, 1L);
-        assertNotNull(stream);
-        List<Discussion> discussions = stream.collect(Collectors.toList());
-        assertTrue(compareJson(discussions, "issue-discussions.json"));
-    }
+  @Test
+  public void testGetIssueDiscussionsByStream() throws Exception {
+    final Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getIssueDiscussionsStream(1L, 1L);
+    assertNotNull(stream);
+    final List<Discussion> discussions = stream.collect(Collectors.toList());
+    assertTrue(compareJson(discussions, "issue-discussions.json"));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestIssuesApi.java
+++ b/src/test/java/org/gitlab4j/api/TestIssuesApi.java
@@ -35,7 +35,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.Random;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.Constants.IssueState;
 import org.gitlab4j.api.models.Duration;

--- a/src/test/java/org/gitlab4j/api/TestMergeRequestDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestMergeRequestDiscussionsApi.java
@@ -7,12 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.Discussion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,46 +21,50 @@ import org.mockito.Mockito;
 
 public class TestMergeRequestDiscussionsApi implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(Discussion.class,  null,  "merge-request-discussions.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+    response = new MockResponse(Discussion.class, null, "merge-request-discussions.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetMergeRequestDiscussionsByList() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getMergeRequestDiscussions(1L, 1L);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "merge-request-discussions.json"));
-    }
+  @Test
+  public void testGetMergeRequestDiscussionsByList() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getMergeRequestDiscussions(1L, 1L);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "merge-request-discussions.json"));
+  }
 
-    @Test
-    public void testGetMergeRequestDiscussionsByListMaxItems() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getMergeRequestDiscussions(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "merge-request-discussions.json"));
-    }
+  @Test
+  public void testGetMergeRequestDiscussionsByListMaxItems() throws Exception {
+    final List<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getMergeRequestDiscussions(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "merge-request-discussions.json"));
+  }
 
-    @Test
-    public void testGetMergeRequestDiscussionsByPager() throws Exception {
-        Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getMergeRequestDiscussionsPager(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions.all(), "merge-request-discussions.json"));
-    }
+  @Test
+  public void testGetMergeRequestDiscussionsByPager() throws Exception {
+    final Pager<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getMergeRequestDiscussionsPager(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions.all(), "merge-request-discussions.json"));
+  }
 
-    @Test
-    public void testGetMergeRequestDiscussionsByStream() throws Exception {
-        Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getMergeRequestDiscussionsStream(1L, 1L);
-        assertNotNull(stream);
-        List<Discussion> discussions = stream.collect(Collectors.toList());
-        assertTrue(compareJson(discussions, "merge-request-discussions.json"));
-    }
+  @Test
+  public void testGetMergeRequestDiscussionsByStream() throws Exception {
+    final Stream<Discussion> stream =
+        new DiscussionsApi(gitLabApi).getMergeRequestDiscussionsStream(1L, 1L);
+    assertNotNull(stream);
+    final List<Discussion> discussions = stream.collect(Collectors.toList());
+    assertTrue(compareJson(discussions, "merge-request-discussions.json"));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -36,7 +36,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.AccessRequest;

--- a/src/test/java/org/gitlab4j/api/TestSnippetDiscussionsApi.java
+++ b/src/test/java/org/gitlab4j/api/TestSnippetDiscussionsApi.java
@@ -7,12 +7,10 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.Discussion;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -23,46 +21,48 @@ import org.mockito.Mockito;
 
 public class TestSnippetDiscussionsApi implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(Discussion.class,  null, "snippet-discussions.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
-    }
+  @BeforeEach
+  public void setUp() throws Exception {
+    openMocks(this);
+    response = new MockResponse(Discussion.class, null, "snippet-discussions.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
 
-    @Test
-    public void testGetSnippetDiscussionsByList() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getSnippetDiscussions(1L, 1L);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "snippet-discussions.json"));
-    }
+  @Test
+  public void testGetSnippetDiscussionsByList() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getSnippetDiscussions(1L, 1L);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "snippet-discussions.json"));
+  }
 
-    @Test
-    public void testGetSnippetDiscussionsByListWithMaxItems() throws Exception {
-        List<Discussion> discussions = new DiscussionsApi(gitLabApi).getSnippetDiscussions(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions, "snippet-discussions.json"));
-    }
+  @Test
+  public void testGetSnippetDiscussionsByListWithMaxItems() throws Exception {
+    final List<Discussion> discussions = new DiscussionsApi(gitLabApi).getSnippetDiscussions(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions, "snippet-discussions.json"));
+  }
 
-    @Test
-    public void testGetSnippetDiscussionsByPager() throws Exception {
-        Pager<Discussion> discussions = new DiscussionsApi(gitLabApi).getSnippetDiscussionsPager(1L, 1L, 20);
-        assertNotNull(discussions);
-        assertTrue(compareJson(discussions.all(), "snippet-discussions.json"));
-    }
+  @Test
+  public void testGetSnippetDiscussionsByPager() throws Exception {
+    final Pager<Discussion> discussions =
+        new DiscussionsApi(gitLabApi).getSnippetDiscussionsPager(1L, 1L, 20);
+    assertNotNull(discussions);
+    assertTrue(compareJson(discussions.all(), "snippet-discussions.json"));
+  }
 
-    @Test
-    public void testGetSnippetDiscussionsByStream() throws Exception {
-        Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getSnippetDiscussionsStream(1L, 1L);
-        assertNotNull(stream);
-        List<Discussion> discussions = stream.collect(Collectors.toList());
-        assertTrue(compareJson(discussions, "snippet-discussions.json"));
-    }
+  @Test
+  public void testGetSnippetDiscussionsByStream() throws Exception {
+    final Stream<Discussion> stream = new DiscussionsApi(gitLabApi).getSnippetDiscussionsStream(1L, 1L);
+    assertNotNull(stream);
+    final List<Discussion> discussions = stream.collect(Collectors.toList());
+    assertTrue(compareJson(discussions, "snippet-discussions.json"));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestStreams.java
+++ b/src/test/java/org/gitlab4j/api/TestStreams.java
@@ -11,11 +11,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.List;
 import java.util.stream.Stream;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.User;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,93 +25,94 @@ import org.mockito.Mockito;
 
 public class TestStreams implements Constants {
 
-    @Mock private GitLabApi gitLabApi;
-    @Mock private GitLabApiClient gitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse response;
+  @Mock private GitLabApi gitLabApi;
+  @Mock private GitLabApiClient gitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
+  private MockResponse response;
 
-    static private List<User> sortedUsers;
+  private static List<User> sortedUsers;
 
-    @BeforeAll
-    public static void setupClass() throws Exception {
+  @BeforeAll
+  public static void setupClass() throws Exception {
 
-        // Get a list of users sorted by username, we use this as thye source of truth for the asserts
-        sortedUsers = JsonUtils.unmarshalResourceList(User.class, "user-list.json");
-        sortedUsers.sort(comparing(User::getUsername));
+    // Get a list of users sorted by username, we use this as thye source of truth for the asserts
+    sortedUsers = JsonUtils.unmarshalResourceList(User.class, "user-list.json");
+    sortedUsers.sort(comparing(User::getUsername));
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    openMocks(this);
+    response = new MockResponse(User.class, null, "user-list.json");
+    when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
+    when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
+    when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .thenReturn(response);
+  }
+
+  @Test
+  public void testStream() throws Exception {
+
+    // Arrange
+    final Stream<User> stream = new UserApi(gitLabApi).getUsersStream();
+
+    // Assert
+    assertNotNull(stream);
+    final List<User> users = stream.sorted(comparing(User::getUsername)).collect(toList());
+    assertNotNull(users);
+
+    assertEquals(users.size(), sortedUsers.size());
+    for (int i = 0; i < users.size(); i++) {
+      assertTrue(compareJson(sortedUsers.get(i), users.get(i)));
     }
+  }
 
-    @BeforeEach
-    public void setup() throws Exception {
-    	openMocks(this);
-        response = new MockResponse(User.class, null, "user-list.json");
-        when(gitLabApi.getApiClient()).thenReturn(gitLabApiClient);
-        when(gitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(gitLabApiClient.get(attributeCaptor.capture(), Mockito.<Object>any())).thenReturn(response);
+  @Test
+  public void testParallelStream() throws Exception {
+
+    // Arrange
+    final Stream<User> stream = new UserApi(gitLabApi).getUsersStream();
+
+    // Assert
+    assertNotNull(stream);
+    final List<User> users = stream.parallel().sorted(comparing(User::getUsername)).collect(toList());
+    assertNotNull(users);
+
+    assertEquals(users.size(), sortedUsers.size());
+    for (int i = 0; i < users.size(); i++) {
+      assertTrue(compareJson(sortedUsers.get(i), users.get(i)));
     }
+  }
 
-    @Test
-    public void testStream() throws Exception {
+  @Test
+  public void testLazyStream() throws Exception {
 
-        // Arrange
-        Stream<User> stream = new UserApi(gitLabApi).getUsersStream();
+    // Arrange
+    final Pager<User> pager = new UserApi(gitLabApi).getUsers(10);
+    final Stream<User> stream = pager.lazyStream();
 
-        // Assert
-        assertNotNull(stream);
-        List<User> users = stream.sorted(comparing(User::getUsername)).collect(toList());
-        assertNotNull(users);
+    // Assert
+    assertNotNull(stream);
+    final List<String> usernames = stream.map(User::getUsername).collect(toList());
+    assertNotNull(usernames);
 
-        assertEquals(users.size(), sortedUsers.size());
-        for (int i = 0; i < users.size(); i++) {
-            assertTrue(compareJson(sortedUsers.get(i), users.get(i)));
-        }
+    assertEquals(usernames.size(), sortedUsers.size());
+    for (int i = 0; i < sortedUsers.size(); i++) {
+      assertTrue(usernames.contains(sortedUsers.get(i).getUsername()));
     }
+  }
 
-    @Test
-    public void testParallelStream() throws Exception {
+  @Test
+  public void testStreamLazyLimit() throws Exception {
 
-        // Arrange
-        Stream<User> stream = new UserApi(gitLabApi).getUsersStream();
+    // Arrange and only continue if there are more than 3 users
+    final Pager<User> pager = new UserApi(gitLabApi).getUsers(2);
+    assumeTrue(pager != null && pager.getTotalItems() > 3);
+    final Stream<User> stream = pager.lazyStream();
 
-        // Assert
-        assertNotNull(stream);
-        List<User> users = stream.parallel().sorted(comparing(User::getUsername)).collect(toList());
-        assertNotNull(users);
-
-        assertEquals(users.size(), sortedUsers.size());
-        for (int i = 0; i < users.size(); i++) {
-            assertTrue(compareJson(sortedUsers.get(i), users.get(i)));
-        }
-    }
-
-    @Test
-    public void testLazyStream() throws Exception {
-
-        // Arrange
-        Pager<User> pager = new UserApi(gitLabApi).getUsers(10);
-        Stream<User> stream = pager.lazyStream();
-
-        // Assert
-        assertNotNull(stream);
-        List<String> usernames = stream.map(User::getUsername).collect(toList());
-        assertNotNull(usernames);
-
-        assertEquals(usernames.size(), sortedUsers.size());
-        for (int i = 0; i < sortedUsers.size(); i++) {
-            assertTrue(usernames.contains(sortedUsers.get(i).getUsername()));
-        }
-    }
-
-    @Test
-    public void testStreamLazyLimit() throws Exception {
-
-        // Arrange and only continue if there are more than 3 users
-        Pager<User> pager = new UserApi(gitLabApi).getUsers(2);
-        assumeTrue(pager != null && pager.getTotalItems() > 3);
-        Stream<User> stream = pager.lazyStream();
-
-        // Assert
-        List<User> users = stream.limit(3).collect(toList());
-        assertNotNull(users);
-        assertEquals(3, users.size());
-    }
+    // Assert
+    final List<User> users = stream.limit(3).collect(toList());
+    assertNotNull(users);
+    assertEquals(3, users.size());
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestUnitMergeRequestApi.java
+++ b/src/test/java/org/gitlab4j/api/TestUnitMergeRequestApi.java
@@ -4,59 +4,75 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasEntry;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
-import static org.mockito.MockitoAnnotations.openMocks;
 
+import jakarta.ws.rs.core.MultivaluedMap;
 import java.util.Collections;
-
-import javax.ws.rs.core.MultivaluedMap;
-
 import org.gitlab4j.api.models.MergeRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
+import org.mockito.BDDMockito;
 import org.mockito.Captor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
 
-public class TestUnitMergeRequestApi {
+@ExtendWith(MockitoExtension.class)
+class TestUnitMergeRequestApi {
 
-    @Mock private GitLabApi mockGitLabApi;
-    @Mock private GitLabApiClient mockedGitLabApiClient;
-    @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
-    private MockResponse mockedResponse;
+  @Mock private GitLabApi mockGitLabApi;
+  @Mock private GitLabApiClient mockedGitLabApiClient;
+  @Captor private ArgumentCaptor<MultivaluedMap<String, String>> attributeCaptor;
 
-    @BeforeEach
-    public void setUp() throws Exception {
-    	openMocks(this);
-        mockedResponse = new MockResponse(MergeRequest.class, "merge-request.json", null);
-        when(mockGitLabApi.getApiClient()).thenReturn(mockedGitLabApiClient);
+  @BeforeEach
+  void setUp() throws Exception {
+    BDDMockito.given(mockGitLabApi.getApiClient()).willReturn(mockedGitLabApiClient);
+    BDDMockito.given(mockedGitLabApiClient.validateSecretToken(any())).willReturn(true);
+    final MockResponse mockedResponse =
+        new MockResponse(MergeRequest.class, "merge-request.json", null);
+    BDDMockito.given(
+            mockedGitLabApiClient.put(attributeCaptor.capture(), Mockito.any(Object[].class)))
+        .willReturn(mockedResponse);
+  }
 
-        when(mockedGitLabApiClient.validateSecretToken(any())).thenReturn(true);
-        when(mockedGitLabApiClient.put(attributeCaptor.capture(), Mockito.<Object>any()))
-                .thenReturn(mockedResponse);
-    }
+  @Test
+  void whenAllArgumentsNull_thenNoAttributesSent() throws Exception {
+    // Given
+    final MergeRequestApi mergeRequestApi = new MergeRequestApi(this.mockGitLabApi);
 
-    @Test
-    public void whenAllArgumentsNull_thenNoAttributesSent() throws Exception {
-        new MergeRequestApi(mockGitLabApi).updateMergeRequest(1L, 2L, null, null, null, null, null, null,
-                null, null, null, null, null);
-        assertEquals(0, attributeCaptor.getValue().size());
-    }
+    // When
+    mergeRequestApi.updateMergeRequest(
+        1L, 2L, null, null, null, null, null, null, null, null, null, null, null);
+    // Then
+    assertEquals(0, attributeCaptor.getValue().size());
+  }
 
-    @Test
-    public void falseBooleansAreSerializedCorrectly() throws Exception {
-        new MergeRequestApi(mockGitLabApi).updateMergeRequest(1L, 2L, null, null, null, null, null, null,
-                null, null, null, null, false);
-        assertThat(attributeCaptor.getValue(),
-                hasEntry("allow_collaboration", Collections.singletonList("false")));
-    }
+  @Test
+  void falseBooleansAreSerializedCorrectly() throws Exception {
+    // Given
+    final MergeRequestApi mergeRequestApi = new MergeRequestApi(this.mockGitLabApi);
 
-    @Test
-    public void trueBooleansAreSerializedCorrectly() throws Exception {
-        new MergeRequestApi(mockGitLabApi).updateMergeRequest(1L, 2L, null, null, null, null, null, null,
-                null, null, null, null, true);
-        assertThat(attributeCaptor.getValue(),
-                hasEntry("allow_collaboration", Collections.singletonList("true")));
-    }
+    // When
+    mergeRequestApi.updateMergeRequest(
+        1L, 2L, null, null, null, null, null, null, null, null, null, null, false);
+    // Then
+    assertThat(
+        attributeCaptor.getValue(),
+        hasEntry("allow_collaboration", Collections.singletonList("false")));
+  }
+
+  @Test
+  void trueBooleansAreSerializedCorrectly() throws Exception {
+    // Given
+    final MergeRequestApi mergeRequestApi = new MergeRequestApi(this.mockGitLabApi);
+
+    // When
+    mergeRequestApi.updateMergeRequest(
+        1L, 2L, null, null, null, null, null, null, null, null, null, null, true);
+    // Then
+    assertThat(
+        attributeCaptor.getValue(),
+        hasEntry("allow_collaboration", Collections.singletonList("true")));
+  }
 }

--- a/src/test/java/org/gitlab4j/api/TestUserApi.java
+++ b/src/test/java/org/gitlab4j/api/TestUserApi.java
@@ -15,7 +15,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Optional;
 
-import javax.ws.rs.core.Response;
+import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.models.AccessLevel;
 import org.gitlab4j.api.models.Email;


### PR DESCRIPTION
In order to use gitlab4j-api with new version of SpringBoot and related dependencies, we had to upgrade several libraries.
It implies also a move from javax.xxx to jakarta.xxx for JEE libraries.

Relates to existing issues:
- Move to Java 11 or Java 17 for next major iteration of gitlab4j-api #817
- Add java9+ and Jakarta EE Support #894