### PR TITLE
updating docker-maven-plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -307,7 +307,7 @@
 			<plugin>
 				<groupId>io.fabric8</groupId>
 				<artifactId>docker-maven-plugin</artifactId>
-				<version>0.30.0</version>
+				<version>0.43.0</version>
 				<configuration>
 					<images>
 						<image>


### PR DESCRIPTION
Updating the docker-maven-plugin for supporting ARM based M1 chips.

Refer #985 