### PR TITLE
Initial work for 6.x branch

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -9,8 +9,8 @@ on:
 
 jobs:
 
-  build-jdk8:
-    name: "Build JDK 8"
+  build-jdk11:
+    name: "Build JDK 11"
     runs-on: ubuntu-latest
     services:
       gitlab-instance:
@@ -23,11 +23,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Set up JDK 8
+      - name: Set up JDK 11
         uses: actions/setup-java@v2
         with:
           distribution: adopt-hotspot
-          java-version: 8
+          java-version: 11
       - name: Get Date
         id: get-date
         run: |

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ GitLab4J&trade; API (gitlab4j-api) provides a full featured and easy to consume 
 ## Table of Contents
 * [GitLab Server Version Support](#gitLab-server-version-support)<br/>
 * [Using GitLab4J-API](#using-gitlab4j-api)<br/>
-  * [Java 8 Requirement](#java-8-requirement)<br/>
+  * [Java 11 Requirement](#java-11-requirement)<br/>
   * [Javadocs](#javadocs)<br/>
   * [Project Set Up](#project-set-up)<br/>
   * [Usage Examples](#usage-examples)<br/>
@@ -40,8 +40,8 @@ As of GitLab 11.0 support for the GitLab API v3 has been removed from the GitLab
 ---
 ## Using GitLab4J-API
 
-### **Java 8 Requirement**
-As of GitLab4J-API 4.8.0, Java 8+ is now required to use GitLab4J-API.
+### **Java 11 Requirement**
+As of GitLab4J-API 6.0.0, Java 11+ is now required to use GitLab4J-API.
 
 ### **Javadocs**
 Javadocs are available here: [![javadoc.io](https://javadoc.io/badge2/org.gitlab4j/gitlab4j-api/javadoc.io.svg)](https://javadoc.io/doc/org.gitlab4j/gitlab4j-api)
@@ -53,7 +53,7 @@ To utilize GitLab4J&trade; API in your Java project, simply add the following de
 ```java
 dependencies {
     ...
-    compile group: 'org.gitlab4j', name: 'gitlab4j-api', version: '5.1.0'
+    compile group: 'org.gitlab4j', name: 'gitlab4j-api', version: '6.0.0'
 }
 ```
 
@@ -64,7 +64,7 @@ dependencies {
 <dependency>
     <groupId>org.gitlab4j</groupId>
     <artifactId>gitlab4j-api</artifactId>
-    <version>5.1.0</version>
+    <version>6.0.0</version>
 </dependency>
 ```
 

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api</artifactId>
 	<packaging>jar</packaging>
-	<version>5.1.0</version>
+	<version>6.0.0-SNAPSHOT</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>
@@ -43,9 +43,9 @@
 	</developers>
 
 	<properties>
-		<java.level>8</java.level>
-		<java.source.version>1.8</java.source.version>
-		<java.target.version>1.8</java.target.version>
+		<java.source.version>11</java.source.version>
+		<java.target.version>11</java.target.version>
+		<maven.compiler.release>11</maven.compiler.release>
 
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -258,7 +258,7 @@
 				<configuration>
 					<rules>
 						<enforceBytecodeVersion>
-							<maxJdkVersion>1.8</maxJdkVersion>
+							<maxJdkVersion>11</maxJdkVersion>
 							<ignoreClasses>
 								<ignoreClass>module-info</ignoreClass>
 							</ignoreClasses>
@@ -280,26 +280,6 @@
 						<version>1.3</version>
 					</dependency>
 				</dependencies>
-			</plugin>
-
-			<plugin>
-				<groupId>org.codehaus.mojo</groupId>
-				<artifactId>animal-sniffer-maven-plugin</artifactId>
-				<version>1.20</version>
-				<executions>
-					<execution>
-						<goals>
-							<goal>check</goal>
-						</goals>
-						<id>check</id>
-					</execution>
-				</executions>
-				<configuration>
-					<signature>
-						<groupId>org.codehaus.mojo.signature</groupId>
-						<artifactId>java1${java.level}</artifactId>
-					</signature>
-				</configuration>
 			</plugin>
 
 			<plugin>


### PR DESCRIPTION
This is the preparation work to work on the `6.x.x` version on the `6.x` branch, as described in https://github.com/gitlab4j/gitlab4j-api/issues/926.

* Update to java 11
* Bump version to `6.0.0-SNAPSHOT`

Based on the work of @gedeffe in https://github.com/gitlab4j/gitlab4j-api/pull/943

