### PR TITLE
Fix wrongly named "*_at" members

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GpgKey.java
+++ b/src/main/java/org/gitlab4j/api/models/GpgKey.java
@@ -2,11 +2,13 @@ package org.gitlab4j.api.models;
 
 import java.util.Date;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class GpgKey {
 
     private Long id;
     private String key;
-    private Date created_at;
+    private Date createdAt;
 
     public Long getId() {
         return id;
@@ -24,11 +26,31 @@ public class GpgKey {
         this.key = key;
     }
 
-    public Date getCreated_at() {
-        return created_at;
+
+    public Date getCreatedAt() {
+        return createdAt;
     }
 
-    public void setCreated_at(Date created_at) {
-        this.created_at = created_at;
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
     }
-}
+
+    /**
+     * @deprecated Replaced by {@link #getCreatedAt()}
+     * @return the created at Date
+     */
+    @Deprecated
+    @JsonIgnore
+    public Date getCreated_at() {
+        return createdAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #setCreatedAt(Date)}
+     * @param createdAt new created at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setCreated_at(Date createdAt) {
+        this.createdAt = createdAt;
+    }}

--- a/src/main/java/org/gitlab4j/api/models/PackageFile.java
+++ b/src/main/java/org/gitlab4j/api/models/PackageFile.java
@@ -4,11 +4,13 @@ import java.util.Date;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class PackageFile {
 
     private Long id;
     private Long packageId;
-    private Date created_at;
+    private Date createdAt;
     private String fileName;
     private Long size;
     private String fileMd5;
@@ -30,14 +32,33 @@ public class PackageFile {
         this.packageId = packageId;
     }
 
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getCreatedAt()}
+     * @return the created at Date
+     */
+    @Deprecated
+    @JsonIgnore
     public Date getCreated_at() {
-        return created_at;
+        return createdAt;
     }
 
-    public void setCreated_at(Date created_at) {
-        this.created_at = created_at;
+    /**
+     * @deprecated Replaced by {@link #setCreatedAt(Date)}
+     * @param createdAt new created at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setCreated_at(Date createdAt) {
+        this.createdAt = createdAt;
     }
-
     public String getFileName() {
         return fileName;
     }

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -130,32 +130,32 @@ public class Pipeline {
         return updatedAt;
     }
 
-    public void setUpdatedAt(Date updated_at) {
-        this.updatedAt = updated_at;
+    public void setUpdatedAt(Date updatedAt) {
+        this.updatedAt = updatedAt;
     }
 
     public Date getStartedAt() {
         return startedAt;
     }
 
-    public void setStartedAt(Date started_at) {
-        this.startedAt = started_at;
+    public void setStartedAt(Date startedAt) {
+        this.startedAt = startedAt;
     }
 
     public Date getFinishedAt() {
         return finishedAt;
     }
 
-    public void setFinishedAt(Date finished_at) {
-        this.finishedAt = finished_at;
+    public void setFinishedAt(Date finishedAt) {
+        this.finishedAt = finishedAt;
     }
 
     public Date getCommittedAt() {
         return committedAt;
     }
 
-    public void setCommittedAt(Date committed_at) {
-        this.committedAt = committed_at;
+    public void setCommittedAt(Date committedAt) {
+        this.committedAt = committedAt;
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -5,6 +5,8 @@ import java.util.Date;
 import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 /**
  * The documentation at: <a href="https://docs.gitlab.com/ee/user/project/integrations/webhook_events.html#job-events">
  * Job Events</a> is incorrect, this class represents the actual content of the Job Hook event.
@@ -22,8 +24,8 @@ public class BuildEvent extends AbstractEvent {
     private String buildName;
     private String buildStage;
     private String buildStatus;
-    private Date buildStarted_at;
-    private Date buildFinished_at;
+    private Date buildStartedAt;
+    private Date buildFinishedAt;
     private Float buildDuration;
 
     private Float buildQueuedDuration;
@@ -111,20 +113,60 @@ public class BuildEvent extends AbstractEvent {
         this.buildStatus = buildStatus;
     }
 
+    public Date getBuildStartedAt() {
+        return buildStartedAt;
+    }
+
+    public void setBuildStartedAt(Date buildStartedAt) {
+        this.buildStartedAt = buildStartedAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getBuildStartedAt()}
+     * @return the buildstarted at Date
+     */
+    @Deprecated
+    @JsonIgnore
     public Date getBuildStarted_at() {
-        return buildStarted_at;
+        return buildStartedAt;
     }
 
-    public void setBuildStarted_at(Date buildStarted_at) {
-        this.buildStarted_at = buildStarted_at;
+    /**
+     * @deprecated Replaced by {@link #setBuildStartedAt(Date)}
+     * @param buildStartedAt new buildstarted at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setBuildStarted_at(Date buildStartedAt) {
+        this.buildStartedAt = buildStartedAt;
     }
 
+    public Date getBuildFinishedAt() {
+        return buildFinishedAt;
+    }
+
+    public void setBuildFinishedAt(Date buildFinishedAt) {
+        this.buildFinishedAt = buildFinishedAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getBuildFinishedAt()}
+     * @return the buildfinished at Date
+     */
+    @Deprecated
+    @JsonIgnore
     public Date getBuildFinished_at() {
-        return buildFinished_at;
+        return buildFinishedAt;
     }
 
-    public void setBuildFinished_at(Date buildFinished_at) {
-        this.buildFinished_at = buildFinished_at;
+    /**
+     * @deprecated Replaced by {@link #setBuildFinishedAt(Date)}
+     * @param buildFinishedAt new buildfinished at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setBuildFinished_at(Date buildFinishedAt) {
+        this.buildFinishedAt = buildFinishedAt;
     }
 
     public Float getBuildDuration() {

--- a/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
@@ -5,6 +5,8 @@ import java.util.Date;
 import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+
 public class JobEvent extends AbstractEvent {
 
     public static final String JOB_HOOK_X_GITLAB_EVENT = "Job Hook";
@@ -18,8 +20,8 @@ public class JobEvent extends AbstractEvent {
     private String jobName;
     private String jobStage;
     private String jobStatus;
-    private Date jobStarted_at;
-    private Date jobFinished_at;
+    private Date jobStartedAt;
+    private Date jobFinishedAt;
     private Integer jobDuration;
     private Boolean jobAllowFailure;
     private String jobFailureReason;
@@ -103,22 +105,61 @@ public class JobEvent extends AbstractEvent {
         this.jobStatus = jobStatus;
     }
 
+    public Date getJobStartedAt() {
+        return jobStartedAt;
+    }
+
+    public void setJobStartedAt(Date jobStartedAt) {
+        this.jobStartedAt = jobStartedAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getJobStartedAt()}
+     * @return the jobstarted at Date
+     */
+    @Deprecated
+    @JsonIgnore
     public Date getJobStarted_at() {
-        return jobStarted_at;
+        return jobStartedAt;
     }
 
-    public void setJobStarted_at(Date jobStarted_at) {
-        this.jobStarted_at = jobStarted_at;
+    /**
+     * @deprecated Replaced by {@link #setJobStartedAt(Date)}
+     * @param jobStartedAt new jobstarted at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setJobStarted_at(Date jobStartedAt) {
+        this.jobStartedAt = jobStartedAt;
     }
 
+    public Date getJobFinishedAt() {
+        return jobFinishedAt;
+    }
+
+    public void setJobFinishedAt(Date jobFinishedAt) {
+        this.jobFinishedAt = jobFinishedAt;
+    }
+
+    /**
+     * @deprecated Replaced by {@link #getJobFinishedAt()}
+     * @return the jobfinished at Date
+     */
+    @Deprecated
+    @JsonIgnore
     public Date getJobFinished_at() {
-        return jobFinished_at;
+        return jobFinishedAt;
     }
 
-    public void setJobFinished_at(Date jobFinished_at) {
-        this.jobFinished_at = jobFinished_at;
+    /**
+     * @deprecated Replaced by {@link #setJobFinishedAt(Date)}
+     * @param jobFinishedAt new jobfinished at value
+     */
+    @Deprecated
+    @JsonIgnore
+    public void setJobFinished_at(Date jobFinishedAt) {
+        this.jobFinishedAt = jobFinishedAt;
     }
-
     public Integer getJobDuration() {
         return jobDuration;
     }


### PR DESCRIPTION
Some java members are wrongly named.

* `created_at` --> `createdAt`
* `started_at` --> `startedAt`
* `finished_at` --> `finishedAt`
* `committed_at` --> `committedAt`
* `buildStarted_at` --> `buildStartedAt`
* `buildFinished_at` --> `buildFinishedAt`
* `jobStarted_at` --> `jobStartedAt`
* `jobFinished_at` --> `jobFinishedAt`

This PR is fixing it in a backward compatible way.