### PR TITLE
#993 Gitlab diff api seems to mismatch param

### DIFF
--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -21,6 +21,7 @@ import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestDiff;
 import org.gitlab4j.api.models.MergeRequestFilter;
 import org.gitlab4j.api.models.MergeRequestParams;
+import org.gitlab4j.api.models.MergeRequestVersion;
 import org.gitlab4j.api.models.Participant;
 import org.gitlab4j.api.models.Pipeline;
 
@@ -401,9 +402,11 @@ public class MergeRequestApi extends AbstractApi {
      * @param mergeRequestIid the internal ID of the merge request
      * @return a List of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
+     * @deprecated use {@link #getDiffVersions(Object, Long)} instead
      */
-    public List<MergeRequestDiff> getMergeRequestDiffVersions(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-	return (getMergeRequestDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+    @Deprecated
+    public List<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+	return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
     }
 
     /**
@@ -416,8 +419,10 @@ public class MergeRequestApi extends AbstractApi {
      * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
      * @return a Pager of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
+     * @deprecated use {@link #getDiffVersions(Object, Long, int)} instead
      */
-    public Pager<MergeRequestDiff> getMergeRequestDiffVersions(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+    @Deprecated
+    public Pager<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
         return (new Pager<MergeRequestDiff>(this, MergeRequestDiff.class, itemsPerPage, null,
         	"projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "versions"));
     }
@@ -431,9 +436,11 @@ public class MergeRequestApi extends AbstractApi {
      * @param mergeRequestIid the internal ID of the merge request
      * @return a Stream of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
+     * @deprecated use {@link #getDiffVersionsStream(Object, Long)} instead
      */
-    public Stream<MergeRequestDiff> getMergeRequestDiffVersionsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+    @Deprecated
+    public Stream<MergeRequestDiff> getMergeRequestDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
     }
 
     /**
@@ -446,9 +453,91 @@ public class MergeRequestApi extends AbstractApi {
      * @param versionId the ID of the merge request diff version
      * @return a MergeRequestDiff instance for the specified MR diff version
      * @throws GitLabApiException if any exception occurs
+     * @deprecated use {@link #getDiffVersion(Object, Long, Long)} instead
      */
-    public MergeRequestDiff getMergeRequestDiffVersion(Object projectIdOrPath,
+    @Deprecated
+    public MergeRequestDiff getMergeRequestDiff(Object projectIdOrPath,
 	    Long mergeRequestIid, Long versionId) throws GitLabApiException {
+        return getDiffVersion(projectIdOrPath, mergeRequestIid, versionId);
+    }
+
+    /**
+     * Get a single merge request diff version as an Optional instance.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @param versionId the ID of the merge request diff version
+     * @return the specified MergeRequestDiff as an Optional instance instance
+     * @deprecated use {@link #getOptionalDiffVersion(Object, Long, Long)} instead
+     */
+    @Deprecated
+    public Optional<MergeRequestDiff> getOptionalMergeRequestDiff(
+	    Object projectIdOrPath, Long mergeRequestIid, Long versionId) {
+        try {
+            return (Optional.ofNullable(getMergeRequestDiff(projectIdOrPath, mergeRequestIid, versionId)));
+        } catch (GitLabApiException glae) {
+            return (GitLabApi.createOptionalFromException(glae));
+        }
+    }
+
+    /**
+     * Get a list of merge request diff versions.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @return a List of merge request diff versions for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<MergeRequestVersion> getDiffVersions(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+    }
+
+    /**
+     * Get a Pager of merge request diff versions.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @param itemsPerPage the number of MergeRequest instances that will be fetched per page
+     * @return a Pager of merge request diff versions for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<MergeRequestVersion> getDiffVersions(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+        return (new Pager<MergeRequestVersion>(this, MergeRequestVersion.class, itemsPerPage, null,
+            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "versions"));
+    }
+
+    /**
+     * Get a Stream of merge request diff versions.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @return a Stream of merge request diff versions for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Stream<MergeRequestVersion> getDiffVersionsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+    }
+
+    /**
+     * Get a single merge request diff version.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions/:version_id</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @param versionId the ID of the merge request diff version
+     * @return a MergeRequestVersion instance for the specified MR diff version
+     * @throws GitLabApiException if any exception occurs
+     */
+    public MergeRequestDiff getDiffVersion(Object projectIdOrPath, Long mergeRequestIid, Long versionId) throws GitLabApiException {
         Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
                 "merge_requests", mergeRequestIid, "versions", versionId);
         return (response.readEntity(MergeRequestDiff.class));
@@ -462,12 +551,11 @@ public class MergeRequestApi extends AbstractApi {
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid the internal ID of the merge request
      * @param versionId the ID of the merge request diff version
-     * @return the specified MergeRequestDiff as an Optional instance instance
+     * @return the specified MergeRequestVersion as an Optional instance instance
      */
-    public Optional<MergeRequestDiff> getOptionalMergeRequestDiffVersion(
-	    Object projectIdOrPath, Long mergeRequestIid, Long versionId) {
+    public Optional<MergeRequestDiff> getOptionalDiffVersion(Object projectIdOrPath, Long mergeRequestIid, Long versionId) {
         try {
-            return (Optional.ofNullable(getMergeRequestDiffVersion(projectIdOrPath, mergeRequestIid, versionId)));
+            return (Optional.ofNullable(getDiffVersion(projectIdOrPath, mergeRequestIid, versionId)));
         } catch (GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
@@ -483,8 +571,8 @@ public class MergeRequestApi extends AbstractApi {
      * @return a List of merge request diffs for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public List<Diff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+    public List<Diff> getDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
     }
 
     /**
@@ -498,7 +586,7 @@ public class MergeRequestApi extends AbstractApi {
      * @return a Pager of merge request diffs for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<Diff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+    public Pager<Diff> getDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
         return (new Pager<>(this, Diff.class, itemsPerPage, null,
             "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "diffs"));
     }
@@ -513,8 +601,8 @@ public class MergeRequestApi extends AbstractApi {
      * @return a Stream of merge request diffs for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<Diff> getMergeRequestDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+    public Stream<Diff> getDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/MergeRequestApi.java
+++ b/src/main/java/org/gitlab4j/api/MergeRequestApi.java
@@ -15,6 +15,7 @@ import org.gitlab4j.api.models.ApprovalRule;
 import org.gitlab4j.api.models.ApprovalRuleParams;
 import org.gitlab4j.api.models.ApprovalState;
 import org.gitlab4j.api.models.Commit;
+import org.gitlab4j.api.models.Diff;
 import org.gitlab4j.api.models.Issue;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestDiff;
@@ -401,8 +402,8 @@ public class MergeRequestApi extends AbstractApi {
      * @return a List of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public List<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-	return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+    public List<MergeRequestDiff> getMergeRequestDiffVersions(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+	return (getMergeRequestDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
     }
 
     /**
@@ -416,7 +417,7 @@ public class MergeRequestApi extends AbstractApi {
      * @return a Pager of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public Pager<MergeRequestDiff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+    public Pager<MergeRequestDiff> getMergeRequestDiffVersions(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
         return (new Pager<MergeRequestDiff>(this, MergeRequestDiff.class, itemsPerPage, null,
         	"projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "versions"));
     }
@@ -431,8 +432,8 @@ public class MergeRequestApi extends AbstractApi {
      * @return a Stream of merge request diff versions for the specified merge request
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<MergeRequestDiff> getMergeRequestDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
-        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
+    public Stream<MergeRequestDiff> getMergeRequestDiffVersionsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getMergeRequestDiffVersions(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
     }
 
     /**
@@ -446,7 +447,7 @@ public class MergeRequestApi extends AbstractApi {
      * @return a MergeRequestDiff instance for the specified MR diff version
      * @throws GitLabApiException if any exception occurs
      */
-    public MergeRequestDiff getMergeRequestDiff(Object projectIdOrPath,
+    public MergeRequestDiff getMergeRequestDiffVersion(Object projectIdOrPath,
 	    Long mergeRequestIid, Long versionId) throws GitLabApiException {
         Response response = get(Response.Status.OK, null, "projects", getProjectIdOrPath(projectIdOrPath),
                 "merge_requests", mergeRequestIid, "versions", versionId);
@@ -463,13 +464,57 @@ public class MergeRequestApi extends AbstractApi {
      * @param versionId the ID of the merge request diff version
      * @return the specified MergeRequestDiff as an Optional instance instance
      */
-    public Optional<MergeRequestDiff> getOptionalMergeRequestDiff(
+    public Optional<MergeRequestDiff> getOptionalMergeRequestDiffVersion(
 	    Object projectIdOrPath, Long mergeRequestIid, Long versionId) {
         try {
-            return (Optional.ofNullable(getMergeRequestDiff(projectIdOrPath, mergeRequestIid, versionId)));
+            return (Optional.ofNullable(getMergeRequestDiffVersion(projectIdOrPath, mergeRequestIid, versionId)));
         } catch (GitLabApiException glae) {
             return (GitLabApi.createOptionalFromException(glae));
         }
+    }
+
+    /**
+     * Get a list of merge request diffs.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/diffs</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @return a List of merge request diffs for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<Diff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).all());
+    }
+
+    /**
+     * Get a Pager of merge request diffs.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/diffs</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @param itemsPerPage the number of Diff instances that will be fetched per page
+     * @return a Pager of merge request diffs for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Pager<Diff> getMergeRequestDiffs(Object projectIdOrPath, Long mergeRequestIid, int itemsPerPage) throws GitLabApiException {
+        return (new Pager<>(this, Diff.class, itemsPerPage, null,
+            "projects", getProjectIdOrPath(projectIdOrPath), "merge_requests", mergeRequestIid, "diffs"));
+    }
+
+    /**
+     * Get a Stream of merge request diffs.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/diffs</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid the internal ID of the merge request
+     * @return a Stream of merge request diffs for the specified merge request
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Stream<Diff> getMergeRequestDiffsStream(Object projectIdOrPath, Long mergeRequestIid) throws GitLabApiException {
+        return (getMergeRequestDiffs(projectIdOrPath, mergeRequestIid, getDefaultPerPage()).stream());
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
@@ -1,86 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
 import java.util.List;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class MergeRequestDiff {
+public class MergeRequestDiff extends MergeRequestVersion {
 
-    private Long id;
-    private String headCommitSha;
-    private String baseCommitSha;
-    private String startCommitSha;
-    private Date createdAt;
-    private Long mergeRequestId;
-    private String state;
-    private String realSize;
     private List<Commit> commits;
     private List<Diff> diffs;
-
-    public Long getId() {
-        return id;
-    }
-
-    public void setId(Long id) {
-        this.id = id;
-    }
-
-    public String getHeadCommitSha() {
-        return headCommitSha;
-    }
-
-    public void setHeadCommitSha(String headCommitSha) {
-        this.headCommitSha = headCommitSha;
-    }
-
-    public String getBaseCommitSha() {
-        return baseCommitSha;
-    }
-
-    public void setBaseCommitSha(String baseCommitSha) {
-        this.baseCommitSha = baseCommitSha;
-    }
-
-    public String getStartCommitSha() {
-        return startCommitSha;
-    }
-
-    public void setStartCommitSha(String startCommitSha) {
-        this.startCommitSha = startCommitSha;
-    }
-
-    public Date getCreatedAt() {
-        return createdAt;
-    }
-
-    public void setCreatedAt(Date createdAt) {
-        this.createdAt = createdAt;
-    }
-
-    public Long getMergeRequestId() {
-        return mergeRequestId;
-    }
-
-    public void setMergeRequestId(Long mergeRequestId) {
-        this.mergeRequestId = mergeRequestId;
-    }
-
-    public String getState() {
-        return state;
-    }
-
-    public void setState(String state) {
-        this.state = state;
-    }
-
-    public String getRealSize() {
-        return realSize;
-    }
-
-    public void setRealSize(String realSize) {
-        this.realSize = realSize;
-    }
 
     public List<Commit> getCommits() {
         return commits;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
@@ -1,0 +1,86 @@
+package org.gitlab4j.api.models;
+
+import java.util.Date;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class MergeRequestVersion {
+
+    private Long id;
+    private String headCommitSha;
+    private String baseCommitSha;
+    private String startCommitSha;
+    private Date createdAt;
+    private Long mergeRequestId;
+    private String state;
+    private String realSize;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getHeadCommitSha() {
+        return headCommitSha;
+    }
+
+    public void setHeadCommitSha(String headCommitSha) {
+        this.headCommitSha = headCommitSha;
+    }
+
+    public String getBaseCommitSha() {
+        return baseCommitSha;
+    }
+
+    public void setBaseCommitSha(String baseCommitSha) {
+        this.baseCommitSha = baseCommitSha;
+    }
+
+    public String getStartCommitSha() {
+        return startCommitSha;
+    }
+
+    public void setStartCommitSha(String startCommitSha) {
+        this.startCommitSha = startCommitSha;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Long getMergeRequestId() {
+        return mergeRequestId;
+    }
+
+    public void setMergeRequestId(Long mergeRequestId) {
+        this.mergeRequestId = mergeRequestId;
+    }
+
+    public String getState() {
+        return state;
+    }
+
+    public void setState(String state) {
+        this.state = state;
+    }
+
+    public String getRealSize() {
+        return realSize;
+    }
+
+    public void setRealSize(String realSize) {
+        this.realSize = realSize;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -85,6 +85,7 @@ import org.gitlab4j.api.models.Link;
 import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestDiff;
+import org.gitlab4j.api.models.MergeRequestVersion;
 import org.gitlab4j.api.models.Milestone;
 import org.gitlab4j.api.models.Note;
 import org.gitlab4j.api.models.NotificationSettings;
@@ -654,6 +655,12 @@ public class TestGitLabApiBeans {
     public void testMergeRequestDiffs() throws Exception {
         List<MergeRequestDiff> diffs = unmarshalResourceList(MergeRequestDiff.class, "merge-request-diffs.json");
         assertTrue(compareJson(diffs, "merge-request-diffs.json"));
+    }
+
+    @Test
+    public void testMergeRequestVersions() throws Exception {
+        List<MergeRequestVersion> versions = unmarshalResourceList(MergeRequestVersion.class, "merge-request-versions.json");
+        assertTrue(compareJson(versions, "merge-request-diffs.json"));
     }
 
     @Test

--- a/src/test/resources/org/gitlab4j/api/merge-request-versions.json
+++ b/src/test/resources/org/gitlab4j/api/merge-request-versions.json
@@ -1,0 +1,19 @@
+[{
+  "id": 110,
+  "head_commit_sha": "33e2ee8579fda5bc36accc9c6fbd0b4fefda9e30",
+  "base_commit_sha": "eeb57dffe83deb686a60a71c16c32f71046868fd",
+  "start_commit_sha": "eeb57dffe83deb686a60a71c16c32f71046868fd",
+  "created_at": "2016-07-26T14:44:48.926Z",
+  "merge_request_id": 105,
+  "state": "collected",
+  "real_size": "1"
+}, {
+  "id": 108,
+  "head_commit_sha": "3eed087b29835c48015768f839d76e5ea8f07a24",
+  "base_commit_sha": "eeb57dffe83deb686a60a71c16c32f71046868fd",
+  "start_commit_sha": "eeb57dffe83deb686a60a71c16c32f71046868fd",
+  "created_at": "2016-07-25T14:21:33.028Z",
+  "merge_request_id": 105,
+  "state": "collected",
+  "real_size": "1"
+}]


### PR DESCRIPTION
For actualization MergeRequestApi:
- added methods "getMergeRequestDiffs" for GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/diffs
- renamed method "getMergeRequestDiffs" for GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/versions

Fixes #993 