### PR TITLE
#992 Missing Metatdata api implementation

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApi.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApi.java
@@ -99,6 +99,7 @@ public class GitLabApi implements AutoCloseable {
     private UserApi userApi;
     private WikisApi wikisApi;
     private KeysApi keysApi;
+    private MetadataApi metadataApi;
 
     /**
      * Get the GitLab4J shared Logger instance.
@@ -1463,7 +1464,7 @@ public class GitLabApi implements AutoCloseable {
 
         return releaseLinksApi;
     }
-    
+
     /**
      * Gets the ReleasesApi instance owned by this GitLabApi instance. The ReleasesApi is used
      * to perform all release related API calls.
@@ -1737,6 +1738,21 @@ public class GitLabApi implements AutoCloseable {
             }
         }
         return keysApi;
+    }
+
+    /**
+     * Gets the MetadataApi instance owned by this GitlabApi instance. The MetadataApi is used to
+     * retrieve metadata information for this GitLab instance
+     *
+     * @return the MetadataApi instance owned by this GitlabApi instance
+     */
+    public MetadataApi getMetadataApi() {
+        synchronized (this) {
+            if (metadataApi == null) {
+                metadataApi = new MetadataApi(this);
+            }
+        }
+        return metadataApi;
     }
 
 

--- a/src/main/java/org/gitlab4j/api/MetadataApi.java
+++ b/src/main/java/org/gitlab4j/api/MetadataApi.java
@@ -1,0 +1,31 @@
+package org.gitlab4j.api;
+
+import javax.ws.rs.core.Response;
+import javax.ws.rs.core.Response.Status;
+import org.gitlab4j.api.models.Metadata;
+
+/**
+ * This class implements the client side API for the Gitlab metadata call.
+ *
+ * @see <a href="https://https://docs.gitlab.com/ee/api/metadata.html">Metadata API at Gitlab</a>
+ */
+public class MetadataApi extends AbstractApi {
+
+    public MetadataApi(GitLabApi gitLabApi) {
+        super(gitLabApi);
+    }
+
+    /**
+     * Get Gitlab metadata
+     *
+     * <pre><code>Gitlab Endpoint: GET /metadata</code></pre>
+     *
+     * @return Gitlab metadata
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Metadata getMetadata() throws GitLabApiException {
+        Response response = get(Status.OK, null, "metadata");
+        return (response.readEntity(Metadata.class));
+    }
+
+}

--- a/src/main/java/org/gitlab4j/api/models/Metadata.java
+++ b/src/main/java/org/gitlab4j/api/models/Metadata.java
@@ -1,0 +1,89 @@
+package org.gitlab4j.api.models;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.gitlab4j.api.utils.JacksonJson;
+
+public class Metadata {
+
+    private String version;
+    private String revision;
+    private Kas kas;
+    private Boolean enterprise;
+
+    public String getVersion() {
+        return version;
+    }
+
+    public void setVersion(String version) {
+        this.version = version;
+    }
+
+    public String getRevision() {
+        return revision;
+    }
+
+    public void setRevision(String revision) {
+        this.revision = revision;
+    }
+
+    public Kas getKas() {
+        return kas;
+    }
+
+    public void setKas(Kas kas) {
+        this.kas = kas;
+    }
+
+    public Boolean getEnterprise() {
+        return enterprise;
+    }
+
+    public void setEnterprise(Boolean enterprise) {
+        this.enterprise = enterprise;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+
+    private static class Kas {
+
+        private Boolean enabled;
+        @JsonProperty("externalUrl")
+        private String externalUrl;
+        private String version;
+
+        public Boolean getEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
+        }
+
+        public String getExternalUrl() {
+            return externalUrl;
+        }
+
+        public void setExternalUrl(String externalUrl) {
+            this.externalUrl = externalUrl;
+        }
+
+        public String getVersion() {
+            return version;
+        }
+
+        public void setVersion(String version) {
+            this.version = version;
+        }
+
+        @Override
+        public String toString() {
+            return (JacksonJson.toJsonString(this));
+        }
+    }
+
+
+
+}

--- a/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
+++ b/src/test/java/org/gitlab4j/api/TestGitLabApiBeans.java
@@ -87,6 +87,7 @@ import org.gitlab4j.api.models.Member;
 import org.gitlab4j.api.models.MergeRequest;
 import org.gitlab4j.api.models.MergeRequestDiff;
 import org.gitlab4j.api.models.MergeRequestVersion;
+import org.gitlab4j.api.models.Metadata;
 import org.gitlab4j.api.models.Milestone;
 import org.gitlab4j.api.models.Note;
 import org.gitlab4j.api.models.NotificationSettings;
@@ -789,5 +790,11 @@ public class TestGitLabApiBeans {
     public void testProjectAccessToken() throws Exception {
         ProjectAccessToken token = unmarshalResource(ProjectAccessToken.class, "project-access-token.json");
         assertTrue(compareJson(token, "project-access-token.json"));
+    }
+
+    @Test
+    public void testMetadata() throws Exception {
+        Metadata metadata = unmarshalResource(Metadata.class, "metadata.json");
+        assertTrue(compareJson(metadata, "metadata.json"));
     }
 }

--- a/src/test/java/org/gitlab4j/api/TestMetadataApi.java
+++ b/src/test/java/org/gitlab4j/api/TestMetadataApi.java
@@ -1,0 +1,47 @@
+package org.gitlab4j.api;
+
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import org.gitlab4j.api.models.Metadata;
+import org.gitlab4j.api.models.Project;
+import org.gitlab4j.api.models.User;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+
+@Tag("integration")
+@ExtendWith(SetupIntegrationTestExtension.class)
+@Disabled("Required Gitlab version not less then 15.6")
+public class TestMetadataApi extends AbstractIntegrationTest {
+
+    private static GitLabApi gitLabApi;
+    private static Project testProject;
+    private static User currentUser;
+
+    public TestMetadataApi() {
+        super();
+    }
+
+    @BeforeAll
+    public static void setup() {
+        gitLabApi = baseTestSetup();
+        testProject = getTestProject();
+        currentUser = getCurrentUser();
+    }
+
+    @BeforeEach
+    public void beforeMethod() {
+        assumeTrue(gitLabApi != null);
+    }
+
+    @Test
+    public void testGetMetadata() throws GitLabApiException {
+        Metadata metadata = gitLabApi.getMetadataApi().getMetadata();
+        System.out.println("METADATA +\n" + metadata);
+    }
+
+
+}

--- a/src/test/resources/org/gitlab4j/api/metadata.json
+++ b/src/test/resources/org/gitlab4j/api/metadata.json
@@ -1,0 +1,10 @@
+{
+  "version": "15.11.13",
+  "revision": "cc3748fcd2d",
+  "kas": {
+    "enabled": true,
+    "externalUrl": "ws://820bd8a8b4f6/-/kubernetes-agent/",
+    "version": "v15.11.0"
+  },
+  "enterprise": false
+}


### PR DESCRIPTION
Added Metadata Api. It requires Gitlab version not less then 15.6 in integration tests so test was disabled until Gitlab version updating.