### PR TITLE
Add name attribute to Pipeline class

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -28,6 +28,7 @@ public class Pipeline {
     private Float queuedDuration;
     private String webUrl;
     private DetailedStatus detailedStatus;
+    private String name;
 
     public Long getId() {
         return id;
@@ -275,6 +276,14 @@ public class Pipeline {
 
     public void setDetailedStatus(DetailedStatus detailedStatus) {
         this.detailedStatus = detailedStatus;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     @Override

--- a/src/test/resources/org/gitlab4j/api/pipeline.json
+++ b/src/test/resources/org/gitlab4j/api/pipeline.json
@@ -32,5 +32,6 @@
      "favicon": "/assets/ci_favicons/favicon_status_pending-5bdf338420e5221ca24353b6bff1c9367189588750632e9a871b7af09ff6a2ae.png"
   },
   "coverage": "30.0",
-  "web_url": "https://example.com/foo/bar/pipelines/46"
+  "web_url": "https://example.com/foo/bar/pipelines/46",
+  "name": "Custom pipeline name"
 }


### PR DESCRIPTION
Adds the `name` attribute to the Pipeline model.

Reflects the name that pipelines may (optionally) have, officially since 15.7. See:
* https://gitlab.com/gitlab-org/gitlab/-/issues/372538
* https://docs.gitlab.com/ee/ci/yaml/#workflowname
