### PR TITLE
adding SKIPPED commit state in Constants

### DIFF
--- a/src/main/java/org/gitlab4j/api/Constants.java
+++ b/src/main/java/org/gitlab4j/api/Constants.java
@@ -663,7 +663,7 @@ public interface Constants {
      */
     public enum CommitBuildState {
 
-        PENDING, RUNNING, SUCCESS, FAILED, CANCELED;
+        PENDING, RUNNING, SUCCESS, FAILED, CANCELED, SKIPPED;
 
         private static JacksonJsonEnumHelper<CommitBuildState> enumHelper = new JacksonJsonEnumHelper<>(CommitBuildState.class);
 


### PR DESCRIPTION
The GitLab API for Jobs supports SKIPPED commit status - [refer](https://docs.gitlab.com/ee/api/jobs.html). Thus adding SKIPPED enumeration in GitLab4J-API version 5.2.0