### PR TITLE
Add missing field public_email in userToForm

### DIFF
--- a/src/main/java/org/gitlab4j/api/UserApi.java
+++ b/src/main/java/org/gitlab4j/api/UserApi.java
@@ -984,6 +984,7 @@ public class UserApi extends AbstractApi {
         String skipConfirmationFeildName = create ? "skip_confirmation" : "skip_reconfirmation";
 
         return (new GitLabApiForm()
+                .withParam("public_email", user.getPublicEmail(), false)
                 .withParam("email", user.getEmail(), create)
                 .withParam("password", password, false)
                 .withParam("reset_password", resetPassword, false)


### PR DESCRIPTION
`public_email` is a valid parameter when modifying users:
https://docs.gitlab.com/ee/api/users.html#user-modification