### PR TITLE
Add "links" to Release

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Release.java
+++ b/src/main/java/org/gitlab4j/api/models/Release.java
@@ -2,8 +2,12 @@ package org.gitlab4j.api.models;
 
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 
 import org.gitlab4j.api.utils.JacksonJson;
+
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class Release {
 
@@ -20,6 +24,8 @@ public class Release {
     private String tagPath;
     private String evidenceSha;
     private Assets assets;
+    @JsonProperty("_links")
+    private Map<String, String> links;
 
     public String getName() {
         return name;
@@ -123,6 +129,23 @@ public class Release {
 
     public void setAssets(Assets assets) {
         this.assets = assets;
+    }
+
+    public Map<String, String> getLinks() {
+        return links;
+    }
+
+    public void setLinks(Map<String, String> links) {
+        this.links = links;
+    }
+
+    @JsonIgnore
+    public String getLinkByName(String name) {
+        if (links == null || links.isEmpty()) {
+            return (null);
+        }
+
+        return (links.get(name));
     }
 
     @Override

--- a/src/test/resources/org/gitlab4j/api/releases.json
+++ b/src/test/resources/org/gitlab4j/api/releases.json
@@ -94,6 +94,15 @@
             }
          ],
          "evidence_file_path":"https://gitlab.example.com/root/awesome-app/-/releases/v0.2/evidence.json"
+      },
+      "_links": {
+        "closed_issues_url": "https://gitlab.example.com/root/awesome-app/-/issues?release_tag=v0.2&scope=all&state=closed",
+        "closed_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.2&scope=all&state=closed",
+        "edit_url": "https://gitlab.example.com/root/awesome-app/-/releases/v0.2/edit",
+        "merged_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.2&scope=all&state=merged",
+        "opened_issues_url": "https://gitlab.example.com/root/awesome-app/-/issues?release_tag=v0.2&scope=all&state=opened",
+        "opened_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.2&scope=all&state=opened",
+        "self": "https://gitlab.example.com/root/awesome-app/-/releases/v0.2"
       }
    },
    {
@@ -152,6 +161,15 @@
 
          ],
          "evidence_file_path":"https://gitlab.example.com/root/awesome-app/-/releases/v0.1/evidence.json"
+      },
+      "_links": {
+        "closed_issues_url": "https://gitlab.example.com/root/awesome-app/-/issues?release_tag=v0.1&scope=all&state=closed",
+        "closed_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.1&scope=all&state=closed",
+        "edit_url": "https://gitlab.example.com/root/awesome-app/-/releases/v0.1/edit",
+        "merged_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.1&scope=all&state=merged",
+        "opened_issues_url": "https://gitlab.example.com/root/awesome-app/-/issues?release_tag=v0.1&scope=all&state=opened",
+        "opened_merge_requests_url": "https://gitlab.example.com/root/awesome-app/-/merge_requests?release_tag=v0.1&scope=all&state=opened",
+        "self": "https://gitlab.example.com/root/awesome-app/-/releases/v0.1"
       }
    }
 ]


### PR DESCRIPTION
Add missing `links` attribute in `Release`.

See: https://docs.gitlab.com/ee/api/releases/#get-a-release-by-a-tag-name