### PR TITLE
Change the response type of "createFile" and "updateFile"

### DIFF
--- a/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
+++ b/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
@@ -16,6 +16,7 @@ import jakarta.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Blame;
 import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.RepositoryFileResponse;
 
 /**
  * This class provides an entry point to all the GitLab API repository files calls.
@@ -211,7 +212,7 @@ public class RepositoryFileApi extends AbstractApi {
      * @return a RepositoryFile instance with the created file info
      * @throws GitLabApiException if any exception occurs
      */
-    public RepositoryFile createFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
+    public RepositoryFileResponse createFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
 
         Form formData = createForm(file, branchName, commitMessage);
         Response response;
@@ -223,7 +224,7 @@ public class RepositoryFileApi extends AbstractApi {
                     "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(file.getFilePath()));
         }
 
-        return (response.readEntity(RepositoryFile.class));
+        return (response.readEntity(RepositoryFileResponse.class));
     }
 
     /**
@@ -246,7 +247,7 @@ public class RepositoryFileApi extends AbstractApi {
      * @deprecated  Will be removed in version 6.0, replaced by {@link #createFile(Object, RepositoryFile, String, String)}
      */
     @Deprecated
-    public RepositoryFile createFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
+    public RepositoryFileResponse createFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
         return (createFile(projectId, file, branchName, commitMessage));
     }
 
@@ -268,7 +269,7 @@ public class RepositoryFileApi extends AbstractApi {
      * @return a RepositoryFile instance with the updated file info
      * @throws GitLabApiException if any exception occurs
      */
-    public RepositoryFile updateFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
+    public RepositoryFileResponse updateFile(Object projectIdOrPath, RepositoryFile file, String branchName, String commitMessage) throws GitLabApiException {
 
         Form formData = createForm(file, branchName, commitMessage);
         Response response;
@@ -280,7 +281,7 @@ public class RepositoryFileApi extends AbstractApi {
                     "projects", getProjectIdOrPath(projectIdOrPath), "repository", "files", urlEncode(file.getFilePath()));
         }
 
-        return (response.readEntity(RepositoryFile.class));
+        return (response.readEntity(RepositoryFileResponse.class));
     }
 
     /**
@@ -303,7 +304,7 @@ public class RepositoryFileApi extends AbstractApi {
      * @deprecated  Will be removed in version 6.0, replaced by {@link #updateFile(Object, RepositoryFile, String, String)}
      */
     @Deprecated
-    public RepositoryFile updateFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
+    public RepositoryFileResponse updateFile(RepositoryFile file, Long projectId, String branchName, String commitMessage) throws GitLabApiException {
         return (updateFile(projectId, file, branchName, commitMessage));
     }
 

