### PR TITLE
Add Automatic-Module-Name manifest entry

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -171,6 +171,9 @@
 				<configuration>
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
+						<manifestEntries>
+							<Automatic-Module-Name>org.gitlab4j</Automatic-Module-Name>
+						</manifestEntries>
 					</archive>
 				</configuration>
 			</plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -172,7 +172,7 @@
 					<archive>
 						<manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
 						<manifestEntries>
-							<Automatic-Module-Name>org.gitlab4j</Automatic-Module-Name>
+							<Automatic-Module-Name>org.gitlab4j.api</Automatic-Module-Name>
 						</manifestEntries>
 					</archive>
 				</configuration>


### PR DESCRIPTION
This gets rid of warnings on Java 9+, and makes it safer to use this library as a module.