### PR TITLE
Add GitLab endpoints to the javadoc in the NotesApi

### DIFF
--- a/src/main/java/org/gitlab4j/api/NotesApi.java
+++ b/src/main/java/org/gitlab4j/api/NotesApi.java
@@ -131,6 +131,8 @@ public class NotesApi extends AbstractApi {
     /**
      * Get the specified issues's note.
      *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
+     *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param issueIid the issue IID to get the notes for
      * @param noteId the ID of the Note to get
@@ -145,6 +147,9 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Create a issues's note.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
+     *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance @param projectIdOrPath the project ID to create the issues for
      * @param issueIid the issue IID to create the notes for
      * @param body the content of note
@@ -158,6 +163,8 @@ public class NotesApi extends AbstractApi {
     /**
      * Create a issues's note.
      *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
+     *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param issueIid the issue IID to create the notes for
      * @param body the content of note
@@ -170,6 +177,8 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Create a issues's note.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param issueIid the issue IID to create the notes for
@@ -194,6 +203,8 @@ public class NotesApi extends AbstractApi {
     /**
      * Update the specified issues's note.
      *
+     * <pre><code>GitLab Endpoint: PUT /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
+     *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param issueIid the issue IID to update the notes for
      * @param noteId the ID of the node to update
@@ -211,6 +222,8 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Delete the specified issues's note.
+     *
+     * <pre><code>GitLab Endpoint: DELETE /projects/:id/issues/:issue_iid/notes/:note_id</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param issueIid the issue IID to delete the notes for
@@ -378,6 +391,8 @@ public class NotesApi extends AbstractApi {
     /**
      * Get the specified merge request's note.
      *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>
+     *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid  the merge request IID to get the notes for
      * @param noteId the ID of the Note to get
@@ -392,6 +407,8 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Create a merge request's note.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid  the merge request IID to create the notes for
@@ -408,6 +425,8 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Update the specified merge request's note.
+     *
+     * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid  the merge request IID to update the notes for
@@ -426,6 +445,8 @@ public class NotesApi extends AbstractApi {
 
     /**
      * Delete the specified merge request's note.
+     *
+     * <pre><code>GitLab Endpoint: DELETE /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid the merge request IID to delete the notes for


### PR DESCRIPTION
This is a follow up of https://github.com/gitlab4j/gitlab4j-api/pull/1029 to fix the javadoc