### PR TITLE
Change type of artifactPath to String

### DIFF
--- a/src/main/java/org/gitlab4j/api/JobApi.java
+++ b/src/main/java/org/gitlab4j/api/JobApi.java
@@ -4,7 +4,6 @@ import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
@@ -429,17 +428,16 @@ public class JobApi extends AbstractApi implements Constants {
      * @return a File instance pointing to the download of the specified artifacts file
      * @throws GitLabApiException if any exception occurs
      */
-    public File downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, Path artifactPath, File directory) throws GitLabApiException {
+    public File downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, String artifactPath, File directory) throws GitLabApiException {
 
-        String path = artifactPath.toString().replace("\\", "/");
         Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", path);
+                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", artifactPath);
         try {
 
             if (directory == null)
                 directory = new File(System.getProperty("java.io.tmpdir"));
 
-            String filename = artifactPath.getFileName().toString();
+            String filename = artifactPath;
             File file = new File(directory, filename);
 
             InputStream in = response.readEntity(InputStream.class);
@@ -464,10 +462,9 @@ public class JobApi extends AbstractApi implements Constants {
      * @return an InputStream to read the specified artifacts file from
      * @throws GitLabApiException if any exception occurs
      */
-    public InputStream downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, Path artifactPath) throws GitLabApiException {
-        String path = artifactPath.toString().replace("\\", "/");
+    public InputStream downloadSingleArtifactsFile(Object projectIdOrPath, Long jobId, String artifactPath) throws GitLabApiException {
         Response response = get(Response.Status.OK, getDefaultPerPageParam(),
-                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", path);
+                "projects", getProjectIdOrPath(projectIdOrPath), "jobs", jobId, "artifacts", artifactPath);
         return (response.readEntity(InputStream.class));
     }
 


### PR DESCRIPTION
The `artifact_path` is from type String:
https://docs.gitlab.com/ee/api/job_artifacts.html#download-a-single-artifact-file-by-job-id

Using a `java.nio.file.Path` to model this has very little benefit, since we have no real file system in that case.

---

The current work-around is to create a `ArtifactsFile` to set the `filename` attribute as String:

```java
ArtifactsFile file = new ArtifactsFile();
file.setFilename(artifactPath); 
InputStream inputisStream = gitLabApi.getJobApi().downloadArtifactsFile(idOrPath(project), jobId, file);
```

---

IMO this breaking change on the `6.x` branch is OK.