--- a/src/main/java/org/gitlab4j/api/models/RepositoryFileResponse.java
+++ b/src/main/java/org/gitlab4j/api/models/RepositoryFileResponse.java
@@ -1,0 +1,36 @@
+
+package org.gitlab4j.api.models;
+
+import java.util.Base64;
+
+import org.gitlab4j.api.Constants.Encoding;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
+public class RepositoryFileResponse {
+
+    private String filePath; // full path to file. Ex. lib/class.rb
+    private String branch;
+
+    public String getFilePath() {
+        return filePath;
+    }
+
+    public void setFilePath(String filePath) {
+        this.filePath = filePath;
+    }
+
+    public String getBranch() {
+        return branch;
+    }
+
+    public void setBranch(String branch) {
+        this.branch = branch;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -103,6 +103,7 @@ import org.gitlab4j.api.models.RegistryRepository;
 import org.gitlab4j.api.models.Release;
 import org.gitlab4j.api.models.RemoteMirror;
 import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.RepositoryFileResponse;
 import org.gitlab4j.api.models.Runner;
 import org.gitlab4j.api.models.RunnerDetail;
 import org.gitlab4j.api.models.SearchBlob;
@@ -546,6 +547,12 @@ public class TestGitLabApiBeans {
     public void testRepositoryFile() throws Exception {
         RepositoryFile file = unmarshalResource(RepositoryFile.class, "repository-file.json");
         assertTrue(compareJson(file, "repository-file.json"));
+    }
+    
+    @Test
+    public void testRepositoryFileResponse() throws Exception {
+        RepositoryFileResponse file = unmarshalResource(RepositoryFileResponse.class, "repository-file-response.json");
+        assertTrue(compareJson(file, "repository-file-response.json"));
     }
 
     @Test

--- a/src/test/java/org/gitlab4j/api/TestPipelineApi.java
+++ b/src/test/java/org/gitlab4j/api/TestPipelineApi.java
@@ -18,6 +18,7 @@ import org.gitlab4j.api.models.Pipeline;
 import org.gitlab4j.api.models.PipelineSchedule;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.RepositoryFileResponse;
 import org.gitlab4j.api.models.Trigger;
 import org.gitlab4j.api.models.Variable;
 import org.junit.jupiter.api.AfterAll;
@@ -39,8 +40,8 @@ public class TestPipelineApi extends AbstractIntegrationTest {
 
     private static GitLabApi gitLabApi;
     private static Project testProject;
-    private static RepositoryFile createdGitlabCiYml;
-    private static RepositoryFile gitlabCiYml;
+    private static RepositoryFileResponse createdGitlabCiYml;
+    private static RepositoryFileResponse gitlabCiYml;
 
     public TestPipelineApi() {
         super();
@@ -91,7 +92,10 @@ public class TestPipelineApi extends AbstractIntegrationTest {
         Optional<RepositoryFile> fileInfo =
                 gitLabApi.getRepositoryFileApi().getOptionalFileInfo(testProject, ".gitlab-ci.yml", "master");
         if (fileInfo.isPresent()) {
-            gitlabCiYml = fileInfo.get();
+            RepositoryFileResponse file = new RepositoryFileResponse();
+            file.setBranch(fileInfo.get().getRef());
+            file.setFilePath(fileInfo.get().getFilePath());
+            gitlabCiYml = file;
         } else {
 
             try {

--- a/src/test/java/org/gitlab4j/api/TestRepositoryFileApi.java
+++ b/src/test/java/org/gitlab4j/api/TestRepositoryFileApi.java
@@ -17,6 +17,7 @@ import java.util.Optional;
 import org.gitlab4j.api.models.Branch;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.RepositoryFile;
+import org.gitlab4j.api.models.RepositoryFileResponse;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
@@ -156,7 +157,7 @@ public class TestRepositoryFileApi extends AbstractIntegrationTest {
         RepositoryFile file = new RepositoryFile();
         file.setFilePath(TEST_FILEPATH);
         file.setContent(TEST_CONTENT);
-        RepositoryFile createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
+        RepositoryFileResponse createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
         assertNotNull(createdFile);
 
         gitLabApi.getRepositoryFileApi().deleteFile(project.getId(), TEST_FILEPATH, TEST_BRANCH_NAME, "Testing deleteFile().");
@@ -175,7 +176,7 @@ public class TestRepositoryFileApi extends AbstractIntegrationTest {
         RepositoryFile file = new RepositoryFile();
         file.setFilePath(TEST_FILEPATH);
         file.setContent("");
-        RepositoryFile createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
+        RepositoryFileResponse createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
         assertNotNull(createdFile);
 
         gitLabApi.getRepositoryFileApi().deleteFile(project.getId(), TEST_FILEPATH, TEST_BRANCH_NAME, "Testing deleteFile().");
@@ -194,7 +195,7 @@ public class TestRepositoryFileApi extends AbstractIntegrationTest {
         RepositoryFile file = new RepositoryFile();
         file.setFilePath(TEST_FILEPATH);
         file.setContent(TEST_CONTENT);
-        RepositoryFile createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
+        RepositoryFileResponse createdFile = gitLabApi.getRepositoryFileApi().createFile(project.getId(), file, TEST_BRANCH_NAME, "Testing createFile().");
         assertNotNull(createdFile);
 
         Optional<RepositoryFile> optionalFile = gitLabApi.getRepositoryFileApi().getOptionalFile(project, TEST_FILEPATH, TEST_BRANCH_NAME);

--- a/src/test/resources/org/gitlab4j/api/repository-file-response.json
+++ b/src/test/resources/org/gitlab4j/api/repository-file-response.json
@@ -1,0 +1,4 @@
+{
+  "file_path": "app/project.rb",
+  "branch": "master"
+}


### PR DESCRIPTION
Fixes #893

The response JSON of "createFile" and "updateFile" is:
```json
{
  "file_path": "app/project.rb",
  "branch": "master"
}
```
Documentation: 

* https://docs.gitlab.com/ee/api/repository_files.html#create-new-file-in-repository
* https://docs.gitlab.com/ee/api/repository_files.html#update-existing-file-in-repository

This PR introduce a new type `RepositoryFileResponse` that corresponds to this JSON.

Since `6.0.0` is a new major version, I think it is fine to do this breaking change.
