### PR TITLE
Add buildQueuedDuration to BuildEvent

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -25,6 +25,8 @@ public class BuildEvent extends AbstractEvent {
     private Date buildStarted_at;
     private Date buildFinished_at;
     private Float buildDuration;
+
+    private Float buildQueuedDuration;
     private Boolean buildAllowFailure;
     private String buildFailureReason;
     private Long projectId;
@@ -131,6 +133,14 @@ public class BuildEvent extends AbstractEvent {
 
     public void setBuildDuration(Float buildDuration) {
         this.buildDuration = buildDuration;
+    }
+
+    public Float getBuildQueuedDuration() {
+        return buildQueuedDuration;
+    }
+
+    public void setBuildQueuedDuration(Float buildQueuedDuration) {
+        this.buildQueuedDuration = buildQueuedDuration;
     }
 
     public Boolean getBuildAllowFailure() {

--- a/src/test/resources/org/gitlab4j/api/build-event.json
+++ b/src/test/resources/org/gitlab4j/api/build-event.json
@@ -10,6 +10,7 @@
 	"build_status": "running",
 	"build_started_at": "2019-05-17T18:09:21Z",
 	"build_duration": 0.05880817,
+	"build_queued_duration": 1095.5887,
 	"build_allow_failure": false,
 	"build_failure_reason": "unknown_failure",
 	"pipeline_id": 2366,	


### PR DESCRIPTION
Fixing https://github.com/gitlab4j/gitlab4j-api/issues/780 issue.

To me, it seems valid and sending by gitlab (in my setup at least).