### PR TITLE
#1000 Unable to find protected tag api

### DIFF
--- a/src/main/java/org/gitlab4j/api/TagsApi.java
+++ b/src/main/java/org/gitlab4j/api/TagsApi.java
@@ -415,7 +415,7 @@ public class TagsApi extends AbstractApi {
     /**
      * Protects a single repository tag or several project repository tags using a wildcard protected tag.
      *
-     * <pre><code>GitLab Endpoint: GET /projects/:id/protected_tags</code></pre>
+     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_tags</code></pre>
      *
      * @param projectIdOrPath id, path of the project, or a Project instance holding the project ID or path
      * @param name the name of the tag or wildcard


### PR DESCRIPTION
Correct JavaDoc for "protectTag" method to show actual information of method's GitLab Endpoint

Fixes #1000