### PR TITLE
Add namespace to user

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/User.java
+++ b/src/main/java/org/gitlab4j/api/models/User.java
@@ -24,6 +24,7 @@ public class User extends AbstractUser<User> {
     private Date lastSignInAt;
     private String linkedin;
     private String location;
+    private Long namespaceId;
     private String organization;
     private Boolean privateProfile;
     private Integer projectsLimit;
@@ -164,6 +165,14 @@ public class User extends AbstractUser<User> {
 
     public void setLocation(String location) {
         this.location = location;
+    }
+
+    public Long getNamespaceId() {
+        return namespaceId;
+    }
+
+    public void setNamespaceId(Long namespaceId) {
+        this.namespaceId = namespaceId;
     }
 
     public String getOrganization() {

--- a/src/test/resources/org/gitlab4j/api/user.json
+++ b/src/test/resources/org/gitlab4j/api/user.json
@@ -34,5 +34,6 @@
   "external": false,
   "private_profile": false,
   "shared_runners_minutes_limit": 133,
-  "extra_shared_runners_minutes_limit": 133
+  "extra_shared_runners_minutes_limit": 133,
+  "namespace_id": 1
 }


### PR DESCRIPTION
The problem arising is that the namespace id is not always equal to the user id.

Example:

1. Create user: User Id 1, Namespace Id 1
2. Create Group: Namespace Id 2
3. Create user: User Id 2, Namespace Id 3

This PR adds the attribute to the user so that the information is available in a user object.