### PR TITLE
Delete "ProjectSharedGroup" (replaced by "SharedGroup")

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -76,7 +76,7 @@ public class Project {
     private Boolean requestAccessEnabled;
     private String runnersToken;
     private Boolean sharedRunnersEnabled;
-    private List<ProjectSharedGroup> sharedWithGroups;
+    private List<SharedGroup> sharedWithGroups;
     private Boolean snippetsEnabled;
     private String sshUrlToRepo;
     private Integer starCount;
@@ -502,11 +502,11 @@ public class Project {
         this.sharedRunnersEnabled = sharedRunnersEnabled;
     }
 
-    public List<ProjectSharedGroup> getSharedWithGroups() {
+    public List<SharedGroup> getSharedWithGroups() {
         return sharedWithGroups;
     }
 
-    public void setSharedWithGroups(List<ProjectSharedGroup> sharedWithGroups) {
+    public void setSharedWithGroups(List<SharedGroup> sharedWithGroups) {
         this.sharedWithGroups = sharedWithGroups;
     }
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectSharedGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectSharedGroup.java
@@ -1,8 +1,0 @@
-package org.gitlab4j.api.models;
-
-/**
- * @deprecated use {@link SharedGroup} instead
- */
-@Deprecated
-public class ProjectSharedGroup extends SharedGroup {
-}


### PR DESCRIPTION
Follow up of https://github.com/gitlab4j/gitlab4j-api/pull/1057, delete the deprecated class `ProjectSharedGroup`