### PR TITLE
Add pipeline id attribute to BuildEvent class

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -6,7 +6,7 @@ import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 
 /**
- * The documentation at: <a href="https://docs.gitlab.com/ee/user/project/integrations/webhooks.html#job-events">
+ * The documentation at: <a href="https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events">
  * Job Events</a> is incorrect, this class represents the actual content of the Job Hook event.
  */
 public class BuildEvent extends AbstractEvent {
@@ -28,6 +28,8 @@ public class BuildEvent extends AbstractEvent {
     private Boolean buildAllowFailure;
     private String buildFailureReason;
     private Long projectId;
+
+    private Long pipelineId;
     private String projectName;
     private EventUser user;
     private BuildCommit commit;
@@ -153,6 +155,14 @@ public class BuildEvent extends AbstractEvent {
 
     public void setProjectId(Long projectId) {
         this.projectId = projectId;
+    }
+
+    public Long getPipelineId() {
+        return pipelineId;
+    }
+
+    public void setPipelineId(Long pipelineId) {
+        this.pipelineId = pipelineId;
     }
 
     public String getProjectName() {


### PR DESCRIPTION
As stated in https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events, gitlab is sending numeric pipeline_id attribute directly in build kind of webhook data.