### PR TITLE
Remove deprecated "get/setXxxx_at" methods

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/GpgKey.java
+++ b/src/main/java/org/gitlab4j/api/models/GpgKey.java
@@ -34,23 +34,4 @@ public class GpgKey {
     public void setCreatedAt(Date createdAt) {
         this.createdAt = createdAt;
     }
-
-    /**
-     * @deprecated Replaced by {@link #getCreatedAt()}
-     * @return the created at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getCreated_at() {
-        return createdAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setCreatedAt(Date)}
-     * @param createdAt new created at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setCreated_at(Date createdAt) {
-        this.createdAt = createdAt;
-    }}
+}

--- a/src/main/java/org/gitlab4j/api/models/PackageFile.java
+++ b/src/main/java/org/gitlab4j/api/models/PackageFile.java
@@ -40,25 +40,6 @@ public class PackageFile {
         this.createdAt = createdAt;
     }
 
-    /**
-     * @deprecated Replaced by {@link #getCreatedAt()}
-     * @return the created at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getCreated_at() {
-        return createdAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setCreatedAt(Date)}
-     * @param createdAt new created at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setCreated_at(Date createdAt) {
-        this.createdAt = createdAt;
-    }
     public String getFileName() {
         return fileName;
     }

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -158,16 +158,6 @@ public class Pipeline {
         this.committedAt = committedAt;
     }
 
-    /**
-     * @deprecated Replaced by {@link #getStartedAt()}
-     * @return the started at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getStarted_at() {
-        return startedAt;
-    }
-
     public String getCoverage() {
         return coverage;
     }

--- a/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -121,51 +121,11 @@ public class BuildEvent extends AbstractEvent {
         this.buildStartedAt = buildStartedAt;
     }
 
-    /**
-     * @deprecated Replaced by {@link #getBuildStartedAt()}
-     * @return the buildstarted at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getBuildStarted_at() {
-        return buildStartedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setBuildStartedAt(Date)}
-     * @param buildStartedAt new buildstarted at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setBuildStarted_at(Date buildStartedAt) {
-        this.buildStartedAt = buildStartedAt;
-    }
-
     public Date getBuildFinishedAt() {
         return buildFinishedAt;
     }
 
     public void setBuildFinishedAt(Date buildFinishedAt) {
-        this.buildFinishedAt = buildFinishedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #getBuildFinishedAt()}
-     * @return the buildfinished at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getBuildFinished_at() {
-        return buildFinishedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setBuildFinishedAt(Date)}
-     * @param buildFinishedAt new buildfinished at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setBuildFinished_at(Date buildFinishedAt) {
         this.buildFinishedAt = buildFinishedAt;
     }
 

--- a/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
@@ -113,26 +113,6 @@ public class JobEvent extends AbstractEvent {
         this.jobStartedAt = jobStartedAt;
     }
 
-    /**
-     * @deprecated Replaced by {@link #getJobStartedAt()}
-     * @return the jobstarted at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getJobStarted_at() {
-        return jobStartedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setJobStartedAt(Date)}
-     * @param jobStartedAt new jobstarted at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setJobStarted_at(Date jobStartedAt) {
-        this.jobStartedAt = jobStartedAt;
-    }
-
     public Date getJobFinishedAt() {
         return jobFinishedAt;
     }
@@ -141,25 +121,6 @@ public class JobEvent extends AbstractEvent {
         this.jobFinishedAt = jobFinishedAt;
     }
 
-    /**
-     * @deprecated Replaced by {@link #getJobFinishedAt()}
-     * @return the jobfinished at Date
-     */
-    @Deprecated
-    @JsonIgnore
-    public Date getJobFinished_at() {
-        return jobFinishedAt;
-    }
-
-    /**
-     * @deprecated Replaced by {@link #setJobFinishedAt(Date)}
-     * @param jobFinishedAt new jobfinished at value
-     */
-    @Deprecated
-    @JsonIgnore
-    public void setJobFinished_at(Date jobFinishedAt) {
-        this.jobFinishedAt = jobFinishedAt;
-    }
     public Integer getJobDuration() {
         return jobDuration;
     }


### PR DESCRIPTION
Follow up of https://github.com/gitlab4j/gitlab4j-api/pull/1062

Remove the deprecated methods for version `6.x`