### PR TITLE
added new api call for forced push checks #1071

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -136,7 +136,7 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName, AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel) throws GitLabApiException {
-        return (protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, null, null));
+        return (protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, null, null, null));
     }
 
     /**
@@ -155,13 +155,14 @@ public class ProtectedBranchesApi extends AbstractApi {
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
             AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            Boolean codeOwnerApprovalRequired, Boolean allowForcedPush) throws GitLabApiException {
         Form formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
                 .withParam("push_access_level", pushAccessLevel)
                 .withParam("merge_access_level", mergeAccessLevel)
                 .withParam("unprotect_access_level", unprotectAccessLevel)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+                .withParam("code_owner_approval_required", codeOwnerApprovalRequired)
+                .withParam("allow_force_push", allowForcedPush);
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
@@ -185,14 +186,15 @@ public class ProtectedBranchesApi extends AbstractApi {
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
             Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+            Boolean codeOwnerApprovalRequired, Boolean allowForcedPush) throws GitLabApiException {
 
         Form formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
                 .withParam("allowed_to_push[][user_id]", allowedToPushUserId)
                 .withParam("allowed_to_merge[][user_id]", allowedToMergeUserId)
                 .withParam("allowed_to_unprotect[][user_id]", allowedToUnprotectUserId)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+                .withParam("code_owner_approval_required", codeOwnerApprovalRequired)
+                .withParam("allow_force_push", allowForcedPush);
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
@@ -228,6 +230,7 @@ public class ProtectedBranchesApi extends AbstractApi {
             allowedToMerge.getForm(formData, "allowed_to_merge");
         if (allowedToUnprotect != null)
             allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
+        //FIXME: cannot test, having CE only to test
 
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -1,7 +1,6 @@
 package org.gitlab4j.api;
 
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -151,7 +150,28 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @param mergeAccessLevel access levels allowed to merge (defaults: 40, maintainer access level)
      * @param unprotectAccessLevel access levels allowed to unprotect (defaults: 40, maintainer access level)
      * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
-     * @param allowForcedPush by default a forced push is only prohibited on main/master, so a good default is to set this to false to disallow a forced push (and loosing all prior history of the former pushes)
+     * @return the branch info for the protected branch
+     * @throws GitLabApiException if any exception occurs
+     * @see ProtectedBranchesApi#protectBranch(Object, String, AccessLevel, AccessLevel, AccessLevel, Boolean, Boolean)
+     */
+    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
+            AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+        return protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, unprotectAccessLevel, codeOwnerApprovalRequired, null);
+    }
+
+    /**
+     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param branchName the name of the branch to protect, can be a wildcard
+     * @param pushAccessLevel access levels allowed to push (defaults: 40, maintainer access level)
+     * @param mergeAccessLevel access levels allowed to merge (defaults: 40, maintainer access level)
+     * @param unprotectAccessLevel access levels allowed to unprotect (defaults: 40, maintainer access level)
+     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @param allowForcedPush when enabled, members who can push to this branch can also force push. (default: false)
      * @return the branch info for the protected branch
      * @throws GitLabApiException if any exception occurs
      */
@@ -163,29 +183,11 @@ public class ProtectedBranchesApi extends AbstractApi {
                 .withParam("push_access_level", pushAccessLevel)
                 .withParam("merge_access_level", mergeAccessLevel)
                 .withParam("unprotect_access_level", unprotectAccessLevel)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
-        if (Objects.nonNull(allowForcedPush)) {
-            // append if parameter is set
-            formData = formData.withParam("allow_force_push", allowForcedPush);
-        }
-        
+                .withParam("code_owner_approval_required", codeOwnerApprovalRequired)
+                .withParam("allow_force_push", allowForcedPush);
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
-    }
-
-    /**
-     * Backward compatibility method for {@link ProtectedBranchesApi#protectBranch(Object, String, AccessLevel, AccessLevel, AccessLevel, Boolean, Boolean)}
-     *
-     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
-     *
-     * @see ProtectedBranchesApi#protectBranch(Object, String, AccessLevel, AccessLevel, AccessLevel, Boolean, Boolean)
-     */
-    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
-            AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
-            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
-        ProtectedBranch lResult = protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, unprotectAccessLevel, codeOwnerApprovalRequired, null);
-        return lResult;
     }
 
     /**
@@ -201,6 +203,29 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @param allowedToMergeUserId user ID allowed to merge, can be null
      * @param allowedToUnprotectUserId user ID allowed to unprotect, can be null
      * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @return the branch info for the protected branch
+     * @throws GitLabApiException if any exception occurs
+     */
+    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
+            Integer allowedToPushUserId, Integer allowedToMergeUserId, Integer allowedToUnprotectUserId,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+        return protectBranch(projectIdOrPath, branchName, allowedToPushUserId, allowedToMergeUserId, allowedToUnprotectUserId, codeOwnerApprovalRequired, null);
+    }
+
+    /**
+     * Protects a single repository branch or several project repository branches using a wildcard protected branch.
+     *
+     * <p>NOTE: This method is only available to GitLab Starter, Bronze, or higher.</p>
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param branchName the name of the branch to protect, can be a wildcard
+     * @param allowedToPushUserId user ID allowed to push, can be null
+     * @param allowedToMergeUserId user ID allowed to merge, can be null
+     * @param allowedToUnprotectUserId user ID allowed to unprotect, can be null
+     * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @param allowForcedPush when enabled, members who can push to this branch can also force push. (default: false) 
      * @return the branch info for the protected branch
      * @throws GitLabApiException if any exception occurs
      */

