### PR TITLE
Add LinkedIssue for endpoint "/projects/:id/issues/:issue_iid/links"

### DIFF
--- a/src/main/java/org/gitlab4j/api/IssuesApi.java
+++ b/src/main/java/org/gitlab4j/api/IssuesApi.java
@@ -17,6 +17,7 @@ import org.gitlab4j.api.models.IssueLink;
 import org.gitlab4j.api.models.IssuesStatistics;
 import org.gitlab4j.api.models.IssuesStatisticsFilter;
 import org.gitlab4j.api.models.LinkType;
+import org.gitlab4j.api.models.LinkedIssue;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.Participant;
 import org.gitlab4j.api.models.TimeStats;
@@ -834,7 +835,7 @@ public class IssuesApi extends AbstractApi implements Constants {
      * @return a list of related issues of a given issue, sorted by the relationship creation datetime (ascending)
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Issue> getIssueLinks(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    public List<LinkedIssue> getIssueLinks(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
         return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).all());
     }
 
@@ -852,8 +853,8 @@ public class IssuesApi extends AbstractApi implements Constants {
      * @return a Pager of related issues of a given issue, sorted by the relationship creation datetime (ascending)
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Issue> getIssueLinks(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
-        return (new Pager<Issue>(this, Issue.class, itemsPerPage, null,
+    public Pager<LinkedIssue> getIssueLinks(Object projectIdOrPath, Long issueIid, int itemsPerPage) throws GitLabApiException {
+        return (new Pager<LinkedIssue>(this, LinkedIssue.class, itemsPerPage, null,
                 "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "links"));
     }
 
@@ -870,7 +871,7 @@ public class IssuesApi extends AbstractApi implements Constants {
      * @return a Stream of related issues of a given issue, sorted by the relationship creation datetime (ascending)
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Issue> getIssueLinksStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
+    public Stream<LinkedIssue> getIssueLinksStream(Object projectIdOrPath, Long issueIid) throws GitLabApiException {
         return (getIssueLinks(projectIdOrPath, issueIid, getDefaultPerPage()).stream());
     }
 

--- a/src/main/java/org/gitlab4j/api/models/EpicIssue.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicIssue.java
@@ -8,37 +8,13 @@ import org.gitlab4j.api.utils.JacksonJson;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
-public class EpicIssue extends Issue {
-
-    private Integer downvotes;
-    private Integer upvotes;
+public class EpicIssue extends AbstractIssue {
 
     @JsonProperty("_links")
     private Map<String, String> links;
 
-    private Boolean subscribed;
     private Long epicIssueId;
     private Integer relativePosition;
-
-    @Override
-	public Integer getDownvotes() {
-        return downvotes;
-    }
-
-    @Override
-	public void setDownvotes(Integer downvotes) {
-        this.downvotes = downvotes;
-    }
-
-    @Override
-	public Integer getUpvotes() {
-        return upvotes;
-    }
-
-    @Override
-	public void setUpvotes(Integer upvotes) {
-        this.upvotes = upvotes;
-    }
 
     public Map<String, String> getLinks() {
         return links;
@@ -55,16 +31,6 @@ public class EpicIssue extends Issue {
         }
 
         return (links.get(name));
-    }
-
-    @Override
-	public Boolean getSubscribed() {
-        return subscribed;
-    }
-
-    @Override
-	public void setSubscribed(Boolean subscribed) {
-        this.subscribed = subscribed;
     }
 
     public Long getEpicIssueId() {

--- a/src/main/java/org/gitlab4j/api/models/Issue.java
+++ b/src/main/java/org/gitlab4j/api/models/Issue.java
@@ -1,18 +1,11 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class Issue extends AbstractIssue {
 
     private Boolean subscribed;
-
-    private Long issueLinkId;
-    private LinkType linkType;
-    private Date linkCreatedAt;
-    private Date linkUpdatedAt;
 
     public Boolean getSubscribed() {
         return subscribed;
@@ -20,38 +13,6 @@ public class Issue extends AbstractIssue {
 
     public void setSubscribed(Boolean subscribed) {
         this.subscribed = subscribed;
-    }
-
-    public Long getIssueLinkId() {
-        return issueLinkId;
-    }
-
-    public void setIssueLinkId(Long issueLinkId) {
-        this.issueLinkId = issueLinkId;
-    }
-
-    public LinkType getLinkType() {
-        return linkType;
-    }
-
-    public void setLinkType(LinkType linkType) {
-        this.linkType = linkType;
-    }
-
-    public Date getLinkCreatedAt() {
-        return linkCreatedAt;
-    }
-
-    public void setLinkCreatedAt(Date linkCreatedAt) {
-        this.linkCreatedAt = linkCreatedAt;
-    }
-
-    public Date getLinkUpdatedAt() {
-        return linkUpdatedAt;
-    }
-
-    public void setLinkUpdatedAt(Date linkUpdatedAt) {
-        this.linkUpdatedAt = linkUpdatedAt;
     }
 
     @Override

--- a/src/main/java/org/gitlab4j/api/models/LinkedIssue.java
+++ b/src/main/java/org/gitlab4j/api/models/LinkedIssue.java
@@ -1,0 +1,51 @@
+
+package org.gitlab4j.api.models;
+
+import java.util.Date;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class LinkedIssue extends AbstractIssue {
+
+    private Long issueLinkId;
+    private LinkType linkType;
+    private Date linkCreatedAt;
+    private Date linkUpdatedAt;
+
+    public Long getIssueLinkId() {
+        return issueLinkId;
+    }
+
+    public void setIssueLinkId(Long issueLinkId) {
+        this.issueLinkId = issueLinkId;
+    }
+
+    public LinkType getLinkType() {
+        return linkType;
+    }
+
+    public void setLinkType(LinkType linkType) {
+        this.linkType = linkType;
+    }
+
+    public Date getLinkCreatedAt() {
+        return linkCreatedAt;
+    }
+
+    public void setLinkCreatedAt(Date linkCreatedAt) {
+        this.linkCreatedAt = linkCreatedAt;
+    }
+
+    public Date getLinkUpdatedAt() {
+        return linkUpdatedAt;
+    }
+
+    public void setLinkUpdatedAt(Date linkUpdatedAt) {
+        this.linkUpdatedAt = linkUpdatedAt;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -79,6 +79,7 @@ import org.gitlab4j.api.models.Key;
 import org.gitlab4j.api.models.Label;
 import org.gitlab4j.api.models.LabelEvent;
 import org.gitlab4j.api.models.Link;
+import org.gitlab4j.api.models.LinkedIssue;
 import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestDiff;
@@ -370,7 +371,7 @@ public class TestGitLabApiBeans {
 
     @Test
     public void testLinkedIssues() throws Exception {
-        List<Issue> linkedIssues = unmarshalResourceList(Issue.class, "linked-issues.json");
+        List<LinkedIssue> linkedIssues = unmarshalResourceList(LinkedIssue.class, "linked-issues.json");
         assertTrue(compareJson(linkedIssues, "linked-issues.json"));
     }
 

--- a/src/test/resources/org/gitlab4j/api/epic-issue.json
+++ b/src/test/resources/org/gitlab4j/api/epic-issue.json
@@ -59,7 +59,6 @@
     "award_emoji": "http://localhost:3001/api/v4/projects/8/issues/6/award_emoji",
     "project": "http://localhost:3001/api/v4/projects/8"
   },
-  "subscribed": true,
   "epic_issue_id": 2,
   "relative_position": 55
 }

--- a/src/test/resources/org/gitlab4j/api/linked-issues.json
+++ b/src/test/resources/org/gitlab4j/api/linked-issues.json
@@ -19,7 +19,6 @@
       "username" : "eileen.lowe"
     },
     "updated_at" : "2016-01-07T12:44:33.959Z",
-    "subscribed" : true,
     "user_notes_count": 0,
     "web_url": "http://example.com/example/example/issues/14",
     "confidential": false,


### PR DESCRIPTION
Follow up of https://github.com/gitlab4j/gitlab4j-api/pull/964 and as discussed in https://github.com/gitlab4j/gitlab4j-api/issues/729#issuecomment-1522803907:

In `6.x` we can do the breaking change of having the exact attribute for the different type of Issue sub-classes.

----

The main breaking change is that the endpoint:

```http
GET /projects/:id/issues/:issue_iid/links
```

Now returns `List<LinkedIssue>` instead of `List<Issue>`.

----

Also on the different `AbstractIssue` sub-class you now have the exact attributes that are available.

