### PR TITLE
Added support for listing LDAP group links

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -22,6 +22,7 @@ import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.GroupFilter;
 import org.gitlab4j.api.models.GroupParams;
 import org.gitlab4j.api.models.GroupProjectsFilter;
+import org.gitlab4j.api.models.LdapGroupLink;
 import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.Variable;
@@ -1175,6 +1176,20 @@ public class GroupApi extends AbstractApi {
      */
     public void ldapSync(Object groupIdOrPath) throws GitLabApiException {
         post(Response.Status.NO_CONTENT, (Form)null, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_sync");
+    }
+
+    /**
+     * Get the list of LDAP group links.
+     * 
+     * <pre><code>GitLab Endpoint: GET /groups/:id/ldap_group_links</code></pre>
+     * 
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
+     * @return a list of LDAP group links
+     * @throws GitLabApiException if any exception occurs
+     */
+    public List<LdapGroupLink> getLdapGroupLinks(Object groupIdOrPath) throws GitLabApiException {
+         Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "ldap_group_links");
+         return (response.readEntity(new GenericType<List<LdapGroupLink>>() {}));
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
@@ -5,11 +5,6 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class LdapGroupLink {
 
-    // The GitLab REST API documentation (https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links)
-    // does not specify the attributes which are returned for a LDAP group link :-/.
-    // This are the attributes returned by our GitLab instance (15.10.2-ee).
-    // These seem fine because they match with the attributes which you can pass when adding a LDAP group link :-).
-
     private String cn;
 
     private AccessLevel groupAccess;

--- a/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
@@ -1,0 +1,57 @@
+
+package org.gitlab4j.api.models;
+
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class LdapGroupLink {
+
+    // The GitLab REST API documentation (https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links)
+    // does not specify the attributes which are returned for a LDAP group link :-/.
+    // This are the attributes returned by our GitLab instance (15.10.2-ee).
+    // These seem fine because they match with the attributes which you can pass when adding a LDAP group link :-).
+
+    private String cn;
+
+    private AccessLevel groupAccess;
+
+    private String provider;
+
+    private String filter;
+
+    public String getCn() {
+        return cn;
+    }
+
+    public void setCn(String aCn) {
+        cn = aCn;
+    }
+
+    public AccessLevel getGroupAccess() {
+       return groupAccess;
+    }
+
+    public void setGroupAccess(AccessLevel aGroupAccess) {
+        groupAccess = aGroupAccess;
+    }
+
+    public String getProvider() {
+        return provider;
+     }
+
+    public void setProvider(String aProvider) {
+        provider = aProvider;
+    }
+
+    public String getFilter() {
+        return filter;
+    }
+
+    public void setFilter(String aFilter) {
+        filter = aFilter;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -81,6 +81,7 @@ import org.gitlab4j.api.models.Job;
 import org.gitlab4j.api.models.Key;
 import org.gitlab4j.api.models.Label;
 import org.gitlab4j.api.models.LabelEvent;
+import org.gitlab4j.api.models.LdapGroupLink;
 import org.gitlab4j.api.models.Link;
 import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.MergeRequest;
@@ -769,6 +770,12 @@ public class TestGitLabApiBeans {
     public void testLabels() throws Exception {
         List<Label> labels = unmarshalResourceList(Label.class, "labels.json");
         assertTrue(compareJson(labels, "labels.json"));
+    }
+
+    @Test
+    public void testLdapGroupLink() throws Exception {
+        LdapGroupLink link = unmarshalResource(LdapGroupLink.class, "ldap-group-link.json");
+        assertTrue(compareJson(link, "ldap-group-link.json"));
     }
 
     @Test

--- a/src/test/resources/org/gitlab4j/api/ldap-group-link.json
+++ b/src/test/resources/org/gitlab4j/api/ldap-group-link.json
@@ -1,0 +1,6 @@
+{
+    "cn": "My Group",
+    "group_access": 30,
+    "provider": "tertiary",
+    "filter": "(employeeType=developer)"
+}


### PR DESCRIPTION
Fixes https://github.com/gitlab4j/gitlab4j-api/issues/1014

See https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links

---

About the `LdapGroupLink` model:

> The GitLab REST API documentation (https://docs.gitlab.com/ee/api/groups.html#list-ldap-group-links)
> does not specify the attributes which are returned for a LDAP group link :-/.
> This are the attributes returned by our GitLab instance (`15.10.2-ee`).
> These seem fine because they match with the attributes which you can pass when adding a LDAP group link :-).
