### PR TITLE
Update jersey version to 2.39.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -50,8 +50,7 @@
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 		<project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
 
-		<jersey.version>2.35</jersey.version>
-		<jackson.version>2.12.7.1</jackson.version>
+		<jersey.version>2.39.1</jersey.version>
 		<servlet.version>4.0.4</servlet.version>
 		<activation.version>1.2.2</activation.version>
 


### PR DESCRIPTION
As discussed in https://github.com/gitlab4j/gitlab4j-api/issues/974 and https://github.com/gitlab4j/gitlab4j-api/issues/976 we could update jersey to the latest version.