### PR TITLE
Make Pager constructor public

### DIFF
--- a/src/main/java/org/gitlab4j/api/Pager.java
+++ b/src/main/java/org/gitlab4j/api/Pager.java
@@ -69,7 +69,7 @@ public class Pager<T> implements Iterator<List<T>>, Constants {
      * @param pathArgs HTTP path arguments
      * @throws GitLabApiException if any error occurs
      */
-    Pager(AbstractApi api, Class<T> type, int itemsPerPage, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
+    public Pager(AbstractApi api, Class<T> type, int itemsPerPage, MultivaluedMap<String, String> queryParams, Object... pathArgs) throws GitLabApiException {
 
         javaType = mapper.getTypeFactory().constructCollectionType(List.class, type);
 


### PR DESCRIPTION
It is often useful for clients of this library to subclass a `AbstractApi`, or one of its concrete subclasses, to implement custom requests towards the GitLab API.

This is hard right now, because the constructor of `Pager` is package private, so clients cannot access it. This is a bit weird, since `Pager` itself is public. 

This change makes the constructor public.