--- a/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
+++ b/src/main/java/org/gitlab4j/api/ProtectedBranchesApi.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 import java.util.stream.Stream;
 
@@ -150,22 +151,41 @@ public class ProtectedBranchesApi extends AbstractApi {
      * @param mergeAccessLevel access levels allowed to merge (defaults: 40, maintainer access level)
      * @param unprotectAccessLevel access levels allowed to unprotect (defaults: 40, maintainer access level)
      * @param codeOwnerApprovalRequired prevent pushes to this branch if it matches an item in the CODEOWNERS file. (defaults: false)
+     * @param allowForcedPush by default a forced push is only prohibited on main/master, so a good default is to set this to false to disallow a forced push (and loosing all prior history of the former pushes)
      * @return the branch info for the protected branch
      * @throws GitLabApiException if any exception occurs
      */
     public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
             AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
             Boolean codeOwnerApprovalRequired, Boolean allowForcedPush) throws GitLabApiException {
-        Form formData = new GitLabApiForm()
+        GitLabApiForm formData = new GitLabApiForm()
                 .withParam("name", branchName, true)
                 .withParam("push_access_level", pushAccessLevel)
                 .withParam("merge_access_level", mergeAccessLevel)
                 .withParam("unprotect_access_level", unprotectAccessLevel)
-                .withParam("code_owner_approval_required", codeOwnerApprovalRequired)
-                .withParam("allow_force_push", allowForcedPush);
+                .withParam("code_owner_approval_required", codeOwnerApprovalRequired);
+        if (Objects.nonNull(allowForcedPush)) {
+            // append if parameter is set
+            formData = formData.withParam("allow_force_push", allowForcedPush);
+        }
+        
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");
         return (response.readEntity(ProtectedBranch.class));
+    }
+
+    /**
+     * Backward compatibility method for {@link ProtectedBranchesApi#protectBranch(Object, String, AccessLevel, AccessLevel, AccessLevel, Boolean, Boolean)}
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/protected_branches</code></pre>
+     *
+     * @see ProtectedBranchesApi#protectBranch(Object, String, AccessLevel, AccessLevel, AccessLevel, Boolean, Boolean)
+     */
+    public ProtectedBranch protectBranch(Object projectIdOrPath, String branchName,
+            AccessLevel pushAccessLevel, AccessLevel mergeAccessLevel, AccessLevel unprotectAccessLevel,
+            Boolean codeOwnerApprovalRequired) throws GitLabApiException {
+        ProtectedBranch lResult = protectBranch(projectIdOrPath, branchName, pushAccessLevel, mergeAccessLevel, unprotectAccessLevel, codeOwnerApprovalRequired, null);
+        return lResult;
     }
 
     /**
@@ -230,7 +250,6 @@ public class ProtectedBranchesApi extends AbstractApi {
             allowedToMerge.getForm(formData, "allowed_to_merge");
         if (allowedToUnprotect != null)
             allowedToUnprotect.getForm(formData, "allowed_to_unprotect");
-        //FIXME: cannot test, having CE only to test
 
         Response response = post(Response.Status.CREATED, formData.asMap(),
                 "projects", getProjectIdOrPath(projectIdOrPath), "protected_branches");


### PR DESCRIPTION
Here a change to expose the forced commit check

Gitlab documentation: https://docs.gitlab.com/ee/api/protected_branches.html

Fixes #1071