### PR TITLE
Remove "set-output" usage in GitHub action

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Get Date
         id: get-date
         run: |
-          echo "::set-output name=date::$(/bin/date -u "+%Y-%m")"
+          echo "date=$(/bin/date -u "+%Y-%m")" >> $GITHUB_OUTPUT
         shell: bash
       - name: Cache Maven Repository
         id: cache-maven


### PR DESCRIPTION
When the GitHub actions are executed we see this warning:

> **Build JDK 8**
> The `set-output` command is deprecated and will be disabled soon. Please upgrade to using Environment Files. For more information see: https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

<img width="1088" alt="GitHub action warning" src="https://github.com/gitlab4j/gitlab4j-api/assets/1222165/09462dda-8101-4d17-8ab0-6e00fa848ea2">

This PR is fixing that by using the the new way of setting outputs.

See:
https://docs.github.com/en/actions/using-workflows/workflow-commands-for-github-actions#example-of-setting-an-output-parameter
