### PR TITLE
Add the "internal" flag to NotesApi.createIssueNote()

### DIFF
--- a/src/main/java/org/gitlab4j/api/NotesApi.java
+++ b/src/main/java/org/gitlab4j/api/NotesApi.java
@@ -152,7 +152,7 @@ public class NotesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Note createIssueNote(Object projectIdOrPath, Long issueIid, String body) throws GitLabApiException {
-        return (createIssueNote(projectIdOrPath, issueIid, body, null));
+        return (createIssueNote(projectIdOrPath, issueIid, body, null, null));
     }
 
     /**
@@ -166,10 +166,26 @@ public class NotesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Note createIssueNote(Object projectIdOrPath, Long issueIid, String body, Date createdAt) throws GitLabApiException {
+        return (createIssueNote(projectIdOrPath, issueIid, body, null, null));    }
+
+    /**
+     * Create a issues's note.
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param issueIid the issue IID to create the notes for
+     * @param body the content of note
+     * @param createdAt the created time of note
+     * @param internal whether the note shall be marked 'internal'
+     * @return the created Note instance
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Note createIssueNote(Object projectIdOrPath, Long issueIid, String body, Date createdAt, Boolean internal) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("body", body, true)
-                .withParam("created_at", createdAt);
+                .withParam("created_at", createdAt)
+                .withParam("internal", internal);
+        ;
         Response response = post(Response.Status.CREATED, formData,
                 "projects", getProjectIdOrPath(projectIdOrPath), "issues", issueIid, "notes");
         return (response.readEntity(Note.class));

--- a/src/main/java/org/gitlab4j/api/models/Note.java
+++ b/src/main/java/org/gitlab4j/api/models/Note.java
@@ -98,6 +98,7 @@ public class Note {
     private Boolean resolvable;
     private Participant resolvedBy;
     private Date resolvedAt;
+    private Boolean internal;
     private Type type;
 
     private Position position;
@@ -270,7 +271,15 @@ public class Note {
         this.position = position;
     }
 
-    @Override
+    public Boolean getInternal() {
+		return internal;
+	}
+
+	public void setInternal(Boolean internal) {
+		this.internal = internal;
+	}
+
+	@Override
     public String toString() {
         return (JacksonJson.toJsonString(this));
     }

--- a/src/test/resources/org/gitlab4j/api/note.json
+++ b/src/test/resources/org/gitlab4j/api/note.json
@@ -16,6 +16,7 @@
   "resolvable": true,
   "resolved": true,
   "resolved_at": "2021-09-14T09:03:50.221Z",
+  "internal": false,
   "system": false,
   "noteable_id": 52,
   "noteable_type": "Snippet",


### PR DESCRIPTION
- add a new `createIssueNote()` method allowing to pass the `internal` flag.
- add the `internal` flag to the `Note` model