### PR TITLE
Remove deprecated methods in the "models" package

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Branch.java
+++ b/src/main/java/org/gitlab4j/api/models/Branch.java
@@ -107,18 +107,6 @@ public class Branch {
         return this;
     }
 
-    /**
-     * Set the merged attribute
-     * @param merged
-     * @deprecated Use {@link #withMerged(Boolean)} instead
-     * @return Current branch instance
-     */
-    @Deprecated
-    public Branch withDerged(Boolean merged) {
-        this.merged = merged;
-        return this;
-    }
-
     public Branch withMerged(Boolean merged) {
         this.merged = merged;
         return this;

--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -34,14 +34,6 @@ public class GroupFilter {
     }
 
     /**
-     * @deprecated this method contains a typo, use {@link #withAllAvailable(Boolean)} instead
-     */
-    @Deprecated
-    public GroupFilter withAllAvailabley(Boolean allAvailable) {
-        return withAllAvailable(allAvailable);
-    }
-
-    /**
      * Show all the groups you have access to (defaults to false for authenticated users, true for admin).
      * Attributes owned and min_access_level have precedence
      *

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -130,26 +130,6 @@ public class Pipeline {
     }
 
     /**
-     * @deprecated Replaced by {@link #getUpdatedAt()}
-     * @return the updated at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getUpdated_at() {
-        return updatedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setUpdatedAt(Date)}
-     * @param updatedAt new updated at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setUpdated_at(Date updatedAt) {
-        this.updatedAt = updatedAt;
-    }
-
-    /**
      * @deprecated Replaced by {@link #getStartedAt()}
      * @return the started at Date
      */
@@ -157,56 +137,6 @@ public class Pipeline {
     @JsonIgnore
     public Date getStarted_at() {
         return startedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setStartedAt(Date)}
-     * @param startedAt new started at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setStarted_at(Date startedAt) {
-        this.startedAt = startedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #getFinishedAt()}
-     * @return the finished at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getFinished_at() {
-        return finishedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setFinishedAt(Date)}
-     * @param finishedAt new finished at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setFinished_at(Date finishedAt) {
-        this.finishedAt = finishedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #getCommittedAt()}
-     * @return the committed at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getCommitted_at() {
-        return committedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setCommittedAt(Date)}
-     * @param committedAt new committed at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setCommitted_at(Date committedAt) {
-        this.committedAt = committedAt;
     }
 
     public String getCoverage() {

--- a/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
@@ -227,19 +227,6 @@ public class ProjectFilter {
     }
 
     /**
-     * Limit by current user minimal access level
-     *
-     * @param minAccessLevel limit by current user minimal access level
-     * @return the reference to this ProjectFilter instance
-     * @deprecated Replaced by {@link #withMinAccessLevel(AccessLevel) getComponentAt}
-     */
-    @Deprecated
-	public ProjectFilter minAccessLevel(AccessLevel minAccessLevel) {
-        this.minAccessLevel = minAccessLevel;
-        return (this);
-    }
-
-    /**
      * Limit by current user minimal access level.
      *
      * @param minAccessLevel limit by current user minimal access level

--- a/src/main/java/org/gitlab4j/api/models/PushData.java
+++ b/src/main/java/org/gitlab4j/api/models/PushData.java
@@ -16,18 +16,6 @@ public class PushData {
     private String ref;
     private String commitTitle;
 
-    @Deprecated
-    @JsonIgnore
-    public Integer getCommit_count() {
-        return commitCount;
-    }
-
-    @Deprecated
-    @JsonIgnore
-    public void setCommit_count(Integer commit_count) {
-        this.commitCount = commit_count;
-    }
-
     public Integer getCommitCount() {
         return commitCount;
     }

--- a/src/main/java/org/gitlab4j/api/models/User.java
+++ b/src/main/java/org/gitlab4j/api/models/User.java
@@ -423,32 +423,6 @@ public class User extends AbstractUser<User> {
         return this;
     }
 
-    /**
-     * Fluent method to set the projects_limit setting.
-     *
-     * @param projectsLimit the value for the projects_limit setting
-     * @deprecated Replaced by {@link #withProjectsLimit(Integer)}
-     * @see #withProjectsLimit(Integer)
-     * @return the value of this instance
-     */
-    @Deprecated
-    public User withProjectLimit(Integer projectsLimit) {
-        return withProjectsLimit(projectsLimit);
-    }
- 
-    /**
-     * Fluent method to set the shared_projects_minutes_limit setting.
-     *
-     * @param sharedRunnersMinuteLimit the value for the shared_projects_minutes_limit setting
-     * @deprecated Replaced by {@link #withSharedRunnersMinutesLimit(Integer)}
-     * @see #withSharedRunnersMinutesLimit(Integer)
-     * @return the value of this instance
-     */
-    @Deprecated
-    public User withSharedRunnersMinuteLimit(Integer sharedRunnersMinuteLimit) {
-        return withSharedRunnersMinutesLimit(sharedRunnersMinuteLimit);
-    }
-
     @Override
     public String toString() {
         return (JacksonJson.toJsonString(this));


### PR DESCRIPTION
Since breaking changes are allowed on the [`6.x` branch](https://github.com/gitlab4j/gitlab4j-api/tree/6.x) where the next major version is prepared: 

In the package `org.gitlab4j.api.models`, remove the deprecated methods that have a clear replacement (there was a typo or an inconsistency).
