### PR TITLE
Models implements serializable interface to support native image(GraalVM)

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApiException.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiException.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.databind.JsonNode;
  * with a GitLab API endpoint.
  */
 public class GitLabApiException extends Exception {
-
     private static final long serialVersionUID = 1L;
+
     private StatusType statusInfo;
     private int httpStatus;
     private String message;

--- a/src/main/java/org/gitlab4j/api/models/AbstractEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractEpic.java
@@ -1,20 +1,21 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.List;
-import java.util.Map;
-
-import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-public class AbstractEpic<E extends AbstractEpic<E>> extends AbstractMinimalEpic<E> {
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+import java.util.Map;
 
-   public enum EpicState {
+public class AbstractEpic<E extends AbstractEpic<E>> extends AbstractMinimalEpic<E> implements Serializable {
+    private static final long serialVersionUID = 8802254258764033205L;
+
+    public enum EpicState {
         OPENED, CLOSED, ALL;
 
        private static JacksonJsonEnumHelper<EpicState> enumHelper = new JacksonJsonEnumHelper<>(EpicState.class);

--- a/src/main/java/org/gitlab4j/api/models/AbstractEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractEpic.java
@@ -13,7 +13,7 @@ import java.util.List;
 import java.util.Map;
 
 public class AbstractEpic<E extends AbstractEpic<E>> extends AbstractMinimalEpic<E> implements Serializable {
-    private static final long serialVersionUID = 8802254258764033205L;
+    private static final long serialVersionUID = 1L;
 
     public enum EpicState {
         OPENED, CLOSED, ALL;

--- a/src/main/java/org/gitlab4j/api/models/AbstractGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractGroup.java
@@ -8,7 +8,8 @@ import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AbstractGroup<G extends AbstractGroup<G>> implements Serializable {
-    private static final long serialVersionUID = 2616198272324179140L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private String avatarUrl;

--- a/src/main/java/org/gitlab4j/api/models/AbstractGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractGroup.java
@@ -1,13 +1,14 @@
 
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class AbstractGroup<G extends AbstractGroup<G>> {
-
+public abstract class AbstractGroup<G extends AbstractGroup<G>> implements Serializable {
+    private static final long serialVersionUID = 2616198272324179140L;
     private Long id;
     private String name;
     private String avatarUrl;

--- a/src/main/java/org/gitlab4j/api/models/AbstractIssue.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractIssue.java
@@ -15,10 +15,11 @@ import java.util.Date;
 import java.util.List;
 
 public abstract class AbstractIssue implements Serializable {
-    private static final long serialVersionUID = -9116273927092802149L;
+    private static final long serialVersionUID = 1L;
 
     public static class TaskCompletionStatus implements Serializable {
-        private static final long serialVersionUID = -7685544544331694460L;
+        private static final long serialVersionUID = 1L;
+
         private Integer count;
         private Integer completedCount;
 

--- a/src/main/java/org/gitlab4j/api/models/AbstractIssue.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractIssue.java
@@ -1,23 +1,24 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.List;
-
-import org.gitlab4j.api.Constants.IssueState;
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.LongNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 import com.fasterxml.jackson.databind.node.ValueNode;
+import org.gitlab4j.api.Constants.IssueState;
+import org.gitlab4j.api.utils.JacksonJson;
 
-public abstract class AbstractIssue {
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
-    public static class TaskCompletionStatus {
+public abstract class AbstractIssue implements Serializable {
+    private static final long serialVersionUID = -9116273927092802149L;
 
+    public static class TaskCompletionStatus implements Serializable {
+        private static final long serialVersionUID = -7685544544331694460L;
         private Integer count;
         private Integer completedCount;
 

--- a/src/main/java/org/gitlab4j/api/models/AbstractMinimalEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractMinimalEpic.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class AbstractMinimalEpic<E extends AbstractMinimalEpic<E>> {
+import java.io.Serializable;
 
+public class AbstractMinimalEpic<E extends AbstractMinimalEpic<E>> implements Serializable {
+    private static final long serialVersionUID = -1988058935141973607L;
     private Long id;
     private Long iid;
     private Long groupId;

--- a/src/main/java/org/gitlab4j/api/models/AbstractMinimalEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractMinimalEpic.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class AbstractMinimalEpic<E extends AbstractMinimalEpic<E>> implements Serializable {
-    private static final long serialVersionUID = -1988058935141973607L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Long iid;
     private Long groupId;

--- a/src/main/java/org/gitlab4j/api/models/AbstractUser.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractUser.java
@@ -1,14 +1,14 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import java.io.Serializable;
+import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-public abstract class AbstractUser<U extends AbstractUser<U>> {
-
+public abstract class AbstractUser<U extends AbstractUser<U>> implements Serializable {
+    private static final long serialVersionUID = -9021980908269047845L;
     private String avatarUrl;
     private Date createdAt;
     private String email;

--- a/src/main/java/org/gitlab4j/api/models/AbstractUser.java
+++ b/src/main/java/org/gitlab4j/api/models/AbstractUser.java
@@ -8,7 +8,8 @@ import java.util.Date;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public abstract class AbstractUser<U extends AbstractUser<U>> implements Serializable {
-    private static final long serialVersionUID = -9021980908269047845L;
+    private static final long serialVersionUID = 1L;
+
     private String avatarUrl;
     private Date createdAt;
     private String email;

--- a/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
+++ b/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.GitLabApiForm;
 
-public class AcceptMergeRequestParams {
+import java.io.Serializable;
 
+public class AcceptMergeRequestParams implements Serializable {
+    private static final long serialVersionUID = -2261999999404292928L;
     private String mergeCommitMessage;
     private Boolean mergeWhenPipelineSucceeds;
     private String sha;

--- a/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
+++ b/src/main/java/org/gitlab4j/api/models/AcceptMergeRequestParams.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.GitLabApiForm;
 import java.io.Serializable;
 
 public class AcceptMergeRequestParams implements Serializable {
-    private static final long serialVersionUID = -2261999999404292928L;
+    private static final long serialVersionUID = 1L;
+
     private String mergeCommitMessage;
     private Boolean mergeWhenPipelineSucceeds;
     private String sha;

--- a/src/main/java/org/gitlab4j/api/models/AccessRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/AccessRequest.java
@@ -3,7 +3,7 @@ package org.gitlab4j.api.models;
 import java.util.Date;
 
 public class AccessRequest extends AbstractUser<AccessRequest> {
-
+    private static final long serialVersionUID = 4063392072771491788L;
     private Date requestedAt;
     private AccessLevel accessLevel;
 

--- a/src/main/java/org/gitlab4j/api/models/AccessRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/AccessRequest.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import java.util.Date;
 
 public class AccessRequest extends AbstractUser<AccessRequest> {
-    private static final long serialVersionUID = 4063392072771491788L;
+    private static final long serialVersionUID = 1L;
+
     private Date requestedAt;
     private AccessLevel accessLevel;
 

--- a/src/main/java/org/gitlab4j/api/models/AllowedTo.java
+++ b/src/main/java/org/gitlab4j/api/models/AllowedTo.java
@@ -9,7 +9,8 @@ import java.io.Serializable;
  * allowed_to_push, allowed_to_merge, and allowed_to_unprotect values.
  */
 public class AllowedTo implements Serializable {
-    private static final long serialVersionUID = -2912839174502977874L;
+    private static final long serialVersionUID = 1L;
+
     private AccessLevel accessLevel;
     private Long userId;
     private Long groupId;

--- a/src/main/java/org/gitlab4j/api/models/AllowedTo.java
+++ b/src/main/java/org/gitlab4j/api/models/AllowedTo.java
@@ -2,12 +2,14 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.GitLabApiForm;
 
+import java.io.Serializable;
+
 /**
  * This class is used by the ProtectedBranchesAPi to set up the
  * allowed_to_push, allowed_to_merge, and allowed_to_unprotect values.
  */
-public class AllowedTo {
-
+public class AllowedTo implements Serializable {
+    private static final long serialVersionUID = -2912839174502977874L;
     private AccessLevel accessLevel;
     private Long userId;
     private Long groupId;

--- a/src/main/java/org/gitlab4j/api/models/Application.java
+++ b/src/main/java/org/gitlab4j/api/models/Application.java
@@ -1,7 +1,9 @@
 package org.gitlab4j.api.models;
 
-public class Application {
+import java.io.Serializable;
 
+public class Application implements Serializable {
+    private static final long serialVersionUID = -3074887863851381131L;
     private Long id;
     private String applicationId;
     private String applicationName;

--- a/src/main/java/org/gitlab4j/api/models/Application.java
+++ b/src/main/java/org/gitlab4j/api/models/Application.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import java.io.Serializable;
 
 public class Application implements Serializable {
-    private static final long serialVersionUID = -3074887863851381131L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String applicationId;
     private String applicationName;

--- a/src/main/java/org/gitlab4j/api/models/ApplicationSettings.java
+++ b/src/main/java/org/gitlab4j/api/models/ApplicationSettings.java
@@ -19,7 +19,8 @@ import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
 public class ApplicationSettings implements Serializable {
-    private static final long serialVersionUID = -4830677378866003355L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Date createdAt;
     private Date updatedAt;

--- a/src/main/java/org/gitlab4j/api/models/ApplicationSettings.java
+++ b/src/main/java/org/gitlab4j/api/models/ApplicationSettings.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -17,8 +18,8 @@ import com.fasterxml.jackson.databind.node.IntNode;
 import com.fasterxml.jackson.databind.node.NullNode;
 import com.fasterxml.jackson.databind.node.TextNode;
 
-public class ApplicationSettings {
-
+public class ApplicationSettings implements Serializable {
+    private static final long serialVersionUID = -4830677378866003355L;
     private Long id;
     private Date createdAt;
     private Date updatedAt;

--- a/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
@@ -2,10 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ApprovalRule {
-
+public class ApprovalRule implements Serializable {
+    private static final long serialVersionUID = -5607473655312877909L;
     private Long id;
     private String name;
     private String ruleType;

--- a/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRule.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ApprovalRule implements Serializable {
-    private static final long serialVersionUID = -5607473655312877909L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private String ruleType;

--- a/src/main/java/org/gitlab4j/api/models/ApprovalRuleParams.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRuleParams.java
@@ -6,7 +6,8 @@ import java.util.List;
 import org.gitlab4j.api.GitLabApiForm;
 
 public class ApprovalRuleParams implements Serializable {
-    private static final long serialVersionUID = -1656517377374411043L;
+    private static final long serialVersionUID = 1L;
+
     private Integer approvalsRequired;
     private String name;
     private Boolean appliesToAllProtectedBranches;

--- a/src/main/java/org/gitlab4j/api/models/ApprovalRuleParams.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalRuleParams.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.gitlab4j.api.GitLabApiForm;
 
-public class ApprovalRuleParams {
-
-	private Integer approvalsRequired;
+public class ApprovalRuleParams implements Serializable {
+    private static final long serialVersionUID = -1656517377374411043L;
+    private Integer approvalsRequired;
     private String name;
     private Boolean appliesToAllProtectedBranches;
     private List<Long> groupIds;

--- a/src/main/java/org/gitlab4j/api/models/ApprovalState.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalState.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ApprovalState {
+import java.io.Serializable;
+import java.util.List;
 
+public class ApprovalState implements Serializable {
+    private static final long serialVersionUID = -3848509790629188218L;
     private Boolean approvalRulesOverwritten;
     private List<ApprovalRule> rules;
 

--- a/src/main/java/org/gitlab4j/api/models/ApprovalState.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovalState.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ApprovalState implements Serializable {
-    private static final long serialVersionUID = -3848509790629188218L;
+    private static final long serialVersionUID = 1L;
+
     private Boolean approvalRulesOverwritten;
     private List<ApprovalRule> rules;
 

--- a/src/main/java/org/gitlab4j/api/models/ApprovedBy.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovedBy.java
@@ -1,9 +1,10 @@
 
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
 
 /**
  * This class is used by various models to represent the approved_by property,
@@ -11,8 +12,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *
  * @since 4.19.0
  */
-public class ApprovedBy {
-
+public class ApprovedBy implements Serializable {
+    private static final long serialVersionUID = 7527083171275917542L;
     private User user;
     private Group group;
 

--- a/src/main/java/org/gitlab4j/api/models/ApprovedBy.java
+++ b/src/main/java/org/gitlab4j/api/models/ApprovedBy.java
@@ -13,7 +13,8 @@ import java.io.Serializable;
  * @since 4.19.0
  */
 public class ApprovedBy implements Serializable {
-    private static final long serialVersionUID = 7527083171275917542L;
+    private static final long serialVersionUID = 1L;
+
     private User user;
     private Group group;
 

--- a/src/main/java/org/gitlab4j/api/models/Artifact.java
+++ b/src/main/java/org/gitlab4j/api/models/Artifact.java
@@ -8,7 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class Artifact implements Serializable {
-    private static final long serialVersionUID = 4700314154831526606L;
+    private static final long serialVersionUID = 1L;
 
     public enum FileType {
         ARCHIVE, METADATA, TRACE, JUNIT;

--- a/src/main/java/org/gitlab4j/api/models/Artifact.java
+++ b/src/main/java/org/gitlab4j/api/models/Artifact.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class Artifact {
+public class Artifact implements Serializable {
+    private static final long serialVersionUID = 4700314154831526606L;
 
     public enum FileType {
         ARCHIVE, METADATA, TRACE, JUNIT;

--- a/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
+++ b/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ArtifactsFile {
+import java.io.Serializable;
 
+public class ArtifactsFile implements Serializable {
+    private static final long serialVersionUID = -6852156410785558385L;
     private String filename;
     private Long size;
 

--- a/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
+++ b/src/main/java/org/gitlab4j/api/models/ArtifactsFile.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class ArtifactsFile implements Serializable {
-    private static final long serialVersionUID = -6852156410785558385L;
+    private static final long serialVersionUID = 1L;
+
     private String filename;
     private Long size;
 

--- a/src/main/java/org/gitlab4j/api/models/Assets.java
+++ b/src/main/java/org/gitlab4j/api/models/Assets.java
@@ -1,17 +1,19 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.Constants.ArchiveFormat;
 import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
+import java.util.List;
 
 /**
  * This class is part of the Release class model.
  */
-public class Assets {
+public class Assets implements Serializable {
+    private static final long serialVersionUID = 2384144246830837990L;
 
-    public static class Source {
-
+    public static class Source implements Serializable {
+        private static final long serialVersionUID = 3024534253186638188L;
         private ArchiveFormat format;
         private String url;
 
@@ -37,8 +39,8 @@ public class Assets {
         }
     }
 
-    public static class Link {
-
+    public static class Link implements Serializable {
+        private static final long serialVersionUID = -2722442615226967526L;
         private Long id;
         private String name;
         private String url;

--- a/src/main/java/org/gitlab4j/api/models/Assets.java
+++ b/src/main/java/org/gitlab4j/api/models/Assets.java
@@ -10,10 +10,11 @@ import java.util.List;
  * This class is part of the Release class model.
  */
 public class Assets implements Serializable {
-    private static final long serialVersionUID = 2384144246830837990L;
+    private static final long serialVersionUID = 1L;
 
     public static class Source implements Serializable {
-        private static final long serialVersionUID = 3024534253186638188L;
+        private static final long serialVersionUID = 1L;
+
         private ArchiveFormat format;
         private String url;
 
@@ -40,7 +41,8 @@ public class Assets implements Serializable {
     }
 
     public static class Link implements Serializable {
-        private static final long serialVersionUID = -2722442615226967526L;
+        private static final long serialVersionUID = 1L;
+
         private Long id;
         private String name;
         private String url;

--- a/src/main/java/org/gitlab4j/api/models/Assignee.java
+++ b/src/main/java/org/gitlab4j/api/models/Assignee.java
@@ -4,6 +4,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class Assignee extends AbstractUser<Assignee> {
+    private static final long serialVersionUID = -2458251622117638839L;
 
     @Override
     public String toString() {

--- a/src/main/java/org/gitlab4j/api/models/Assignee.java
+++ b/src/main/java/org/gitlab4j/api/models/Assignee.java
@@ -4,7 +4,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class Assignee extends AbstractUser<Assignee> {
-    private static final long serialVersionUID = -2458251622117638839L;
+    private static final long serialVersionUID = 1L;
 
     @Override
     public String toString() {

--- a/src/main/java/org/gitlab4j/api/models/AuditEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/AuditEvent.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class AuditEvent implements Serializable {
-    private static final long serialVersionUID = 1361335380835271609L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Long authorId;
     private Long entityId;

--- a/src/main/java/org/gitlab4j/api/models/AuditEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/AuditEvent.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class AuditEvent {
+import java.io.Serializable;
+import java.util.Date;
 
+public class AuditEvent implements Serializable {
+    private static final long serialVersionUID = 1361335380835271609L;
     private Long id;
     private Long authorId;
     private Long entityId;

--- a/src/main/java/org/gitlab4j/api/models/AuditEventDetail.java
+++ b/src/main/java/org/gitlab4j/api/models/AuditEventDetail.java
@@ -6,7 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class AuditEventDetail implements Serializable {
-    private static final long serialVersionUID = -407430313828885637L;
+    private static final long serialVersionUID = 1L;
+
     private String change;
     private String from;
     private String to;

--- a/src/main/java/org/gitlab4j/api/models/AuditEventDetail.java
+++ b/src/main/java/org/gitlab4j/api/models/AuditEventDetail.java
@@ -3,8 +3,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class AuditEventDetail {
+import java.io.Serializable;
 
+public class AuditEventDetail implements Serializable {
+    private static final long serialVersionUID = -407430313828885637L;
     private String change;
     private String from;
     private String to;

--- a/src/main/java/org/gitlab4j/api/models/Author.java
+++ b/src/main/java/org/gitlab4j/api/models/Author.java
@@ -2,4 +2,5 @@
 package org.gitlab4j.api.models;
 
 public class Author extends AbstractUser<Author> {
+    private static final long serialVersionUID = -4899398408742861106L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Author.java
+++ b/src/main/java/org/gitlab4j/api/models/Author.java
@@ -2,5 +2,5 @@
 package org.gitlab4j.api.models;
 
 public class Author extends AbstractUser<Author> {
-    private static final long serialVersionUID = -4899398408742861106L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/AwardEmoji.java
+++ b/src/main/java/org/gitlab4j/api/models/AwardEmoji.java
@@ -1,15 +1,16 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
+import java.util.Date;
 
-public class AwardEmoji {
+public class AwardEmoji implements Serializable {
+    private static final long serialVersionUID = -1425405876922309702L;
 
     public enum AwardableType {
         ISSUE, MERGE_REQUEST, NOTE, SNIPPET;

--- a/src/main/java/org/gitlab4j/api/models/AwardEmoji.java
+++ b/src/main/java/org/gitlab4j/api/models/AwardEmoji.java
@@ -10,7 +10,7 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class AwardEmoji implements Serializable {
-    private static final long serialVersionUID = -1425405876922309702L;
+    private static final long serialVersionUID = 1L;
 
     public enum AwardableType {
         ISSUE, MERGE_REQUEST, NOTE, SNIPPET;

--- a/src/main/java/org/gitlab4j/api/models/Badge.java
+++ b/src/main/java/org/gitlab4j/api/models/Badge.java
@@ -8,7 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class Badge implements Serializable {
-    private static final long serialVersionUID = -4358146293064711740L;
+    private static final long serialVersionUID = 1L;
 
     public enum BadgeKind {
         PROJECT, GROUP;

--- a/src/main/java/org/gitlab4j/api/models/Badge.java
+++ b/src/main/java/org/gitlab4j/api/models/Badge.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class Badge {
+public class Badge implements Serializable {
+    private static final long serialVersionUID = -4358146293064711740L;
 
     public enum BadgeKind {
         PROJECT, GROUP;

--- a/src/main/java/org/gitlab4j/api/models/Blame.java
+++ b/src/main/java/org/gitlab4j/api/models/Blame.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class Blame implements Serializable {
-    private static final long serialVersionUID = -7605541188039758092L;
+    private static final long serialVersionUID = 1L;
+
     private Commit commit;
     private List<String> lines;
 

--- a/src/main/java/org/gitlab4j/api/models/Blame.java
+++ b/src/main/java/org/gitlab4j/api/models/Blame.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Blame {
+import java.io.Serializable;
+import java.util.List;
 
+public class Blame implements Serializable {
+    private static final long serialVersionUID = -7605541188039758092L;
     private Commit commit;
     private List<String> lines;
 

--- a/src/main/java/org/gitlab4j/api/models/Board.java
+++ b/src/main/java/org/gitlab4j/api/models/Board.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Board {
+import java.io.Serializable;
+import java.util.List;
 
+public class Board implements Serializable {
+    private static final long serialVersionUID = 2774787747056305357L;
     private Long id;
     private String name;
     private Project project;

--- a/src/main/java/org/gitlab4j/api/models/Board.java
+++ b/src/main/java/org/gitlab4j/api/models/Board.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class Board implements Serializable {
-    private static final long serialVersionUID = 2774787747056305357L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private Project project;

--- a/src/main/java/org/gitlab4j/api/models/BoardList.java
+++ b/src/main/java/org/gitlab4j/api/models/BoardList.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class BoardList {
+import java.io.Serializable;
 
+public class BoardList implements Serializable {
+    private static final long serialVersionUID = 1576257929374124267L;
     private Long id;
     private Label label;
     private Integer position;

--- a/src/main/java/org/gitlab4j/api/models/BoardList.java
+++ b/src/main/java/org/gitlab4j/api/models/BoardList.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class BoardList implements Serializable {
-    private static final long serialVersionUID = 1576257929374124267L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Label label;
     private Integer position;

--- a/src/main/java/org/gitlab4j/api/models/Branch.java
+++ b/src/main/java/org/gitlab4j/api/models/Branch.java
@@ -3,8 +3,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Branch {
+import java.io.Serializable;
 
+public class Branch implements Serializable {
+    private static final long serialVersionUID = -8581563271712199201L;
     private Commit commit;
     private Boolean developersCanMerge;
     private Boolean developersCanPush;

--- a/src/main/java/org/gitlab4j/api/models/Branch.java
+++ b/src/main/java/org/gitlab4j/api/models/Branch.java
@@ -6,7 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Branch implements Serializable {
-    private static final long serialVersionUID = -8581563271712199201L;
+    private static final long serialVersionUID = 1L;
+
     private Commit commit;
     private Boolean developersCanMerge;
     private Boolean developersCanPush;

--- a/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
+++ b/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class BranchAccessLevel {
+import java.io.Serializable;
 
+public class BranchAccessLevel implements Serializable {
+    private static final long serialVersionUID = 5766241722141581577L;
     private Long id;
     private AccessLevel accessLevel;
     private String accessLevelDescription;

--- a/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
+++ b/src/main/java/org/gitlab4j/api/models/BranchAccessLevel.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class BranchAccessLevel implements Serializable {
-    private static final long serialVersionUID = 5766241722141581577L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private AccessLevel accessLevel;
     private String accessLevelDescription;

--- a/src/main/java/org/gitlab4j/api/models/Bridge.java
+++ b/src/main/java/org/gitlab4j/api/models/Bridge.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Bridge implements Serializable {
-    private static final long serialVersionUID = 2971883600795290448L;
+    private static final long serialVersionUID = 1L;
+
     private Commit commit;
     private boolean allowFailure;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/Bridge.java
+++ b/src/main/java/org/gitlab4j/api/models/Bridge.java
@@ -2,9 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class Bridge {
+public class Bridge implements Serializable {
+    private static final long serialVersionUID = 2971883600795290448L;
     private Commit commit;
     private boolean allowFailure;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
+++ b/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
@@ -9,7 +9,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class ChangelogPayload implements Serializable {
-    private static final long serialVersionUID = -4430138739965401359L;
+    private static final long serialVersionUID = 1L;
+
     private String version;
     private String from;
     private String to;

--- a/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
+++ b/src/main/java/org/gitlab4j/api/models/ChangelogPayload.java
@@ -5,10 +5,11 @@ import org.gitlab4j.api.GitLabApiForm;
 import org.gitlab4j.api.utils.ISO8601;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class ChangelogPayload {
-
+public class ChangelogPayload implements Serializable {
+    private static final long serialVersionUID = -4430138739965401359L;
     private String version;
     private String from;
     private String to;

--- a/src/main/java/org/gitlab4j/api/models/Changes.java
+++ b/src/main/java/org/gitlab4j/api/models/Changes.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.gitlab4j.api.utils.JacksonJson;
 
-public class Changes {
+import java.io.Serializable;
 
+public class Changes implements Serializable {
+    private static final long serialVersionUID = -1777640937801508683L;
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty("a_mode")
     private String a_mode;

--- a/src/main/java/org/gitlab4j/api/models/Changes.java
+++ b/src/main/java/org/gitlab4j/api/models/Changes.java
@@ -7,7 +7,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Changes implements Serializable {
-    private static final long serialVersionUID = -1777640937801508683L;
+    private static final long serialVersionUID = 1L;
+
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty("a_mode")
     private String a_mode;

--- a/src/main/java/org/gitlab4j/api/models/ChildEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/ChildEpic.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class ChildEpic extends AbstractEpic<ChildEpic> {
+    private static final long serialVersionUID = 3423897732994265591L;
 
     public String toString() {
         return (JacksonJson.toJsonString(this));

--- a/src/main/java/org/gitlab4j/api/models/ChildEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/ChildEpic.java
@@ -3,7 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class ChildEpic extends AbstractEpic<ChildEpic> {
-    private static final long serialVersionUID = 3423897732994265591L;
+    private static final long serialVersionUID = 1L;
 
     public String toString() {
         return (JacksonJson.toJsonString(this));

--- a/src/main/java/org/gitlab4j/api/models/Comment.java
+++ b/src/main/java/org/gitlab4j/api/models/Comment.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Comment implements Serializable {
-    private static final long serialVersionUID = 1917643760458643525L;
+    private static final long serialVersionUID = 1L;
+
     private Author author;
     private Date createdAt;
     private LineType lineType;

--- a/src/main/java/org/gitlab4j/api/models/Comment.java
+++ b/src/main/java/org/gitlab4j/api/models/Comment.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.Constants.LineType;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Comment {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Comment implements Serializable {
+    private static final long serialVersionUID = 1917643760458643525L;
     private Author author;
     private Date createdAt;
     private LineType lineType;

--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -1,13 +1,14 @@
 
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
-
-public class Commit {
-
+public class Commit implements Serializable {
+    private static final long serialVersionUID = -5309295947818195004L;
     private Author author;
     private Date authoredDate;
     private String authorEmail;

--- a/src/main/java/org/gitlab4j/api/models/Commit.java
+++ b/src/main/java/org/gitlab4j/api/models/Commit.java
@@ -8,7 +8,8 @@ import java.util.Date;
 import java.util.List;
 
 public class Commit implements Serializable {
-    private static final long serialVersionUID = -5309295947818195004L;
+    private static final long serialVersionUID = 1L;
+
     private Author author;
     private Date authoredDate;
     private String authorEmail;

--- a/src/main/java/org/gitlab4j/api/models/CommitAction.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitAction.java
@@ -13,7 +13,7 @@ import java.io.IOException;
 import java.io.Serializable;
 
 public class CommitAction implements Serializable {
-    private static final long serialVersionUID = 5720172990936523724L;
+    private static final long serialVersionUID = 1L;
 
     public enum Action {
 

--- a/src/main/java/org/gitlab4j/api/models/CommitAction.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitAction.java
@@ -1,18 +1,19 @@
 package org.gitlab4j.api.models;
 
-import java.io.File;
-import java.io.IOException;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.Constants.Encoding;
 import org.gitlab4j.api.GitLabApiException;
 import org.gitlab4j.api.utils.FileUtils;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.File;
+import java.io.IOException;
+import java.io.Serializable;
 
-public class CommitAction {
+public class CommitAction implements Serializable {
+    private static final long serialVersionUID = 5720172990936523724L;
 
     public enum Action {
 
@@ -142,7 +143,7 @@ public class CommitAction {
 
     public CommitAction withFileContent(File file, String filePath, Encoding encoding) throws GitLabApiException {
 
-        this.encoding = (encoding != null ? encoding : Encoding.TEXT); 
+        this.encoding = (encoding != null ? encoding : Encoding.TEXT);
         this.filePath = filePath;
 
         try {

--- a/src/main/java/org/gitlab4j/api/models/CommitPayload.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitPayload.java
@@ -7,7 +7,8 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class CommitPayload implements Serializable {
-    private static final long serialVersionUID = -909264239788934196L;
+    private static final long serialVersionUID = 1L;
+
     private String branch;
     private String commitMessage;
     private String startBranch;

--- a/src/main/java/org/gitlab4j/api/models/CommitPayload.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitPayload.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
-
-public class CommitPayload {
-
+public class CommitPayload implements Serializable {
+    private static final long serialVersionUID = -909264239788934196L;
     private String branch;
     private String commitMessage;
     private String startBranch;

--- a/src/main/java/org/gitlab4j/api/models/CommitRef.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitRef.java
@@ -1,13 +1,14 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class CommitRef {
-
+public class CommitRef implements Serializable {
+    private static final long serialVersionUID = 2761193061188727620L;
     private RefType type;
     private String name;
 

--- a/src/main/java/org/gitlab4j/api/models/CommitRef.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitRef.java
@@ -8,7 +8,8 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class CommitRef implements Serializable {
-    private static final long serialVersionUID = 2761193061188727620L;
+    private static final long serialVersionUID = 1L;
+
     private RefType type;
     private String name;
 

--- a/src/main/java/org/gitlab4j/api/models/CommitStats.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStats.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class CommitStats implements Serializable {
-    private static final long serialVersionUID = -5607632904521556869L;
+    private static final long serialVersionUID = 1L;
+
     private Integer additions;
     private Integer deletions;
     private Integer total;

--- a/src/main/java/org/gitlab4j/api/models/CommitStats.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStats.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class CommitStats {
+import java.io.Serializable;
 
+public class CommitStats implements Serializable {
+    private static final long serialVersionUID = -5607632904521556869L;
     private Integer additions;
     private Integer deletions;
     private Integer total;

--- a/src/main/java/org/gitlab4j/api/models/CommitStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStatus.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class CommitStatus {
+import java.io.Serializable;
+import java.util.Date;
 
+public class CommitStatus implements Serializable {
+    private static final long serialVersionUID = -4986890666487972709L;
     private Boolean allowFailure;
     private Author author;
     private Float coverage;

--- a/src/main/java/org/gitlab4j/api/models/CommitStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStatus.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class CommitStatus implements Serializable {
-    private static final long serialVersionUID = -4986890666487972709L;
+    private static final long serialVersionUID = 1L;
+
     private Boolean allowFailure;
     private Author author;
     private Float coverage;

--- a/src/main/java/org/gitlab4j/api/models/CommitStatusFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStatusFilter.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
  * This class is used to filter commit status when getting lists of them.
  */
 public class CommitStatusFilter implements Serializable {
-    private static final long serialVersionUID = -9065214362591834155L;
+    private static final long serialVersionUID = 1L;
+
     private String ref;
     private String stage;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/CommitStatusFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/CommitStatusFilter.java
@@ -1,20 +1,21 @@
 package org.gitlab4j.api.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.GitLabApiForm;
+
+import java.io.Serializable;
 
 /**
  * This class is used to filter commit status when getting lists of them.
  */
-public class CommitStatusFilter {
-
+public class CommitStatusFilter implements Serializable {
+    private static final long serialVersionUID = -9065214362591834155L;
     private String ref;
     private String stage;
     private String name;
     private Boolean all;
-    
+
     public CommitStatusFilter withRef(String ref) {
         this.ref = ref;
         return this;
@@ -30,7 +31,7 @@ public class CommitStatusFilter {
         return this;
     }
 
-    
+
     public CommitStatusFilter withAll(Boolean all) {
         this.all = all;
         return this;
@@ -43,12 +44,12 @@ public class CommitStatusFilter {
             .withParam(Constants.PER_PAGE_PARAM, perPage));
     }
 
-    @JsonIgnore 
+    @JsonIgnore
     public GitLabApiForm getQueryParams() {
         return (new GitLabApiForm()
             .withParam("ref", ref)
             .withParam("stage", stage)
             .withParam("name", name)
-            .withParam("all", all));  
+            .withParam("all", all));
     }
 }

--- a/src/main/java/org/gitlab4j/api/models/CompareResults.java
+++ b/src/main/java/org/gitlab4j/api/models/CompareResults.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class CompareResults {
+import java.io.Serializable;
+import java.util.List;
 
+public class CompareResults implements Serializable {
+    private static final long serialVersionUID = -2871624622998850399L;
     private Commit commit;
     private List<Commit> commits;;
     private List<Diff> diffs;

--- a/src/main/java/org/gitlab4j/api/models/CompareResults.java
+++ b/src/main/java/org/gitlab4j/api/models/CompareResults.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class CompareResults implements Serializable {
-    private static final long serialVersionUID = -2871624622998850399L;
+    private static final long serialVersionUID = 1L;
+
     private Commit commit;
     private List<Commit> commits;;
     private List<Diff> diffs;

--- a/src/main/java/org/gitlab4j/api/models/Contributor.java
+++ b/src/main/java/org/gitlab4j/api/models/Contributor.java
@@ -4,8 +4,8 @@ package org.gitlab4j.api.models;
  * This class models the object for a repository contributor.
  * See <a href="https://docs.gitlab.com/ee/api/repositories.html#contributors">Contributors at GitLab</a>.
  */
-public class Contributor extends AbstractUser<Contributor> {
-
+public class Contributor extends AbstractUser<Contributor>{
+    private static final long serialVersionUID = -4198040423122732070L;
     private Integer commits;
     private Integer additions;
     private Integer deletions;

--- a/src/main/java/org/gitlab4j/api/models/Contributor.java
+++ b/src/main/java/org/gitlab4j/api/models/Contributor.java
@@ -5,7 +5,8 @@ package org.gitlab4j.api.models;
  * See <a href="https://docs.gitlab.com/ee/api/repositories.html#contributors">Contributors at GitLab</a>.
  */
 public class Contributor extends AbstractUser<Contributor>{
-    private static final long serialVersionUID = -4198040423122732070L;
+    private static final long serialVersionUID = 1L;
+
     private Integer commits;
     private Integer additions;
     private Integer deletions;

--- a/src/main/java/org/gitlab4j/api/models/CreatedChildEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/CreatedChildEpic.java
@@ -3,7 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class CreatedChildEpic extends AbstractMinimalEpic<CreatedChildEpic> {
-
+    private static final long serialVersionUID = -5686922693728608886L;
     private Boolean hasChildren;
     private Boolean hasIssues;
     private String url;

--- a/src/main/java/org/gitlab4j/api/models/CreatedChildEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/CreatedChildEpic.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class CreatedChildEpic extends AbstractMinimalEpic<CreatedChildEpic> {
-    private static final long serialVersionUID = -5686922693728608886L;
+    private static final long serialVersionUID = 1L;
+
     private Boolean hasChildren;
     private Boolean hasIssues;
     private String url;

--- a/src/main/java/org/gitlab4j/api/models/CustomAttribute.java
+++ b/src/main/java/org/gitlab4j/api/models/CustomAttribute.java
@@ -1,6 +1,9 @@
 package org.gitlab4j.api.models;
 
-public class CustomAttribute {
+import java.io.Serializable;
+
+public class CustomAttribute implements Serializable {
+    private static final long serialVersionUID = -4021719541521426021L;
     private String key;
     private String value;
 

--- a/src/main/java/org/gitlab4j/api/models/CustomAttribute.java
+++ b/src/main/java/org/gitlab4j/api/models/CustomAttribute.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import java.io.Serializable;
 
 public class CustomAttribute implements Serializable {
-    private static final long serialVersionUID = -4021719541521426021L;
+    private static final long serialVersionUID = 1L;
+
     private String key;
     private String value;
 

--- a/src/main/java/org/gitlab4j/api/models/DeployKey.java
+++ b/src/main/java/org/gitlab4j/api/models/DeployKey.java
@@ -1,18 +1,19 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class DeployKey {
+import java.io.Serializable;
+import java.util.Date;
 
+public class DeployKey implements Serializable {
+    private static final long serialVersionUID = -5773240329719065765L;
     private Long id;
     private String title;
     private String key;
     private Boolean canPush;
     private Date createdAt;
- 
+
     public Long getId() {
         return this.id;
     }
@@ -44,7 +45,7 @@ public class DeployKey {
     public void setCanPush(Boolean canPush) {
         this.canPush = canPush;
     }
-    
+
     public Date getCreatedAt() {
         return this.createdAt;
     }

--- a/src/main/java/org/gitlab4j/api/models/DeployKey.java
+++ b/src/main/java/org/gitlab4j/api/models/DeployKey.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class DeployKey implements Serializable {
-    private static final long serialVersionUID = -5773240329719065765L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String title;
     private String key;

--- a/src/main/java/org/gitlab4j/api/models/DeployToken.java
+++ b/src/main/java/org/gitlab4j/api/models/DeployToken.java
@@ -3,11 +3,12 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-public class DeployToken {
-
+public class DeployToken implements Serializable {
+    private static final long serialVersionUID = -2137975534650973309L;
     private Long id;
     private String name;
     private String username;

--- a/src/main/java/org/gitlab4j/api/models/DeployToken.java
+++ b/src/main/java/org/gitlab4j/api/models/DeployToken.java
@@ -8,7 +8,8 @@ import java.util.Date;
 import java.util.List;
 
 public class DeployToken implements Serializable {
-    private static final long serialVersionUID = -2137975534650973309L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private String username;

--- a/src/main/java/org/gitlab4j/api/models/Deployable.java
+++ b/src/main/java/org/gitlab4j/api/models/Deployable.java
@@ -1,13 +1,14 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.List;
-
 import org.gitlab4j.api.Constants.DeploymentStatus;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Deployable {
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
+public class Deployable implements Serializable {
+    private static final long serialVersionUID = -2615572922445533790L;
     private Long id;
     private DeploymentStatus status;
     private String stage;

--- a/src/main/java/org/gitlab4j/api/models/Deployable.java
+++ b/src/main/java/org/gitlab4j/api/models/Deployable.java
@@ -8,7 +8,8 @@ import java.util.Date;
 import java.util.List;
 
 public class Deployable implements Serializable {
-    private static final long serialVersionUID = -2615572922445533790L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private DeploymentStatus status;
     private String stage;

--- a/src/main/java/org/gitlab4j/api/models/Deployment.java
+++ b/src/main/java/org/gitlab4j/api/models/Deployment.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Deployment implements Serializable {
-    private static final long serialVersionUID = -7687358667670668078L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Long iid;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/Deployment.java
+++ b/src/main/java/org/gitlab4j/api/models/Deployment.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.Constants.DeploymentStatus;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Deployment {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Deployment implements Serializable {
+    private static final long serialVersionUID = -7687358667670668078L;
     private Long id;
     private Long iid;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/DeploymentFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/DeploymentFilter.java
@@ -13,7 +13,8 @@ import org.gitlab4j.api.utils.ISO8601;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class DeploymentFilter implements Serializable {
-    private static final long serialVersionUID = 7839110225941520941L;
+    private static final long serialVersionUID = 1L;
+
     /**
 	 * Return deployments ordered by either one of id, iid, created_at, updated_at or ref fields. Default is id.
 	 */

--- a/src/main/java/org/gitlab4j/api/models/DeploymentFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/DeploymentFilter.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.Constants;
@@ -11,9 +12,9 @@ import org.gitlab4j.api.utils.ISO8601;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class DeploymentFilter {
-
-	/**
+public class DeploymentFilter implements Serializable {
+    private static final long serialVersionUID = 7839110225941520941L;
+    /**
 	 * Return deployments ordered by either one of id, iid, created_at, updated_at or ref fields. Default is id.
 	 */
 	private DeploymentOrderBy orderBy;

--- a/src/main/java/org/gitlab4j/api/models/DetailedStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/DetailedStatus.java
@@ -2,11 +2,13 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
+
 /**
  * This class is part of the Pipeline message.
  */
-public class DetailedStatus {
-
+public class DetailedStatus implements Serializable {
+    private static final long serialVersionUID = -6621240797564980173L;
     private String icon;
     private String text;
     private String label;

--- a/src/main/java/org/gitlab4j/api/models/DetailedStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/DetailedStatus.java
@@ -8,7 +8,8 @@ import java.io.Serializable;
  * This class is part of the Pipeline message.
  */
 public class DetailedStatus implements Serializable {
-    private static final long serialVersionUID = -6621240797564980173L;
+    private static final long serialVersionUID = 1L;
+
     private String icon;
     private String text;
     private String label;

--- a/src/main/java/org/gitlab4j/api/models/Diff.java
+++ b/src/main/java/org/gitlab4j/api/models/Diff.java
@@ -1,17 +1,18 @@
 
 package org.gitlab4j.api.models;
 
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.gitlab4j.api.utils.JacksonJson;
 
-public class Diff {
-    
+import java.io.Serializable;
+
+public class Diff implements Serializable {
+    private static final long serialVersionUID = -4483166688383479990L;
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty("a_mode")
     private String a_mode;
-  
+
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty("b_mode")
     private String b_mode;

--- a/src/main/java/org/gitlab4j/api/models/Diff.java
+++ b/src/main/java/org/gitlab4j/api/models/Diff.java
@@ -8,7 +8,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Diff implements Serializable {
-    private static final long serialVersionUID = -4483166688383479990L;
+    private static final long serialVersionUID = 1L;
+
     @JsonInclude(JsonInclude.Include.ALWAYS)
     @JsonProperty("a_mode")
     private String a_mode;

--- a/src/main/java/org/gitlab4j/api/models/DiffRef.java
+++ b/src/main/java/org/gitlab4j/api/models/DiffRef.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class DiffRef implements Serializable {
-    private static final long serialVersionUID = -9034081155654000901L;
+    private static final long serialVersionUID = 1L;
+
     private String baseSha;
     private String headSha;
     private String startSha;

--- a/src/main/java/org/gitlab4j/api/models/DiffRef.java
+++ b/src/main/java/org/gitlab4j/api/models/DiffRef.java
@@ -2,7 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class DiffRef {
+import java.io.Serializable;
+
+public class DiffRef implements Serializable {
+    private static final long serialVersionUID = -9034081155654000901L;
     private String baseSha;
     private String headSha;
     private String startSha;

--- a/src/main/java/org/gitlab4j/api/models/Discussion.java
+++ b/src/main/java/org/gitlab4j/api/models/Discussion.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Discussion {
+import java.io.Serializable;
+import java.util.List;
 
+public class Discussion implements Serializable {
+    private static final long serialVersionUID = 980803383743624987L;
     private String id;
     private Boolean individualNote;
     private List<Note> notes;

--- a/src/main/java/org/gitlab4j/api/models/Discussion.java
+++ b/src/main/java/org/gitlab4j/api/models/Discussion.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class Discussion implements Serializable {
-    private static final long serialVersionUID = 980803383743624987L;
+    private static final long serialVersionUID = 1L;
+
     private String id;
     private Boolean individualNote;
     private List<Note> notes;

--- a/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
@@ -2,9 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class DownstreamPipeline {
+public class DownstreamPipeline implements Serializable {
+    private static final long serialVersionUID = 6808739921188206517L;
     private int id;
     private String sha;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class DownstreamPipeline implements Serializable {
-    private static final long serialVersionUID = 6808739921188206517L;
+    private static final long serialVersionUID = 1L;
+
     private int id;
     private String sha;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/Duration.java
+++ b/src/main/java/org/gitlab4j/api/models/Duration.java
@@ -10,7 +10,8 @@ import java.io.Serializable;
  * This class represents a duration in time.
  */
 public class Duration implements Serializable {
-    private static final long serialVersionUID = 5088839932537037135L;
+    private static final long serialVersionUID = 1L;
+
     private int seconds;
     private String durationString;
 

--- a/src/main/java/org/gitlab4j/api/models/Duration.java
+++ b/src/main/java/org/gitlab4j/api/models/Duration.java
@@ -1,15 +1,16 @@
 package org.gitlab4j.api.models;
 
-import org.gitlab4j.api.utils.DurationUtils;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.gitlab4j.api.utils.DurationUtils;
+
+import java.io.Serializable;
 
 /**
  * This class represents a duration in time.
  */
-public class Duration {
-
+public class Duration implements Serializable {
+    private static final long serialVersionUID = 5088839932537037135L;
     private int seconds;
     private String durationString;
 

--- a/src/main/java/org/gitlab4j/api/models/Email.java
+++ b/src/main/java/org/gitlab4j/api/models/Email.java
@@ -1,7 +1,9 @@
 package org.gitlab4j.api.models;
 
-public class Email {
+import java.io.Serializable;
 
+public class Email implements Serializable {
+    private static final long serialVersionUID = -7852698606973146239L;
     private Long id;
     private String email;
 

--- a/src/main/java/org/gitlab4j/api/models/Email.java
+++ b/src/main/java/org/gitlab4j/api/models/Email.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import java.io.Serializable;
 
 public class Email implements Serializable {
-    private static final long serialVersionUID = -7852698606973146239L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String email;
 

--- a/src/main/java/org/gitlab4j/api/models/Environment.java
+++ b/src/main/java/org/gitlab4j/api/models/Environment.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class Environment {
+public class Environment implements Serializable {
+    private static final long serialVersionUID = 5680655830549448926L;
 
     public enum EnvironmentState {
 	AVAILABLE, STOPPED;

--- a/src/main/java/org/gitlab4j/api/models/Environment.java
+++ b/src/main/java/org/gitlab4j/api/models/Environment.java
@@ -8,7 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class Environment implements Serializable {
-    private static final long serialVersionUID = 5680655830549448926L;
+    private static final long serialVersionUID = 1L;
 
     public enum EnvironmentState {
 	AVAILABLE, STOPPED;

--- a/src/main/java/org/gitlab4j/api/models/Epic.java
+++ b/src/main/java/org/gitlab4j/api/models/Epic.java
@@ -1,11 +1,11 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Epic extends AbstractEpic<Epic> {
+import java.util.Date;
 
+public class Epic extends AbstractEpic<Epic> {
+    private static final long serialVersionUID = -2039780947154320347L;
     private Boolean startDateIsFixed;
     private Boolean dueDateIsFixed;
     private Date dueDateFromInheritedSource;

--- a/src/main/java/org/gitlab4j/api/models/Epic.java
+++ b/src/main/java/org/gitlab4j/api/models/Epic.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.util.Date;
 
 public class Epic extends AbstractEpic<Epic> {
-    private static final long serialVersionUID = -2039780947154320347L;
+    private static final long serialVersionUID = 1L;
+
     private Boolean startDateIsFixed;
     private Boolean dueDateIsFixed;
     private Date dueDateFromInheritedSource;

--- a/src/main/java/org/gitlab4j/api/models/EpicFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicFilter.java
@@ -1,25 +1,24 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.Constants.EpicOrderBy;
 import org.gitlab4j.api.Constants.SortOrder;
-
-import java.util.Date;
-import java.util.LinkedHashMap;
-import java.util.Map;
-
 import org.gitlab4j.api.GitLabApiForm;
 import org.gitlab4j.api.models.AbstractEpic.EpicState;
 import org.gitlab4j.api.utils.ISO8601;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.LinkedHashMap;
+import java.util.Map;
 
 /**
  *  This class is used to filter Groups when getting lists of epics.
  */
-public class EpicFilter {
-
+public class EpicFilter implements Serializable {
+    private static final long serialVersionUID = 1020596795849193660L;
     private Long authorId;
     private String authorUsername;
     private String labels;
@@ -78,7 +77,7 @@ public class EpicFilter {
         this.authorUsername = authorUsername;
         return (this);
     }
-    
+
     /**
      * Add 'labels' filter.
      *

--- a/src/main/java/org/gitlab4j/api/models/EpicFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicFilter.java
@@ -18,7 +18,8 @@ import java.util.Map;
  *  This class is used to filter Groups when getting lists of epics.
  */
 public class EpicFilter implements Serializable {
-    private static final long serialVersionUID = 1020596795849193660L;
+    private static final long serialVersionUID = 1L;
+
     private Long authorId;
     private String authorUsername;
     private String labels;

--- a/src/main/java/org/gitlab4j/api/models/EpicInLink.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicInLink.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class EpicInLink extends AbstractEpic<EpicInLink> {
+    private static final long serialVersionUID = 3050569265982322906L;
 
     public String toString() {
         return (JacksonJson.toJsonString(this));

--- a/src/main/java/org/gitlab4j/api/models/EpicInLink.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicInLink.java
@@ -3,7 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class EpicInLink extends AbstractEpic<EpicInLink> {
-    private static final long serialVersionUID = 3050569265982322906L;
+    private static final long serialVersionUID = 1L;
 
     public String toString() {
         return (JacksonJson.toJsonString(this));

--- a/src/main/java/org/gitlab4j/api/models/EpicIssueLink.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicIssueLink.java
@@ -6,7 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class EpicIssueLink implements Serializable {
-    private static final long serialVersionUID = 8283764367558203361L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Integer relativePosition;
     private Epic epic;

--- a/src/main/java/org/gitlab4j/api/models/EpicIssueLink.java
+++ b/src/main/java/org/gitlab4j/api/models/EpicIssueLink.java
@@ -3,8 +3,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class EpicIssueLink {
+import java.io.Serializable;
 
+public class EpicIssueLink implements Serializable {
+    private static final long serialVersionUID = 8283764367558203361L;
     private Long id;
     private Integer relativePosition;
     private Epic epic;

--- a/src/main/java/org/gitlab4j/api/models/Event.java
+++ b/src/main/java/org/gitlab4j/api/models/Event.java
@@ -8,7 +8,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Event implements Serializable {
-    private static final long serialVersionUID = -8324645348073849814L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String actionName;
     private Author author;

--- a/src/main/java/org/gitlab4j/api/models/Event.java
+++ b/src/main/java/org/gitlab4j/api/models/Event.java
@@ -1,13 +1,14 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.Constants.TargetType;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Event {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Event implements Serializable {
+    private static final long serialVersionUID = -8324645348073849814L;
     private Long id;
     private String actionName;
     private Author author;

--- a/src/main/java/org/gitlab4j/api/models/EventData.java
+++ b/src/main/java/org/gitlab4j/api/models/EventData.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class EventData {
+import java.io.Serializable;
+import java.util.List;
 
+public class EventData implements Serializable {
+    private static final long serialVersionUID = -1778675702778168859L;
     private String after;
     private String before;
     private List<Commit> commits;

--- a/src/main/java/org/gitlab4j/api/models/EventData.java
+++ b/src/main/java/org/gitlab4j/api/models/EventData.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class EventData implements Serializable {
-    private static final long serialVersionUID = -1778675702778168859L;
+    private static final long serialVersionUID = 1L;
+
     private String after;
     private String before;
     private List<Commit> commits;

--- a/src/main/java/org/gitlab4j/api/models/ExportStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ExportStatus.java
@@ -12,7 +12,7 @@ import java.util.Date;
 import java.util.Map;
 
 public class ExportStatus implements Serializable {
-    private static final long serialVersionUID = -6479418376568344745L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Enum representing the status of the export.

--- a/src/main/java/org/gitlab4j/api/models/ExportStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ExportStatus.java
@@ -1,17 +1,18 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.Map;
-
-import org.gitlab4j.api.utils.JacksonJson;
-import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-public class ExportStatus {
+import java.io.Serializable;
+import java.util.Date;
+import java.util.Map;
+
+public class ExportStatus implements Serializable {
+    private static final long serialVersionUID = -6479418376568344745L;
 
     /**
      * Enum representing the status of the export.

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheck.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheck.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ExternalStatusCheck implements Serializable {
-    private static final long serialVersionUID = 2079093664740067505L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private Long projectId;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheck.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheck.java
@@ -2,10 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.List;
 
-public class ExternalStatusCheck {
-
+public class ExternalStatusCheck implements Serializable {
+    private static final long serialVersionUID = 2079093664740067505L;
     private Long id;
     private String name;
     private Long projectId;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckProtectedBranch.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckProtectedBranch.java
@@ -8,7 +8,8 @@ import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class ExternalStatusCheckProtectedBranch implements Serializable {
-    private static final long serialVersionUID = 3702177459228966383L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private Long projectId;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckProtectedBranch.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckProtectedBranch.java
@@ -1,13 +1,14 @@
 
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ExternalStatusCheckProtectedBranch {
-
+public class ExternalStatusCheckProtectedBranch implements Serializable {
+    private static final long serialVersionUID = 3702177459228966383L;
     private Long id;
     private Long projectId;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckResult.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckResult.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class ExternalStatusCheckResult implements Serializable {
-    private static final long serialVersionUID = 8696813682987928642L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private MergeRequest mergeRequest;
     private ExternalStatusCheck externalStatusCheck;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckResult.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckResult.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ExternalStatusCheckResult {
+import java.io.Serializable;
 
+public class ExternalStatusCheckResult implements Serializable {
+    private static final long serialVersionUID = 8696813682987928642L;
     private Long id;
     private MergeRequest mergeRequest;
     private ExternalStatusCheck externalStatusCheck;

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckStatus.java
@@ -6,8 +6,10 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public class ExternalStatusCheckStatus {
+import java.io.Serializable;
 
+public class ExternalStatusCheckStatus implements Serializable {
+    private static final long serialVersionUID = -4975275665782772237L;
     private Long id;
     private String name;
     private String externalUrl;
@@ -33,7 +35,7 @@ public class ExternalStatusCheckStatus {
             return (enumHelper.toString(this));
         }
     }
-    
+
     public Long getId() {
         return id;
     }

--- a/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ExternalStatusCheckStatus.java
@@ -9,7 +9,8 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import java.io.Serializable;
 
 public class ExternalStatusCheckStatus implements Serializable {
-    private static final long serialVersionUID = -4975275665782772237L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private String externalUrl;

--- a/src/main/java/org/gitlab4j/api/models/FileUpload.java
+++ b/src/main/java/org/gitlab4j/api/models/FileUpload.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class FileUpload {
+import java.io.Serializable;
 
+public class FileUpload implements Serializable {
+    private static final long serialVersionUID = 6666551122360550967L;
     private String alt;
     private String url;
     private String markdown;

--- a/src/main/java/org/gitlab4j/api/models/FileUpload.java
+++ b/src/main/java/org/gitlab4j/api/models/FileUpload.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class FileUpload implements Serializable {
-    private static final long serialVersionUID = 6666551122360550967L;
+    private static final long serialVersionUID = 1L;
+
     private String alt;
     private String url;
     private String markdown;

--- a/src/main/java/org/gitlab4j/api/models/GitLabCiTemplate.java
+++ b/src/main/java/org/gitlab4j/api/models/GitLabCiTemplate.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class GitLabCiTemplate {
+import java.io.Serializable;
 
+public class GitLabCiTemplate implements Serializable {
+    private static final long serialVersionUID = -8338332681415500765L;
     private String name;
     private String content;
 

--- a/src/main/java/org/gitlab4j/api/models/GitLabCiTemplate.java
+++ b/src/main/java/org/gitlab4j/api/models/GitLabCiTemplate.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class GitLabCiTemplate implements Serializable {
-    private static final long serialVersionUID = -8338332681415500765L;
+    private static final long serialVersionUID = 1L;
+
     private String name;
     private String content;
 

--- a/src/main/java/org/gitlab4j/api/models/GitLabCiTemplateElement.java
+++ b/src/main/java/org/gitlab4j/api/models/GitLabCiTemplateElement.java
@@ -2,8 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class GitLabCiTemplateElement {
+import java.io.Serializable;
 
+public class GitLabCiTemplateElement implements Serializable {
+    private static final long serialVersionUID = 5775478350942742711L;
     private String key;
     private String name;
 

--- a/src/main/java/org/gitlab4j/api/models/GitLabCiTemplateElement.java
+++ b/src/main/java/org/gitlab4j/api/models/GitLabCiTemplateElement.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class GitLabCiTemplateElement implements Serializable {
-    private static final long serialVersionUID = 5775478350942742711L;
+    private static final long serialVersionUID = 1L;
+
     private String key;
     private String name;
 

--- a/src/main/java/org/gitlab4j/api/models/GpgSignature.java
+++ b/src/main/java/org/gitlab4j/api/models/GpgSignature.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class GpgSignature implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2146684278503477421L;
     private Long gpgKeyId;
     private String gpgKeyPrimaryKeyid;
     private String gpgKeyUserName;

--- a/src/main/java/org/gitlab4j/api/models/GpgSignature.java
+++ b/src/main/java/org/gitlab4j/api/models/GpgSignature.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class GpgSignature {
+import java.io.Serializable;
 
+public class GpgSignature implements Serializable {
+
+    private static final long serialVersionUID = -2146684278503477421L;
     private Long gpgKeyId;
     private String gpgKeyPrimaryKeyid;
     private String gpgKeyUserName;

--- a/src/main/java/org/gitlab4j/api/models/Group.java
+++ b/src/main/java/org/gitlab4j/api/models/Group.java
@@ -9,6 +9,8 @@ import java.util.List;
 
 public class Group extends AbstractGroup<Group> {
 
+    private static final long serialVersionUID = -903904978831179687L;
+
     public class Statistics {
         private Long storageSize;
         private Long repositorySize;

--- a/src/main/java/org/gitlab4j/api/models/Group.java
+++ b/src/main/java/org/gitlab4j/api/models/Group.java
@@ -8,8 +8,7 @@ import java.util.Date;
 import java.util.List;
 
 public class Group extends AbstractGroup<Group> {
-
-    private static final long serialVersionUID = -903904978831179687L;
+    private static final long serialVersionUID = 1L;
 
     public class Statistics {
         private Long storageSize;

--- a/src/main/java/org/gitlab4j/api/models/GroupAccessToken.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupAccessToken.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class GroupAccessToken extends ImpersonationToken {
-    private static final long serialVersionUID = 338705544580605465L;
+    private static final long serialVersionUID = 1L;
+
     private AccessLevel accessLevel;
 
     public AccessLevel getAccessLevel() {

--- a/src/main/java/org/gitlab4j/api/models/GroupAccessToken.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupAccessToken.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api.models;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class GroupAccessToken extends ImpersonationToken {
+    private static final long serialVersionUID = 338705544580605465L;
     private AccessLevel accessLevel;
 
     public AccessLevel getAccessLevel() {

--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -1,17 +1,19 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.Constants.GroupOrderBy;
 import org.gitlab4j.api.Constants.SortOrder;
-import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.GitLabApiForm;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
+import java.util.List;
 
 /**
  *  This class is used to filter Groups when getting lists of groups.
  */
-public class GroupFilter {
+public class GroupFilter implements Serializable {
 
+    private static final long serialVersionUID = -6089683763762350454L;
     private List<Integer> skipGroups;
     private Boolean allAvailable;
     private String search;

--- a/src/main/java/org/gitlab4j/api/models/GroupFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupFilter.java
@@ -12,8 +12,8 @@ import java.util.List;
  *  This class is used to filter Groups when getting lists of groups.
  */
 public class GroupFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6089683763762350454L;
     private List<Integer> skipGroups;
     private Boolean allAvailable;
     private String search;

--- a/src/main/java/org/gitlab4j/api/models/GroupParams.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupParams.java
@@ -10,8 +10,7 @@ import java.io.Serializable;
  * the parameters for the call to the GitLab API.
  */
 public class GroupParams implements Serializable {
-
-    private static final long serialVersionUID = 4980649800188221721L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Constant to specify the project_creation_level for the group.

--- a/src/main/java/org/gitlab4j/api/models/GroupParams.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupParams.java
@@ -2,12 +2,16 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.GitLabApiForm;
 
+import java.io.Serializable;
+
 /**
  * This class is utilized by the {@link org.gitlab4j.api.GroupApi#createGroup(GroupParams)}
  * and {@link org.gitlab4j.api.GroupApi#updateGroup(Object, GroupParams)} methods to set
  * the parameters for the call to the GitLab API.
  */
-public class GroupParams {
+public class GroupParams implements Serializable {
+
+    private static final long serialVersionUID = 4980649800188221721L;
 
     /**
      * Constant to specify the project_creation_level for the group.

--- a/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
@@ -11,8 +11,8 @@ import java.io.Serializable;
  *  This class is used to filter Projects when getting lists of projects for a specified group.
  */
 public class GroupProjectsFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2606395891055016971L;
     private Boolean archived;
     private Visibility visibility;
     private ProjectOrderBy orderBy;

--- a/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/GroupProjectsFilter.java
@@ -5,11 +5,14 @@ import org.gitlab4j.api.Constants.SortOrder;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.GitLabApiForm;
 
+import java.io.Serializable;
+
 /**
  *  This class is used to filter Projects when getting lists of projects for a specified group.
  */
-public class GroupProjectsFilter {
+public class GroupProjectsFilter implements Serializable {
 
+    private static final long serialVersionUID = -2606395891055016971L;
     private Boolean archived;
     private Visibility visibility;
     private ProjectOrderBy orderBy;
@@ -32,7 +35,7 @@ public class GroupProjectsFilter {
      */
     public GroupProjectsFilter withArchived(Boolean archived) {
         this.archived = archived;
-        return (this);  
+        return (this);
     }
 
     /**
@@ -43,7 +46,7 @@ public class GroupProjectsFilter {
      */
     public GroupProjectsFilter withVisibility(Visibility visibility) {
         this.visibility = visibility;
-        return (this);       
+        return (this);
     }
 
     /**
@@ -80,7 +83,7 @@ public class GroupProjectsFilter {
     }
 
     /**
-     * Return only limited fields for each project. This is a no-op without 
+     * Return only limited fields for each project. This is a no-op without
      * authentication as then only simple fields are returned.
      *
      * @param simple if true, return only limited fields for each project
@@ -115,7 +118,7 @@ public class GroupProjectsFilter {
 
     /**
      *  Include custom attributes in response (admins only).
-     * 
+     *
      * @param withCustomAttributes if true, include custom attributes in the repsonse
      * @return the reference to this ProjectFilter instance
      */

--- a/src/main/java/org/gitlab4j/api/models/HealthCheckInfo.java
+++ b/src/main/java/org/gitlab4j/api/models/HealthCheckInfo.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api.models;
 
 import java.io.IOException;
+import java.io.Serializable;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
@@ -12,8 +13,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
-public class HealthCheckInfo {
+public class HealthCheckInfo implements Serializable {
 
+    private static final long serialVersionUID = 6099547960016518839L;
     @JsonDeserialize(using = HealthCheckItemDeserializer.class)
     private HealthCheckItem dbCheck;
 

--- a/src/main/java/org/gitlab4j/api/models/HealthCheckInfo.java
+++ b/src/main/java/org/gitlab4j/api/models/HealthCheckInfo.java
@@ -14,8 +14,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 
 public class HealthCheckInfo implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6099547960016518839L;
     @JsonDeserialize(using = HealthCheckItemDeserializer.class)
     private HealthCheckItem dbCheck;
 

--- a/src/main/java/org/gitlab4j/api/models/HealthCheckItem.java
+++ b/src/main/java/org/gitlab4j/api/models/HealthCheckItem.java
@@ -6,7 +6,8 @@ import java.util.Map;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class HealthCheckItem implements Serializable {
-    private static final long serialVersionUID = -9119476968963832367L;
+    private static final long serialVersionUID = 1L;
+
     private HealthCheckStatus status;
     private Map<String, String> labels;
     private String message;

--- a/src/main/java/org/gitlab4j/api/models/HealthCheckItem.java
+++ b/src/main/java/org/gitlab4j/api/models/HealthCheckItem.java
@@ -1,10 +1,12 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Map;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class HealthCheckItem {
+public class HealthCheckItem implements Serializable {
+    private static final long serialVersionUID = -9119476968963832367L;
     private HealthCheckStatus status;
     private Map<String, String> labels;
     private String message;

--- a/src/main/java/org/gitlab4j/api/models/Identity.java
+++ b/src/main/java/org/gitlab4j/api/models/Identity.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Identity implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -352988007246422134L;
     private String provider;
     private String externUid;
     private Integer samlProviderId;

--- a/src/main/java/org/gitlab4j/api/models/Identity.java
+++ b/src/main/java/org/gitlab4j/api/models/Identity.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Identity {
+import java.io.Serializable;
 
+public class Identity implements Serializable {
+
+    private static final long serialVersionUID = -352988007246422134L;
     private String provider;
     private String externUid;
     private Integer samlProviderId;

--- a/src/main/java/org/gitlab4j/api/models/ImpersonationToken.java
+++ b/src/main/java/org/gitlab4j/api/models/ImpersonationToken.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
@@ -9,7 +10,8 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public class ImpersonationToken {
+public class ImpersonationToken implements Serializable {
+    private static final long serialVersionUID = -5437477855918094475L;
 
     /** Enum to specify the scope of an ImpersonationToken. */
     public enum Scope {

--- a/src/main/java/org/gitlab4j/api/models/ImpersonationToken.java
+++ b/src/main/java/org/gitlab4j/api/models/ImpersonationToken.java
@@ -11,7 +11,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class ImpersonationToken implements Serializable {
-    private static final long serialVersionUID = -5437477855918094475L;
+    private static final long serialVersionUID = 1L;
 
     /** Enum to specify the scope of an ImpersonationToken. */
     public enum Scope {

--- a/src/main/java/org/gitlab4j/api/models/ImportStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ImportStatus.java
@@ -10,7 +10,7 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class ImportStatus implements Serializable {
-    private static final long serialVersionUID = -5437477855918094477L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Enum representing the status of the import.

--- a/src/main/java/org/gitlab4j/api/models/ImportStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/ImportStatus.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.utils.JacksonJson;
@@ -8,7 +9,8 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public class ImportStatus {
+public class ImportStatus implements Serializable {
+    private static final long serialVersionUID = -5437477855918094477L;
 
     /**
      * Enum representing the status of the import.

--- a/src/main/java/org/gitlab4j/api/models/Issue.java
+++ b/src/main/java/org/gitlab4j/api/models/Issue.java
@@ -7,6 +7,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class Issue extends AbstractIssue {
 
+    private static final long serialVersionUID = 4408821491529505218L;
     private Boolean subscribed;
 
     private Long issueLinkId;

--- a/src/main/java/org/gitlab4j/api/models/Issue.java
+++ b/src/main/java/org/gitlab4j/api/models/Issue.java
@@ -6,8 +6,8 @@ import java.util.Date;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class Issue extends AbstractIssue {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 4408821491529505218L;
     private Boolean subscribed;
 
     private Long issueLinkId;

--- a/src/main/java/org/gitlab4j/api/models/IssueEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueEvent.java
@@ -5,7 +5,11 @@ import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-public class IssueEvent {
+import java.io.Serializable;
+
+public class IssueEvent implements Serializable {
+    private static final long serialVersionUID = -9172768252733688801L;
+
     /** Enum to use for specifying the state events resource type. */
     public enum ResourceType {
 

--- a/src/main/java/org/gitlab4j/api/models/IssueEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueEvent.java
@@ -8,7 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class IssueEvent implements Serializable {
-    private static final long serialVersionUID = -9172768252733688801L;
+    private static final long serialVersionUID = 1L;
 
     /** Enum to use for specifying the state events resource type. */
     public enum ResourceType {

--- a/src/main/java/org/gitlab4j/api/models/IssueFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueFilter.java
@@ -1,8 +1,6 @@
 package org.gitlab4j.api.models;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
-import java.util.Date;
-import java.util.List;
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.Constants.IssueOrderBy;
 import org.gitlab4j.api.Constants.IssueScope;
@@ -11,11 +9,16 @@ import org.gitlab4j.api.Constants.SortOrder;
 import org.gitlab4j.api.GitLabApiForm;
 import org.gitlab4j.api.utils.ISO8601;
 
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
+
 /**
  *  This class is used to filter issues when getting lists of them.
  */
-public class IssueFilter {
+public class IssueFilter implements Serializable {
 
+    private static final long serialVersionUID = -6612905888724502274L;
     /**
      * Return only the milestone having the given iid.
      */

--- a/src/main/java/org/gitlab4j/api/models/IssueFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueFilter.java
@@ -17,8 +17,8 @@ import java.util.List;
  *  This class is used to filter issues when getting lists of them.
  */
 public class IssueFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6612905888724502274L;
     /**
      * Return only the milestone having the given iid.
      */

--- a/src/main/java/org/gitlab4j/api/models/IssueLink.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueLink.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class IssueLink {
+import java.io.Serializable;
 
+public class IssueLink implements Serializable {
+
+    private static final long serialVersionUID = -489517714860533257L;
     private Issue sourceIssue;
     private Issue targetIssue;
     private LinkType linkType;

--- a/src/main/java/org/gitlab4j/api/models/IssueLink.java
+++ b/src/main/java/org/gitlab4j/api/models/IssueLink.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class IssueLink implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -489517714860533257L;
     private Issue sourceIssue;
     private Issue targetIssue;
     private LinkType linkType;

--- a/src/main/java/org/gitlab4j/api/models/IssuesStatistics.java
+++ b/src/main/java/org/gitlab4j/api/models/IssuesStatistics.java
@@ -4,8 +4,11 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class IssuesStatistics {
+import java.io.Serializable;
 
+public class IssuesStatistics implements Serializable {
+
+    private static final long serialVersionUID = -6581608490410246889L;
     private Statistics statistics;
 
     public Statistics getStatistics() {
@@ -21,7 +24,8 @@ public class IssuesStatistics {
         return (statistics != null ? statistics.counts : null);
     }
 
-    public static class Statistics {
+    public static class Statistics implements Serializable {
+        private static final long serialVersionUID = 1578060206571773512L;
         private Counts counts;
 
         public Counts getCounts() {
@@ -33,8 +37,9 @@ public class IssuesStatistics {
         }
     }
 
-    public static class Counts {
+    public static class Counts implements Serializable {
 
+        private static final long serialVersionUID = -1397426876566422385L;
         private Integer all;
         private Integer closed;
         private Integer opened;

--- a/src/main/java/org/gitlab4j/api/models/IssuesStatistics.java
+++ b/src/main/java/org/gitlab4j/api/models/IssuesStatistics.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 
 public class IssuesStatistics implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6581608490410246889L;
     private Statistics statistics;
 
     public Statistics getStatistics() {
@@ -25,7 +25,8 @@ public class IssuesStatistics implements Serializable {
     }
 
     public static class Statistics implements Serializable {
-        private static final long serialVersionUID = 1578060206571773512L;
+        private static final long serialVersionUID = 1L;
+
         private Counts counts;
 
         public Counts getCounts() {
@@ -39,7 +40,8 @@ public class IssuesStatistics implements Serializable {
 
     public static class Counts implements Serializable {
 
-        private static final long serialVersionUID = -1397426876566422385L;
+        private static final long serialVersionUID = 1L;
+
         private Integer all;
         private Integer closed;
         private Integer opened;

--- a/src/main/java/org/gitlab4j/api/models/IssuesStatisticsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IssuesStatisticsFilter.java
@@ -15,8 +15,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  *  This class is used to filter issues when getting issue statistics. of them.
  */
 public class IssuesStatisticsFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -7501532011736965391L;
     private List<String> labels;
     private String milestone;
     private IssueScope scope;

--- a/src/main/java/org/gitlab4j/api/models/IssuesStatisticsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IssuesStatisticsFilter.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
@@ -13,8 +14,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  *  This class is used to filter issues when getting issue statistics. of them.
  */
-public class IssuesStatisticsFilter {
+public class IssuesStatisticsFilter implements Serializable {
 
+    private static final long serialVersionUID = -7501532011736965391L;
     private List<String> labels;
     private String milestone;
     private IssueScope scope;

--- a/src/main/java/org/gitlab4j/api/models/Iteration.java
+++ b/src/main/java/org/gitlab4j/api/models/Iteration.java
@@ -1,13 +1,15 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonValue;
+import org.gitlab4j.api.utils.JacksonJson;
 
-public class Iteration {
+import java.io.Serializable;
+import java.util.Date;
+
+public class Iteration implements Serializable {
+    private static final long serialVersionUID = -7668584990220659049L;
+
     public enum IterationState {
         UPCOMMING(1), CURRENT(2), CLOSED(3);
 

--- a/src/main/java/org/gitlab4j/api/models/Iteration.java
+++ b/src/main/java/org/gitlab4j/api/models/Iteration.java
@@ -8,7 +8,7 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Iteration implements Serializable {
-    private static final long serialVersionUID = -7668584990220659049L;
+    private static final long serialVersionUID = 1L;
 
     public enum IterationState {
         UPCOMMING(1), CURRENT(2), CLOSED(3);

--- a/src/main/java/org/gitlab4j/api/models/IterationFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IterationFilter.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.Constants;
@@ -11,7 +12,9 @@ import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
-public class IterationFilter {
+public class IterationFilter implements Serializable {
+
+    private static final long serialVersionUID = -8121837351844663183L;
 
     public enum IterationFilterState {
         OPENED, UPCOMING, CURRENT, CLOSED, ALL;

--- a/src/main/java/org/gitlab4j/api/models/IterationFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/IterationFilter.java
@@ -13,8 +13,7 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class IterationFilter implements Serializable {
-
-    private static final long serialVersionUID = -8121837351844663183L;
+    private static final long serialVersionUID = 1L;
 
     public enum IterationFilterState {
         OPENED, UPCOMING, CURRENT, CLOSED, ALL;

--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class Job implements Serializable {
 
-public class Job {
-
+    private static final long serialVersionUID = 3324086159440132520L;
     private Long id;
     private Commit commit;
     private String coverage;

--- a/src/main/java/org/gitlab4j/api/models/Job.java
+++ b/src/main/java/org/gitlab4j/api/models/Job.java
@@ -7,8 +7,8 @@ import java.util.Date;
 import java.util.List;
 
 public class Job implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 3324086159440132520L;
     private Long id;
     private Commit commit;
     private String coverage;

--- a/src/main/java/org/gitlab4j/api/models/JobAttribute.java
+++ b/src/main/java/org/gitlab4j/api/models/JobAttribute.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class JobAttribute implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -1898697909418913296L;
     private String key;
   private String value;
 

--- a/src/main/java/org/gitlab4j/api/models/JobAttribute.java
+++ b/src/main/java/org/gitlab4j/api/models/JobAttribute.java
@@ -2,9 +2,12 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class JobAttribute {
+import java.io.Serializable;
 
-  private String key;
+public class JobAttribute implements Serializable {
+
+    private static final long serialVersionUID = -1898697909418913296L;
+    private String key;
   private String value;
 
   public JobAttribute(String key, String value) {

--- a/src/main/java/org/gitlab4j/api/models/JobAttributes.java
+++ b/src/main/java/org/gitlab4j/api/models/JobAttributes.java
@@ -1,12 +1,15 @@
 package org.gitlab4j.api.models;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class JobAttributes {
+import java.io.Serializable;
+import java.util.List;
 
-  @JsonProperty("job_variables_attributes")
+public class JobAttributes implements Serializable {
+
+    private static final long serialVersionUID = 8339758909744590549L;
+    @JsonProperty("job_variables_attributes")
   private List<JobAttribute> jobAttributes;
 
   public JobAttributes(List<JobAttribute> jobAttributes) {

--- a/src/main/java/org/gitlab4j/api/models/JobAttributes.java
+++ b/src/main/java/org/gitlab4j/api/models/JobAttributes.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 import java.util.List;
 
 public class JobAttributes implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 8339758909744590549L;
     @JsonProperty("job_variables_attributes")
   private List<JobAttribute> jobAttributes;
 

--- a/src/main/java/org/gitlab4j/api/models/Key.java
+++ b/src/main/java/org/gitlab4j/api/models/Key.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Key {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Key implements Serializable {
+    private static final long serialVersionUID = -2445059434057852073L;
     private Date createdAt;
     private Long id;
     private String key;

--- a/src/main/java/org/gitlab4j/api/models/Key.java
+++ b/src/main/java/org/gitlab4j/api/models/Key.java
@@ -7,7 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Key implements Serializable {
-    private static final long serialVersionUID = -2445059434057852073L;
+    private static final long serialVersionUID = 1L;
+
     private Date createdAt;
     private Long id;
     private String key;

--- a/src/main/java/org/gitlab4j/api/models/Label.java
+++ b/src/main/java/org/gitlab4j/api/models/Label.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gitlab4j.api.GitLabApiForm;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
 
-public class Label {
+public class Label implements Serializable {
 
+    private static final long serialVersionUID = 2920944591804197634L;
     private Long id;
     private String name;
     private String color;

--- a/src/main/java/org/gitlab4j/api/models/Label.java
+++ b/src/main/java/org/gitlab4j/api/models/Label.java
@@ -7,8 +7,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Label implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 2920944591804197634L;
     private Long id;
     private String name;
     private String color;

--- a/src/main/java/org/gitlab4j/api/models/LabelEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/LabelEvent.java
@@ -1,12 +1,15 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class LabelEvent {
+public class LabelEvent implements Serializable {
+
+    private static final long serialVersionUID = 2844189986730654608L;
 
     /** Enum to use for specifying the label event resource type. */
     public enum ResourceType {

--- a/src/main/java/org/gitlab4j/api/models/LabelEvent.java
+++ b/src/main/java/org/gitlab4j/api/models/LabelEvent.java
@@ -8,8 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class LabelEvent implements Serializable {
-
-    private static final long serialVersionUID = 2844189986730654608L;
+    private static final long serialVersionUID = 1L;
 
     /** Enum to use for specifying the label event resource type. */
     public enum ResourceType {

--- a/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
@@ -3,8 +3,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class LdapGroupLink {
+import java.io.Serializable;
 
+public class LdapGroupLink implements Serializable {
+
+    private static final long serialVersionUID = -6725494282901246090L;
     private String cn;
 
     private AccessLevel groupAccess;

--- a/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/LdapGroupLink.java
@@ -6,8 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class LdapGroupLink implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6725494282901246090L;
     private String cn;
 
     private AccessLevel groupAccess;

--- a/src/main/java/org/gitlab4j/api/models/License.java
+++ b/src/main/java/org/gitlab4j/api/models/License.java
@@ -7,8 +7,8 @@ import java.util.Date;
 import java.util.Map;
 
 public class License implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 8305426745567602018L;
     private Long id;
     private String plan;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/License.java
+++ b/src/main/java/org/gitlab4j/api/models/License.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.Map;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class License implements Serializable {
 
-public class License {
-
+    private static final long serialVersionUID = 8305426745567602018L;
     private Long id;
     private String plan;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/LicenseTemplate.java
+++ b/src/main/java/org/gitlab4j/api/models/LicenseTemplate.java
@@ -6,8 +6,8 @@ import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class LicenseTemplate implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 7204719099700882956L;
     private String key;
     private String name;
     private String nickname;

--- a/src/main/java/org/gitlab4j/api/models/LicenseTemplate.java
+++ b/src/main/java/org/gitlab4j/api/models/LicenseTemplate.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class LicenseTemplate {
+public class LicenseTemplate implements Serializable {
 
+    private static final long serialVersionUID = 7204719099700882956L;
     private String key;
     private String name;
     private String nickname;

--- a/src/main/java/org/gitlab4j/api/models/Link.java
+++ b/src/main/java/org/gitlab4j/api/models/Link.java
@@ -2,10 +2,10 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-import java.util.Date;
-import java.util.List;
+import java.io.Serializable;
 
-public class Link {
+public class Link implements Serializable{
+    private static final long serialVersionUID = 1L;
 
     private Integer id;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/Markdown.java
+++ b/src/main/java/org/gitlab4j/api/models/Markdown.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Markdown implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -5109074296844612091L;
     private String html;
 
     public String getHtml() {

--- a/src/main/java/org/gitlab4j/api/models/Markdown.java
+++ b/src/main/java/org/gitlab4j/api/models/Markdown.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Markdown {
+import java.io.Serializable;
 
+public class Markdown implements Serializable {
+
+    private static final long serialVersionUID = -5109074296844612091L;
     private String html;
 
     public String getHtml() {

--- a/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
@@ -1,6 +1,9 @@
 package org.gitlab4j.api.models;
 
-public class MarkdownRequest {
+import java.io.Serializable;
+
+public class MarkdownRequest implements Serializable {
+    private static final long serialVersionUID = -2437075498227228875L;
     private String text;
     private boolean gfm;
 

--- a/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
@@ -3,7 +3,8 @@ package org.gitlab4j.api.models;
 import java.io.Serializable;
 
 public class MarkdownRequest implements Serializable {
-    private static final long serialVersionUID = -2437075498227228875L;
+    private static final long serialVersionUID = 1L;
+
     private String text;
     private boolean gfm;
 

--- a/src/main/java/org/gitlab4j/api/models/Member.java
+++ b/src/main/java/org/gitlab4j/api/models/Member.java
@@ -6,8 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.util.Date;
 
 public class Member extends AbstractUser<Member> {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6492073834943264389L;
     private AccessLevel accessLevel;
     private Date expiresAt;
     private Identity groupSamlIdentity;

--- a/src/main/java/org/gitlab4j/api/models/Member.java
+++ b/src/main/java/org/gitlab4j/api/models/Member.java
@@ -1,12 +1,13 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
+
+import java.util.Date;
 
 public class Member extends AbstractUser<Member> {
 
+    private static final long serialVersionUID = 6492073834943264389L;
     private AccessLevel accessLevel;
     private Date expiresAt;
     private Identity groupSamlIdentity;

--- a/src/main/java/org/gitlab4j/api/models/Membership.java
+++ b/src/main/java/org/gitlab4j/api/models/Membership.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Membership implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -8141654020767145971L;
     private Long sourceId;
     private String sourceName;
     private MembershipSourceType sourceType;

--- a/src/main/java/org/gitlab4j/api/models/Membership.java
+++ b/src/main/java/org/gitlab4j/api/models/Membership.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Membership {
+import java.io.Serializable;
 
+public class Membership implements Serializable {
+
+    private static final long serialVersionUID = -8141654020767145971L;
     private Long sourceId;
     private String sourceName;
     private MembershipSourceType sourceType;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -9,8 +9,8 @@ import java.util.Date;
 import java.util.List;
 
 public class MergeRequest implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -8455782486451129179L;
     private Boolean allowCollaboration;
     private Boolean allowMaintainerToPush;
     private Integer approvalsBeforeMerge;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -1,15 +1,16 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class MergeRequest implements Serializable {
 
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
-
-public class MergeRequest {
-
+    private static final long serialVersionUID = -8455782486451129179L;
     private Boolean allowCollaboration;
     private Boolean allowMaintainerToPush;
     private Integer approvalsBeforeMerge;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
@@ -6,6 +6,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 public class MergeRequestDiff extends MergeRequestVersion {
 
+    private static final long serialVersionUID = 2764379071350671007L;
     private List<Commit> commits;
     private List<Diff> diffs;
 

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestDiff.java
@@ -5,8 +5,8 @@ import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class MergeRequestDiff extends MergeRequestVersion {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 2764379071350671007L;
     private List<Commit> commits;
     private List<Diff> diffs;
 

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
@@ -22,8 +22,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
  * This class is used to filter merge requests when getting lists of them.
  */
 public class MergeRequestFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -3786830402251866105L;
     private Long projectId;
     private Long groupId;
     private List<Long> iids;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestFilter.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api.models;
 import static org.gitlab4j.api.Constants.MergeRequestScope.ALL;
 import static org.gitlab4j.api.Constants.MergeRequestScope.ASSIGNED_TO_ME;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
@@ -20,8 +21,9 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 /**
  * This class is used to filter merge requests when getting lists of them.
  */
-public class MergeRequestFilter {
+public class MergeRequestFilter implements Serializable {
 
+    private static final long serialVersionUID = -3786830402251866105L;
     private Long projectId;
     private Long groupId;
     private List<Long> iids;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Arrays;
 import java.util.List;
 
@@ -9,8 +10,9 @@ import org.gitlab4j.api.GitLabApiForm;
 /**
  * This class provides the form parameters for creating and updating merge requests.
  */
-public class MergeRequestParams {
+public class MergeRequestParams implements Serializable {
 
+    private static final long serialVersionUID = 3850045219649209460L;
     private String sourceBranch;
     private String targetBranch;
     private String title;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -11,8 +11,8 @@ import org.gitlab4j.api.GitLabApiForm;
  * This class provides the form parameters for creating and updating merge requests.
  */
 public class MergeRequestParams implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 3850045219649209460L;
     private String sourceBranch;
     private String targetBranch;
     private String title;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class MergeRequestVersion {
+public class MergeRequestVersion implements Serializable {
 
+    private static final long serialVersionUID = 445636473281738033L;
     private Long id;
     private String headCommitSha;
     private String baseCommitSha;

--- a/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
+++ b/src/main/java/org/gitlab4j/api/models/MergeRequestVersion.java
@@ -6,8 +6,8 @@ import java.util.Date;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class MergeRequestVersion implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 445636473281738033L;
     private Long id;
     private String headCommitSha;
     private String baseCommitSha;

--- a/src/main/java/org/gitlab4j/api/models/Metadata.java
+++ b/src/main/java/org/gitlab4j/api/models/Metadata.java
@@ -6,8 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Metadata implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2413547164112270863L;
     private String version;
     private String revision;
     private Kas kas;

--- a/src/main/java/org/gitlab4j/api/models/Metadata.java
+++ b/src/main/java/org/gitlab4j/api/models/Metadata.java
@@ -3,8 +3,11 @@ package org.gitlab4j.api.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Metadata {
+import java.io.Serializable;
 
+public class Metadata implements Serializable {
+
+    private static final long serialVersionUID = -2413547164112270863L;
     private String version;
     private String revision;
     private Kas kas;

--- a/src/main/java/org/gitlab4j/api/models/Milestone.java
+++ b/src/main/java/org/gitlab4j/api/models/Milestone.java
@@ -1,13 +1,14 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import java.util.Date;
 
-public class Milestone {
+public class Milestone implements Serializable {
 
+    private static final long serialVersionUID = -3404019540574604663L;
     private Date createdAt;
     private String description;
     @JsonSerialize(using = JacksonJson.DateOnlySerializer.class)

--- a/src/main/java/org/gitlab4j/api/models/Milestone.java
+++ b/src/main/java/org/gitlab4j/api/models/Milestone.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Milestone implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -3404019540574604663L;
     private Date createdAt;
     private String description;
     @JsonSerialize(using = JacksonJson.DateOnlySerializer.class)

--- a/src/main/java/org/gitlab4j/api/models/Namespace.java
+++ b/src/main/java/org/gitlab4j/api/models/Namespace.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Namespace implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -393233581749936360L;
     private Long id;
     private String name;
     private String path;

--- a/src/main/java/org/gitlab4j/api/models/Namespace.java
+++ b/src/main/java/org/gitlab4j/api/models/Namespace.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Namespace {
+import java.io.Serializable;
 
+public class Namespace implements Serializable {
+
+    private static final long serialVersionUID = -393233581749936360L;
     private Long id;
     private String name;
     private String path;

--- a/src/main/java/org/gitlab4j/api/models/Note.java
+++ b/src/main/java/org/gitlab4j/api/models/Note.java
@@ -9,7 +9,7 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Note implements Serializable {
-    private static final long serialVersionUID = 4604942317413087367L;
+    private static final long serialVersionUID = 1L;
 
     /** Enum to use for ordering the results. */
     public static enum OrderBy {

--- a/src/main/java/org/gitlab4j/api/models/Note.java
+++ b/src/main/java/org/gitlab4j/api/models/Note.java
@@ -1,14 +1,15 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
+import java.util.Date;
 
-public class Note {
+public class Note implements Serializable {
+    private static final long serialVersionUID = 4604942317413087367L;
 
     /** Enum to use for ordering the results. */
     public static enum OrderBy {

--- a/src/main/java/org/gitlab4j/api/models/NotificationSettings.java
+++ b/src/main/java/org/gitlab4j/api/models/NotificationSettings.java
@@ -1,12 +1,15 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class NotificationSettings {
+public class NotificationSettings implements Serializable {
+
+    private static final long serialVersionUID = -3034906823726990473L;
 
     /** Notification level */
     public static enum Level {
@@ -31,8 +34,8 @@ public class NotificationSettings {
         }
     }
 
-    public static class Events {
-
+    public static class Events implements Serializable {
+        private static final long serialVersionUID = -7779451561897706339L;
         private Boolean newNote;
         private Boolean newIssue;
         private Boolean reopenIssue;

--- a/src/main/java/org/gitlab4j/api/models/NotificationSettings.java
+++ b/src/main/java/org/gitlab4j/api/models/NotificationSettings.java
@@ -8,8 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class NotificationSettings implements Serializable {
-
-    private static final long serialVersionUID = -3034906823726990473L;
+    private static final long serialVersionUID = 1L;
 
     /** Notification level */
     public static enum Level {
@@ -35,7 +34,8 @@ public class NotificationSettings implements Serializable {
     }
 
     public static class Events implements Serializable {
-        private static final long serialVersionUID = -7779451561897706339L;
+        private static final long serialVersionUID = 1L;
+
         private Boolean newNote;
         private Boolean newIssue;
         private Boolean reopenIssue;

--- a/src/main/java/org/gitlab4j/api/models/OauthTokenResponse.java
+++ b/src/main/java/org/gitlab4j/api/models/OauthTokenResponse.java
@@ -1,7 +1,10 @@
 package org.gitlab4j.api.models;
 
-public class OauthTokenResponse {
+import java.io.Serializable;
 
+public class OauthTokenResponse implements Serializable {
+
+    private static final long serialVersionUID = -6243821985046243075L;
     private String accessToken;
     private String tokenType;
     private String refreshToken;

--- a/src/main/java/org/gitlab4j/api/models/OauthTokenResponse.java
+++ b/src/main/java/org/gitlab4j/api/models/OauthTokenResponse.java
@@ -3,8 +3,8 @@ package org.gitlab4j.api.models;
 import java.io.Serializable;
 
 public class OauthTokenResponse implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6243821985046243075L;
     private String accessToken;
     private String tokenType;
     private String refreshToken;

--- a/src/main/java/org/gitlab4j/api/models/Owner.java
+++ b/src/main/java/org/gitlab4j/api/models/Owner.java
@@ -1,5 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Owner extends AbstractUser<Owner> {
-    private static final long serialVersionUID = -773695148516560415L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Owner.java
+++ b/src/main/java/org/gitlab4j/api/models/Owner.java
@@ -1,4 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Owner extends AbstractUser<Owner> {
+    private static final long serialVersionUID = -773695148516560415L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Package.java
+++ b/src/main/java/org/gitlab4j/api/models/Package.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Package {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Package implements Serializable {
+    private static final long serialVersionUID = 5889634044963420636L;
     private Long id;
     private String name;
     private String version;

--- a/src/main/java/org/gitlab4j/api/models/Package.java
+++ b/src/main/java/org/gitlab4j/api/models/Package.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Package implements Serializable {
-    private static final long serialVersionUID = 5889634044963420636L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private String name;
     private String version;

--- a/src/main/java/org/gitlab4j/api/models/PackageFile.java
+++ b/src/main/java/org/gitlab4j/api/models/PackageFile.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class PackageFile {
+public class PackageFile implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private Long id;
     private Long packageId;

--- a/src/main/java/org/gitlab4j/api/models/PackageFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/PackageFilter.java
@@ -1,15 +1,18 @@
 package org.gitlab4j.api.models;
 
-import org.gitlab4j.api.Constants.PackageStatus;
 import org.gitlab4j.api.Constants.PackageOrderBy;
+import org.gitlab4j.api.Constants.PackageStatus;
 import org.gitlab4j.api.Constants.SortOrder;
 import org.gitlab4j.api.GitLabApiForm;
+
+import java.io.Serializable;
 
 /**
  *  This class is used to filter Projects when getting lists of projects for a specified group.
  */
-public class PackageFilter {
+public class PackageFilter implements Serializable {
 
+    private static final long serialVersionUID = 7975549027581667807L;
     private Boolean excludeSubgroups;
     private PackageOrderBy orderBy;
     private SortOrder sort;

--- a/src/main/java/org/gitlab4j/api/models/PackageFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/PackageFilter.java
@@ -11,8 +11,8 @@ import java.io.Serializable;
  *  This class is used to filter Projects when getting lists of projects for a specified group.
  */
 public class PackageFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 7975549027581667807L;
     private Boolean excludeSubgroups;
     private PackageOrderBy orderBy;
     private SortOrder sort;

--- a/src/main/java/org/gitlab4j/api/models/Participant.java
+++ b/src/main/java/org/gitlab4j/api/models/Participant.java
@@ -1,5 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Participant extends AbstractUser<Participant> {
-    private static final long serialVersionUID = 1914253800296547441L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Participant.java
+++ b/src/main/java/org/gitlab4j/api/models/Participant.java
@@ -1,4 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Participant extends AbstractUser<Participant> {
+    private static final long serialVersionUID = 1914253800296547441L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Permissions.java
+++ b/src/main/java/org/gitlab4j/api/models/Permissions.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Permissions {   
+import java.io.Serializable;
 
+public class Permissions implements Serializable {
+
+    private static final long serialVersionUID = -2395045236486663658L;
     private ProjectAccess projectAccess;
     private ProjectAccess groupAccess;
 

--- a/src/main/java/org/gitlab4j/api/models/Permissions.java
+++ b/src/main/java/org/gitlab4j/api/models/Permissions.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Permissions implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2395045236486663658L;
     private ProjectAccess projectAccess;
     private ProjectAccess groupAccess;
 

--- a/src/main/java/org/gitlab4j/api/models/Pipeline.java
+++ b/src/main/java/org/gitlab4j/api/models/Pipeline.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Pipeline {
+public class Pipeline implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private Long id;
     private Long iid;

--- a/src/main/java/org/gitlab4j/api/models/PipelineFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/PipelineFilter.java
@@ -14,8 +14,8 @@ import java.util.Date;
  *  This class is used to filter Pipelines when getting lists of them.
  */
 public class PipelineFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 578235335955620140L;
     /** {@link org.gitlab4j.api.Constants.PipelineScope} The scope of pipelines, one of: running, pending, finished, branches, tags */
     private PipelineScope scope;
 

--- a/src/main/java/org/gitlab4j/api/models/PipelineFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/PipelineFilter.java
@@ -1,24 +1,25 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gitlab4j.api.Constants.PipelineOrderBy;
 import org.gitlab4j.api.Constants.PipelineScope;
 import org.gitlab4j.api.Constants.SortOrder;
-import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.GitLabApiForm;
+import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+import java.util.Date;
 
 /**
  *  This class is used to filter Pipelines when getting lists of them.
  */
-public class PipelineFilter {
+public class PipelineFilter implements Serializable {
 
+    private static final long serialVersionUID = 578235335955620140L;
     /** {@link org.gitlab4j.api.Constants.PipelineScope} The scope of pipelines, one of: running, pending, finished, branches, tags */
     private PipelineScope scope;
 
-    /** {@link org.gitlab4j.api.Constants.PipelineScope} The status of pipelines, one of: running, pending, success, failed, canceled, skipped, created */    
+    /** {@link org.gitlab4j.api.Constants.PipelineScope} The status of pipelines, one of: running, pending, success, failed, canceled, skipped, created */
     private PipelineStatus status;
 
     /** The ref of pipelines. */

--- a/src/main/java/org/gitlab4j/api/models/PipelineSchedule.java
+++ b/src/main/java/org/gitlab4j/api/models/PipelineSchedule.java
@@ -7,8 +7,8 @@ import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class PipelineSchedule implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -4141121642006352696L;
     private Long id;
     private String description;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/PipelineSchedule.java
+++ b/src/main/java/org/gitlab4j/api/models/PipelineSchedule.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class PipelineSchedule {
+public class PipelineSchedule implements Serializable {
 
+    private static final long serialVersionUID = -4141121642006352696L;
     private Long id;
     private String description;
     private String ref;

--- a/src/main/java/org/gitlab4j/api/models/Position.java
+++ b/src/main/java/org/gitlab4j/api/models/Position.java
@@ -1,12 +1,15 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class Position {
+public class Position implements Serializable {
+
+    private static final long serialVersionUID = 1720468299485697338L;
 
     public static enum PositionType {
 

--- a/src/main/java/org/gitlab4j/api/models/Position.java
+++ b/src/main/java/org/gitlab4j/api/models/Position.java
@@ -8,8 +8,7 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class Position implements Serializable {
-
-    private static final long serialVersionUID = 1720468299485697338L;
+    private static final long serialVersionUID = 1L;
 
     public static enum PositionType {
 

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -17,7 +17,7 @@ import java.util.Date;
 import java.util.List;
 
 public class Project implements Serializable {
-    private static final long serialVersionUID = 7303989372756343383L;
+    private static final long serialVersionUID = 1L;
 
     // Enum for the merge_method of the Project instance.
     public enum MergeMethod {

--- a/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/src/main/java/org/gitlab4j/api/models/Project.java
@@ -1,9 +1,9 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.List;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.gitlab4j.api.Constants.AutoDevopsDeployStrategy;
 import org.gitlab4j.api.Constants.BuildGitStrategy;
 import org.gitlab4j.api.Constants.SquashOption;
@@ -12,11 +12,12 @@ import org.gitlab4j.api.models.ImportStatus.Status;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import java.util.Date;
+import java.util.List;
 
-public class Project {
+public class Project implements Serializable {
+    private static final long serialVersionUID = 7303989372756343383L;
 
     // Enum for the merge_method of the Project instance.
     public enum MergeMethod {

--- a/src/main/java/org/gitlab4j/api/models/ProjectAccess.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectAccess.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class ProjectAccess implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 2586454914563312773L;
     private AccessLevel accessLevel;
     private int notificationLevel;
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectAccess.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectAccess.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ProjectAccess {
+import java.io.Serializable;
 
+public class ProjectAccess implements Serializable {
+
+    private static final long serialVersionUID = 2586454914563312773L;
     private AccessLevel accessLevel;
     private int notificationLevel;
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectAccessToken.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectAccessToken.java
@@ -10,7 +10,8 @@ import java.util.Date;
 import java.util.List;
 
 public class ProjectAccessToken implements Serializable {
-    private static final long serialVersionUID = -6898996649279891825L;
+    private static final long serialVersionUID = 1L;
+
     private Long userId;
     private List<Constants.ProjectAccessTokenScope> scopes;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/ProjectAccessToken.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectAccessToken.java
@@ -5,10 +5,12 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-public class ProjectAccessToken {
+public class ProjectAccessToken implements Serializable {
+    private static final long serialVersionUID = -6898996649279891825L;
     private Long userId;
     private List<Constants.ProjectAccessTokenScope> scopes;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
@@ -7,8 +7,8 @@ import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.io.Serializable;
 
 public class ProjectApprovalsConfig implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -4377250577067837024L;
     private Integer approvalsBeforeMerge;
     private Boolean resetApprovalsOnPush;
     private Boolean selectiveCodeOwnerRemovals;

--- a/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectApprovalsConfig.java
@@ -4,8 +4,11 @@ import org.gitlab4j.api.GitLabApiForm;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public class ProjectApprovalsConfig {
+import java.io.Serializable;
 
+public class ProjectApprovalsConfig implements Serializable {
+
+    private static final long serialVersionUID = -4377250577067837024L;
     private Integer approvalsBeforeMerge;
     private Boolean resetApprovalsOnPush;
     private Boolean selectiveCodeOwnerRemovals;

--- a/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
@@ -8,12 +8,12 @@ import java.util.Date;
 import java.util.List;
 
 public class ProjectFetches implements Serializable {
-
-    private static final long serialVersionUID = -4872633634599186529L;
+    private static final long serialVersionUID = 1L;
 
     public static class DateCount implements Serializable {
 
-        private static final long serialVersionUID = 4630780820005787004L;
+        private static final long serialVersionUID = 1L;
+
         private Integer count;
 
         @JsonSerialize(using = JacksonJson.DateOnlySerializer.class)
@@ -37,7 +37,8 @@ public class ProjectFetches implements Serializable {
     }
 
     public static class Fetches implements Serializable {
-        private static final long serialVersionUID = 4630780820005787008L;
+        private static final long serialVersionUID = 1L;
+
         private Integer total;
         private List<DateCount> days;
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
@@ -1,16 +1,19 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class ProjectFetches implements Serializable {
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+    private static final long serialVersionUID = -4872633634599186529L;
 
-public class ProjectFetches {
+    public static class DateCount implements Serializable {
 
-    public static class DateCount {
-
+        private static final long serialVersionUID = 4630780820005787004L;
         private Integer count;
 
         @JsonSerialize(using = JacksonJson.DateOnlySerializer.class)

--- a/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFetches.java
@@ -36,8 +36,8 @@ public class ProjectFetches implements Serializable {
         }
     }
 
-    public static class Fetches {
-
+    public static class Fetches implements Serializable {
+        private static final long serialVersionUID = 4630780820005787008L;
         private Integer total;
         private List<DateCount> days;
 

--- a/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
@@ -13,8 +13,8 @@ import java.util.Date;
  *  This class is used to filter Projects when getting lists of projects for a specified user.
  */
 public class ProjectFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6862041481569987088L;
     private Boolean archived;
     private Visibility visibility;
     private ProjectOrderBy orderBy;

--- a/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
@@ -1,18 +1,20 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.Constants;
 import org.gitlab4j.api.Constants.ProjectOrderBy;
 import org.gitlab4j.api.Constants.SortOrder;
-import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.GitLabApiForm;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
+import java.util.Date;
 
 /**
  *  This class is used to filter Projects when getting lists of projects for a specified user.
  */
-public class ProjectFilter {
+public class ProjectFilter implements Serializable {
 
+    private static final long serialVersionUID = 6862041481569987088L;
     private Boolean archived;
     private Visibility visibility;
     private ProjectOrderBy orderBy;

--- a/src/main/java/org/gitlab4j/api/models/ProjectGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectGroup.java
@@ -1,5 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class ProjectGroup extends AbstractGroup<ProjectGroup> {
-    private static final long serialVersionUID = -838653094576942075L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/ProjectGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectGroup.java
@@ -1,4 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class ProjectGroup extends AbstractGroup<ProjectGroup> {
+    private static final long serialVersionUID = -838653094576942075L;
 }

--- a/src/main/java/org/gitlab4j/api/models/ProjectGroupsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectGroupsFilter.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.gitlab4j.api.GitLabApiForm;
@@ -7,8 +8,9 @@ import org.gitlab4j.api.GitLabApiForm;
 /**
  *  This class is used to filter Groups when getting lists of groups for a specified project.
  */
-public class ProjectGroupsFilter {
+public class ProjectGroupsFilter implements Serializable {
 
+    private static final long serialVersionUID = -7697389200750527944L;
     private String search;
     private AccessLevel sharedMinAccessLevel;
     private Boolean sharedVisibleOnly;

--- a/src/main/java/org/gitlab4j/api/models/ProjectGroupsFilter.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectGroupsFilter.java
@@ -9,8 +9,8 @@ import org.gitlab4j.api.GitLabApiForm;
  *  This class is used to filter Groups when getting lists of groups for a specified project.
  */
 public class ProjectGroupsFilter implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -7697389200750527944L;
     private String search;
     private AccessLevel sharedMinAccessLevel;
     private Boolean sharedVisibleOnly;

--- a/src/main/java/org/gitlab4j/api/models/ProjectHook.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectHook.java
@@ -1,12 +1,14 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ProjectHook {
+import java.io.Serializable;
+import java.util.Date;
 
+public class ProjectHook implements Serializable {
+
+    private static final long serialVersionUID = 6412954444361160378L;
     private Boolean buildEvents;
     private Date createdAt;
     private Boolean enableSslVerification;

--- a/src/main/java/org/gitlab4j/api/models/ProjectHook.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectHook.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class ProjectHook implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6412954444361160378L;
     private Boolean buildEvents;
     private Date createdAt;
     private Boolean enableSslVerification;

--- a/src/main/java/org/gitlab4j/api/models/ProjectStatistics.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectStatistics.java
@@ -3,13 +3,16 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
+
 /**
  * This class contains the sizing information from the project. To get this information,
  * ProjectApi.getProject() has to be called with parameter statistics=true
  * which is only allowed for GitLab admins.
  */
-public class ProjectStatistics {
+public class ProjectStatistics implements Serializable {
 
+    private static final long serialVersionUID = -6816978423517856645L;
     long commitCount;
     long storageSize;
     long repositorySize;

--- a/src/main/java/org/gitlab4j/api/models/ProjectStatistics.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectStatistics.java
@@ -11,8 +11,8 @@ import java.io.Serializable;
  * which is only allowed for GitLab admins.
  */
 public class ProjectStatistics implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -6816978423517856645L;
     long commitCount;
     long storageSize;
     long repositorySize;

--- a/src/main/java/org/gitlab4j/api/models/ProjectUser.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectUser.java
@@ -1,5 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class ProjectUser extends AbstractUser<ProjectUser> {
-    private static final long serialVersionUID = 1347677526768040078L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/ProjectUser.java
+++ b/src/main/java/org/gitlab4j/api/models/ProjectUser.java
@@ -1,4 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class ProjectUser extends AbstractUser<ProjectUser> {
+    private static final long serialVersionUID = 1347677526768040078L;
 }

--- a/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
+++ b/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
@@ -7,8 +7,8 @@ import java.util.List;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class ProtectedBranch implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -3008917375248933687L;
     private Long id;
     private String name;
     private List<BranchAccessLevel> pushAccessLevels;

--- a/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
+++ b/src/main/java/org/gitlab4j/api/models/ProtectedBranch.java
@@ -1,12 +1,14 @@
 
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ProtectedBranch {
+public class ProtectedBranch implements Serializable {
 
+    private static final long serialVersionUID = -3008917375248933687L;
     private Long id;
     private String name;
     private List<BranchAccessLevel> pushAccessLevels;

--- a/src/main/java/org/gitlab4j/api/models/ProtectedTag.java
+++ b/src/main/java/org/gitlab4j/api/models/ProtectedTag.java
@@ -6,11 +6,11 @@ import java.io.Serializable;
 import java.util.List;
 
 public class ProtectedTag implements Serializable {
-
-    private static final long serialVersionUID = -5721003232110747390L;
+    private static final long serialVersionUID = 1L;
 
     public static class CreateAccessLevel implements Serializable {
-        private static final long serialVersionUID = -676784576865233897L;
+        private static final long serialVersionUID = 1L;
+
         private AccessLevel access_level;
         private String accessLevelDescription;
 

--- a/src/main/java/org/gitlab4j/api/models/ProtectedTag.java
+++ b/src/main/java/org/gitlab4j/api/models/ProtectedTag.java
@@ -1,13 +1,16 @@
 package org.gitlab4j.api.models;
 
-import java.util.List;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class ProtectedTag {
+import java.io.Serializable;
+import java.util.List;
 
-    public static class CreateAccessLevel {
+public class ProtectedTag implements Serializable {
 
+    private static final long serialVersionUID = -5721003232110747390L;
+
+    public static class CreateAccessLevel implements Serializable {
+        private static final long serialVersionUID = -676784576865233897L;
         private AccessLevel access_level;
         private String accessLevelDescription;
 

--- a/src/main/java/org/gitlab4j/api/models/PushRules.java
+++ b/src/main/java/org/gitlab4j/api/models/PushRules.java
@@ -6,8 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class PushRules implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 2847496850414192432L;
     private Long id;
     private Long projectId;
     private String commitMessageRegex;

--- a/src/main/java/org/gitlab4j/api/models/PushRules.java
+++ b/src/main/java/org/gitlab4j/api/models/PushRules.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class PushRules {
+import java.io.Serializable;
+import java.util.Date;
 
+public class PushRules implements Serializable {
+
+    private static final long serialVersionUID = 2847496850414192432L;
     private Long id;
     private Long projectId;
     private String commitMessageRegex;

--- a/src/main/java/org/gitlab4j/api/models/References.java
+++ b/src/main/java/org/gitlab4j/api/models/References.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 
 
 public class References implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -4751755085772406441L;
     @JsonProperty("short")
     private String _short;
     private String relative;

--- a/src/main/java/org/gitlab4j/api/models/References.java
+++ b/src/main/java/org/gitlab4j/api/models/References.java
@@ -3,9 +3,12 @@ package org.gitlab4j.api.models;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 
-public class References {
 
+public class References implements Serializable {
+
+    private static final long serialVersionUID = -4751755085772406441L;
     @JsonProperty("short")
     private String _short;
     private String relative;

--- a/src/main/java/org/gitlab4j/api/models/RegistryRepository.java
+++ b/src/main/java/org/gitlab4j/api/models/RegistryRepository.java
@@ -6,8 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class RegistryRepository implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6871803501873513792L;
     private Long id;
     private String name;
     private String path;

--- a/src/main/java/org/gitlab4j/api/models/RegistryRepository.java
+++ b/src/main/java/org/gitlab4j/api/models/RegistryRepository.java
@@ -2,10 +2,12 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class RegistryRepository {
+public class RegistryRepository implements Serializable {
 
+    private static final long serialVersionUID = 6871803501873513792L;
     private Long id;
     private String name;
     private String path;

--- a/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
+++ b/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
@@ -6,7 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class RegistryRepositoryTag implements Serializable {
-    private static final long serialVersionUID = 115605545594991565L;
+    private static final long serialVersionUID = 1L;
+
     private String name;
     private String path;
     private String location;

--- a/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
+++ b/src/main/java/org/gitlab4j/api/models/RegistryRepositoryTag.java
@@ -2,9 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class RegistryRepositoryTag {
+public class RegistryRepositoryTag implements Serializable {
+    private static final long serialVersionUID = 115605545594991565L;
     private String name;
     private String path;
     private String location;

--- a/src/main/java/org/gitlab4j/api/models/RelatedEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/RelatedEpic.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.util.Date;
 
 public class RelatedEpic extends AbstractEpic<RelatedEpic> {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 4735222753619924221L;
     private Boolean startDateIsFixed;
     private Boolean dueDateIsFixed;
     private Date dueDateFromInheritedSource;

--- a/src/main/java/org/gitlab4j/api/models/RelatedEpic.java
+++ b/src/main/java/org/gitlab4j/api/models/RelatedEpic.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
+
+import java.util.Date;
 
 public class RelatedEpic extends AbstractEpic<RelatedEpic> {
 
+    private static final long serialVersionUID = 4735222753619924221L;
     private Boolean startDateIsFixed;
     private Boolean dueDateIsFixed;
     private Date dueDateFromInheritedSource;

--- a/src/main/java/org/gitlab4j/api/models/RelatedEpicLink.java
+++ b/src/main/java/org/gitlab4j/api/models/RelatedEpicLink.java
@@ -1,11 +1,12 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class RelatedEpicLink {
-
+public class RelatedEpicLink implements Serializable {
+    private static final long serialVersionUID = -5031693941135471316L;
     private Long id;
     private EpicInLink sourceEpic;
     private EpicInLink targetEpic;

--- a/src/main/java/org/gitlab4j/api/models/RelatedEpicLink.java
+++ b/src/main/java/org/gitlab4j/api/models/RelatedEpicLink.java
@@ -6,7 +6,8 @@ import java.util.Date;
 import org.gitlab4j.api.utils.JacksonJson;
 
 public class RelatedEpicLink implements Serializable {
-    private static final long serialVersionUID = -5031693941135471316L;
+    private static final long serialVersionUID = 1L;
+
     private Long id;
     private EpicInLink sourceEpic;
     private EpicInLink targetEpic;

--- a/src/main/java/org/gitlab4j/api/models/Release.java
+++ b/src/main/java/org/gitlab4j/api/models/Release.java
@@ -10,8 +10,8 @@ import java.util.List;
 import java.util.Map;
 
 public class Release implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 1041533230334303476L;
     private String name;
     private String tagName;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/Release.java
+++ b/src/main/java/org/gitlab4j/api/models/Release.java
@@ -1,16 +1,17 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 import java.util.Map;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class Release implements Serializable {
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
-import com.fasterxml.jackson.annotation.JsonProperty;
-
-public class Release {
-
+    private static final long serialVersionUID = 1041533230334303476L;
     private String name;
     private String tagName;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/ReleaseParams.java
+++ b/src/main/java/org/gitlab4j/api/models/ReleaseParams.java
@@ -7,8 +7,8 @@ import java.util.Date;
 import java.util.List;
 
 public class ReleaseParams implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -538304941926811318L;
     private String name;
     private String tagName;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/ReleaseParams.java
+++ b/src/main/java/org/gitlab4j/api/models/ReleaseParams.java
@@ -1,12 +1,14 @@
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
+import java.io.Serializable;
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
+public class ReleaseParams implements Serializable {
 
-public class ReleaseParams {
-
+    private static final long serialVersionUID = -538304941926811318L;
     private String name;
     private String tagName;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/RemoteMirror.java
+++ b/src/main/java/org/gitlab4j/api/models/RemoteMirror.java
@@ -6,8 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class RemoteMirror implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 3263293943076925633L;
     private Long id;
     private Boolean enabled;
     private String lastError;

--- a/src/main/java/org/gitlab4j/api/models/RemoteMirror.java
+++ b/src/main/java/org/gitlab4j/api/models/RemoteMirror.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class RemoteMirror {
+import java.io.Serializable;
+import java.util.Date;
 
+public class RemoteMirror implements Serializable {
+
+    private static final long serialVersionUID = 3263293943076925633L;
     private Long id;
     private Boolean enabled;
     private String lastError;

--- a/src/main/java/org/gitlab4j/api/models/Repository.java
+++ b/src/main/java/org/gitlab4j/api/models/Repository.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Repository implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -8079069832537320645L;
     private String description;
     private String homepage;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/Repository.java
+++ b/src/main/java/org/gitlab4j/api/models/Repository.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Repository {
+import java.io.Serializable;
 
+public class Repository implements Serializable {
+
+    private static final long serialVersionUID = -8079069832537320645L;
     private String description;
     private String homepage;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/RepositoryFile.java
+++ b/src/main/java/org/gitlab4j/api/models/RepositoryFile.java
@@ -9,8 +9,8 @@ import java.io.Serializable;
 import java.util.Base64;
 
 public class RepositoryFile implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 6844347510810856023L;
     private String fileName; // file name only, Ex. class.rb
     private String filePath; // full path to file. Ex. lib/class.rb
     private Integer size;

--- a/src/main/java/org/gitlab4j/api/models/RepositoryFile.java
+++ b/src/main/java/org/gitlab4j/api/models/RepositoryFile.java
@@ -1,15 +1,16 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Base64;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gitlab4j.api.Constants.Encoding;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+import java.util.Base64;
 
-public class RepositoryFile {
+public class RepositoryFile implements Serializable {
 
+    private static final long serialVersionUID = 6844347510810856023L;
     private String fileName; // file name only, Ex. class.rb
     private String filePath; // full path to file. Ex. lib/class.rb
     private Integer size;
@@ -103,7 +104,7 @@ public class RepositoryFile {
 
     /**
      * Returns the content as a String, base64 decoding it if necessary.
-     * For binary files it is recommended to use getDecodedContentAsBytes() 
+     * For binary files it is recommended to use getDecodedContentAsBytes()
      *
      * @return the content as a String, base64 decoding it if necessary
      */

--- a/src/main/java/org/gitlab4j/api/models/Reviewer.java
+++ b/src/main/java/org/gitlab4j/api/models/Reviewer.java
@@ -1,5 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Reviewer extends AbstractUser<Reviewer> {
-    private static final long serialVersionUID = 2476373318211531014L;
+    private static final long serialVersionUID = 1L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Reviewer.java
+++ b/src/main/java/org/gitlab4j/api/models/Reviewer.java
@@ -1,4 +1,5 @@
 package org.gitlab4j.api.models;
 
 public class Reviewer extends AbstractUser<Reviewer> {
+    private static final long serialVersionUID = 2476373318211531014L;
 }

--- a/src/main/java/org/gitlab4j/api/models/Runner.java
+++ b/src/main/java/org/gitlab4j/api/models/Runner.java
@@ -1,13 +1,15 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.io.Serializable;
 
-public class Runner {
+public class Runner implements Serializable {
 
+    private static final long serialVersionUID = 8396377098769240666L;
     private Long id;
     private String description;
     private Boolean active;

--- a/src/main/java/org/gitlab4j/api/models/Runner.java
+++ b/src/main/java/org/gitlab4j/api/models/Runner.java
@@ -8,8 +8,8 @@ import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 import java.io.Serializable;
 
 public class Runner implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 8396377098769240666L;
     private Long id;
     private String description;
     private Boolean active;

--- a/src/main/java/org/gitlab4j/api/models/RunnerDetail.java
+++ b/src/main/java/org/gitlab4j/api/models/RunnerDetail.java
@@ -9,8 +9,8 @@ import java.util.Date;
 import java.util.List;
 
 public class RunnerDetail extends Runner {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 7887700856425080720L;
     private String architecture;
     private String platform;
     private Date contactedAt;

--- a/src/main/java/org/gitlab4j/api/models/RunnerDetail.java
+++ b/src/main/java/org/gitlab4j/api/models/RunnerDetail.java
@@ -1,16 +1,16 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-import java.util.List;
-
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonValue;
+import java.util.Date;
+import java.util.List;
 
 public class RunnerDetail extends Runner {
 
+    private static final long serialVersionUID = 7887700856425080720L;
     private String architecture;
     private String platform;
     private Date contactedAt;

--- a/src/main/java/org/gitlab4j/api/models/SamlGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/SamlGroupLink.java
@@ -6,8 +6,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class SamlGroupLink implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2373881527548802762L;
     private String name;
 
     private AccessLevel accessLevel;

--- a/src/main/java/org/gitlab4j/api/models/SamlGroupLink.java
+++ b/src/main/java/org/gitlab4j/api/models/SamlGroupLink.java
@@ -3,8 +3,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class SamlGroupLink {
+import java.io.Serializable;
 
+public class SamlGroupLink implements Serializable {
+
+    private static final long serialVersionUID = -2373881527548802762L;
     private String name;
 
     private AccessLevel accessLevel;

--- a/src/main/java/org/gitlab4j/api/models/SearchBlob.java
+++ b/src/main/java/org/gitlab4j/api/models/SearchBlob.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class SearchBlob implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 5706788073342987764L;
     private String basename;
     private String data;
     private String filename;

--- a/src/main/java/org/gitlab4j/api/models/SearchBlob.java
+++ b/src/main/java/org/gitlab4j/api/models/SearchBlob.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class SearchBlob {
+import java.io.Serializable;
 
+public class SearchBlob implements Serializable {
+
+    private static final long serialVersionUID = 5706788073342987764L;
     private String basename;
     private String data;
     private String filename;

--- a/src/main/java/org/gitlab4j/api/models/SharedGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/SharedGroup.java
@@ -1,13 +1,14 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import java.io.Serializable;
+import java.util.Date;
 
-public class SharedGroup {
+public class SharedGroup implements Serializable {
 
+    private static final long serialVersionUID = 9147215839960756743L;
     private Long groupId;
     private String groupName;
     private String groupFullPath;

--- a/src/main/java/org/gitlab4j/api/models/SharedGroup.java
+++ b/src/main/java/org/gitlab4j/api/models/SharedGroup.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class SharedGroup implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 9147215839960756743L;
     private Long groupId;
     private String groupName;
     private String groupFullPath;

--- a/src/main/java/org/gitlab4j/api/models/Snippet.java
+++ b/src/main/java/org/gitlab4j/api/models/Snippet.java
@@ -23,12 +23,14 @@
 
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Snippet {
+import java.io.Serializable;
+import java.util.Date;
 
+public class Snippet implements Serializable {
+
+    private static final long serialVersionUID = -3693726269760539889L;
     private Author author;
     private Date createdAt;
     private Date expiresAt;

--- a/src/main/java/org/gitlab4j/api/models/Snippet.java
+++ b/src/main/java/org/gitlab4j/api/models/Snippet.java
@@ -29,8 +29,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Snippet implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -3693726269760539889L;
     private Author author;
     private Date createdAt;
     private Date expiresAt;

--- a/src/main/java/org/gitlab4j/api/models/SshKey.java
+++ b/src/main/java/org/gitlab4j/api/models/SshKey.java
@@ -1,13 +1,14 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import org.gitlab4j.api.utils.JacksonJson;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
+import java.io.Serializable;
+import java.util.Date;
 
-public class SshKey {
+public class SshKey implements Serializable {
 
+    private static final long serialVersionUID = -2559632392834817632L;
     private Long id;
     private String title;
     private String key;

--- a/src/main/java/org/gitlab4j/api/models/SshKey.java
+++ b/src/main/java/org/gitlab4j/api/models/SshKey.java
@@ -7,8 +7,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class SshKey implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2559632392834817632L;
     private Long id;
     private String title;
     private String key;

--- a/src/main/java/org/gitlab4j/api/models/SystemHook.java
+++ b/src/main/java/org/gitlab4j/api/models/SystemHook.java
@@ -1,11 +1,13 @@
 package org.gitlab4j.api.models;
 
-import java.util.Date;
-
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class SystemHook {
+import java.io.Serializable;
+import java.util.Date;
 
+public class SystemHook implements Serializable {
+
+    private static final long serialVersionUID = 5755753266987012078L;
     private Long id;
     private String url;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/SystemHook.java
+++ b/src/main/java/org/gitlab4j/api/models/SystemHook.java
@@ -6,8 +6,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class SystemHook implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 5755753266987012078L;
     private Long id;
     private String url;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/Tag.java
+++ b/src/main/java/org/gitlab4j/api/models/Tag.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Tag {
+import java.io.Serializable;
 
+public class Tag implements Serializable {
+
+    private static final long serialVersionUID = -1006308726664414044L;
     private Commit commit;
     private String message;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/Tag.java
+++ b/src/main/java/org/gitlab4j/api/models/Tag.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Tag implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -1006308726664414044L;
     private Commit commit;
     private String message;
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/TaskCompletionStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/TaskCompletionStatus.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class TaskCompletionStatus implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 2425961171229796182L;
     private Integer count;
     private Integer completedCount;
 

--- a/src/main/java/org/gitlab4j/api/models/TaskCompletionStatus.java
+++ b/src/main/java/org/gitlab4j/api/models/TaskCompletionStatus.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class TaskCompletionStatus {
+import java.io.Serializable;
 
+public class TaskCompletionStatus implements Serializable {
+
+    private static final long serialVersionUID = 2425961171229796182L;
     private Integer count;
     private Integer completedCount;
 

--- a/src/main/java/org/gitlab4j/api/models/TimeStats.java
+++ b/src/main/java/org/gitlab4j/api/models/TimeStats.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class TimeStats {
+import java.io.Serializable;
 
+public class TimeStats implements Serializable {
+
+    private static final long serialVersionUID = -2557491371640747430L;
     private Integer timeEstimate;
     private Integer totalTimeSpent;
     private Duration humanTimeEstimate;

--- a/src/main/java/org/gitlab4j/api/models/TimeStats.java
+++ b/src/main/java/org/gitlab4j/api/models/TimeStats.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class TimeStats implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2557491371640747430L;
     private Integer timeEstimate;
     private Integer totalTimeSpent;
     private Duration humanTimeEstimate;

--- a/src/main/java/org/gitlab4j/api/models/Todo.java
+++ b/src/main/java/org/gitlab4j/api/models/Todo.java
@@ -18,8 +18,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Todo implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -1612489661279498902L;
     private Long id;
     private Project project;
     private Author author;

--- a/src/main/java/org/gitlab4j/api/models/Todo.java
+++ b/src/main/java/org/gitlab4j/api/models/Todo.java
@@ -1,13 +1,5 @@
 package org.gitlab4j.api.models;
 
-import java.io.IOException;
-import java.util.Date;
-
-import org.gitlab4j.api.Constants.TodoAction;
-import org.gitlab4j.api.Constants.TodoState;
-import org.gitlab4j.api.Constants.TodoType;
-import org.gitlab4j.api.utils.JacksonJson;
-
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -16,9 +8,18 @@ import com.fasterxml.jackson.databind.JsonDeserializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.node.ObjectNode;
+import org.gitlab4j.api.Constants.TodoAction;
+import org.gitlab4j.api.Constants.TodoState;
+import org.gitlab4j.api.Constants.TodoType;
+import org.gitlab4j.api.utils.JacksonJson;
 
-public class Todo {
+import java.io.IOException;
+import java.io.Serializable;
+import java.util.Date;
 
+public class Todo implements Serializable {
+
+    private static final long serialVersionUID = -1612489661279498902L;
     private Long id;
     private Project project;
     private Author author;

--- a/src/main/java/org/gitlab4j/api/models/Topic.java
+++ b/src/main/java/org/gitlab4j/api/models/Topic.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Topic implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -5509038784155015404L;
     private Integer id;
 
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/Topic.java
+++ b/src/main/java/org/gitlab4j/api/models/Topic.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Topic {
+import java.io.Serializable;
 
+public class Topic implements Serializable {
+
+    private static final long serialVersionUID = -5509038784155015404L;
     private Integer id;
 
     private String name;

--- a/src/main/java/org/gitlab4j/api/models/TopicParams.java
+++ b/src/main/java/org/gitlab4j/api/models/TopicParams.java
@@ -4,6 +4,7 @@ import org.gitlab4j.api.GitLabApiForm;
 import org.gitlab4j.api.TopicsApi;
 
 import java.io.File;
+import java.io.Serializable;
 
 /**
  * This class is utilized by the {@link TopicsApi#createTopic(TopicParams)}
@@ -12,8 +13,9 @@ import java.io.File;
  *
  * Avatar Upload has its own Upload in {@link TopicsApi#updateTopicAvatar(Integer,File)}
  */
-public class TopicParams {
+public class TopicParams implements Serializable {
 
+    private static final long serialVersionUID = -2248684441661568431L;
     private String name;
     private String title;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/TopicParams.java
+++ b/src/main/java/org/gitlab4j/api/models/TopicParams.java
@@ -14,8 +14,8 @@ import java.io.Serializable;
  * Avatar Upload has its own Upload in {@link TopicsApi#updateTopicAvatar(Integer,File)}
  */
 public class TopicParams implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -2248684441661568431L;
     private String name;
     private String title;
     private String description;

--- a/src/main/java/org/gitlab4j/api/models/TreeItem.java
+++ b/src/main/java/org/gitlab4j/api/models/TreeItem.java
@@ -5,8 +5,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class TreeItem implements Serializable {
-
-    private static final long serialVersionUID = -6095523498844753989L;
+    private static final long serialVersionUID = 1L;
 
     public enum Type {
         TREE, BLOB, COMMIT;

--- a/src/main/java/org/gitlab4j/api/models/TreeItem.java
+++ b/src/main/java/org/gitlab4j/api/models/TreeItem.java
@@ -2,7 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class TreeItem {
+import java.io.Serializable;
+
+public class TreeItem implements Serializable {
+
+    private static final long serialVersionUID = -6095523498844753989L;
 
     public enum Type {
         TREE, BLOB, COMMIT;

--- a/src/main/java/org/gitlab4j/api/models/Trigger.java
+++ b/src/main/java/org/gitlab4j/api/models/Trigger.java
@@ -4,8 +4,8 @@ import java.io.Serializable;
 import java.util.Date;
 
 public class Trigger implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = -5834519760065786408L;
     private Long id;
     private String description;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/Trigger.java
+++ b/src/main/java/org/gitlab4j/api/models/Trigger.java
@@ -1,9 +1,11 @@
 package org.gitlab4j.api.models;
 
+import java.io.Serializable;
 import java.util.Date;
 
-public class Trigger {
+public class Trigger implements Serializable {
 
+    private static final long serialVersionUID = -5834519760065786408L;
     private Long id;
     private String description;
     private Date createdAt;

--- a/src/main/java/org/gitlab4j/api/models/User.java
+++ b/src/main/java/org/gitlab4j/api/models/User.java
@@ -6,8 +6,8 @@ import java.util.Date;
 import java.util.List;
 
 public class User extends AbstractUser<User> {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 5181333036356031840L;
     private String bio;
     private Boolean bot;
     private Boolean canCreateGroup;

--- a/src/main/java/org/gitlab4j/api/models/User.java
+++ b/src/main/java/org/gitlab4j/api/models/User.java
@@ -1,12 +1,13 @@
 package org.gitlab4j.api.models;
 
+import org.gitlab4j.api.utils.JacksonJson;
+
 import java.util.Date;
 import java.util.List;
 
-import org.gitlab4j.api.utils.JacksonJson;
-
 public class User extends AbstractUser<User> {
 
+    private static final long serialVersionUID = 5181333036356031840L;
     private String bio;
     private Boolean bot;
     private Boolean canCreateGroup;

--- a/src/main/java/org/gitlab4j/api/models/Variable.java
+++ b/src/main/java/org/gitlab4j/api/models/Variable.java
@@ -1,17 +1,19 @@
 package org.gitlab4j.api.models;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonValue;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
+
+import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 
-import org.gitlab4j.api.utils.JacksonJson;
-import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
+public class Variable implements Serializable {
 
-import com.fasterxml.jackson.annotation.JsonCreator;
-import com.fasterxml.jackson.annotation.JsonProperty;
-import com.fasterxml.jackson.annotation.JsonValue;
-
-public class Variable {
+    private static final long serialVersionUID = 5873211613037430191L;
 
     /**
      * Enum for the various Commit build status values.

--- a/src/main/java/org/gitlab4j/api/models/Variable.java
+++ b/src/main/java/org/gitlab4j/api/models/Variable.java
@@ -12,8 +12,7 @@ import java.util.List;
 import java.util.Map;
 
 public class Variable implements Serializable {
-
-    private static final long serialVersionUID = 5873211613037430191L;
+    private static final long serialVersionUID = 1L;
 
     /**
      * Enum for the various Commit build status values.

--- a/src/main/java/org/gitlab4j/api/models/Version.java
+++ b/src/main/java/org/gitlab4j/api/models/Version.java
@@ -5,8 +5,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class Version implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 7123100394598007342L;
     private String version;
     private String revision;
 

--- a/src/main/java/org/gitlab4j/api/models/Version.java
+++ b/src/main/java/org/gitlab4j/api/models/Version.java
@@ -2,8 +2,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class Version {
+import java.io.Serializable;
 
+public class Version implements Serializable {
+
+    private static final long serialVersionUID = 7123100394598007342L;
     private String version;
     private String revision;
 

--- a/src/main/java/org/gitlab4j/api/models/WikiAttachment.java
+++ b/src/main/java/org/gitlab4j/api/models/WikiAttachment.java
@@ -2,25 +2,29 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class WikiAttachment {
+import java.io.Serializable;
 
-    public static class Link {
+public class WikiAttachment implements Serializable {
 
+    private static final long serialVersionUID = -7916180068718971133L;
+
+    public static class Link implements Serializable {
+        private static final long serialVersionUID = -5037434183307088155L;
         private String url;
         private String markdown;
 
         public String getUrl() {
             return url;
         }
-    
+
         public void setUrl(String url) {
             this.url = url;
         }
-    
+
         public String getMarkdown() {
             return markdown;
         }
-    
+
         public void setMarkdown(String markdown) {
             this.markdown = markdown;
         }

--- a/src/main/java/org/gitlab4j/api/models/WikiAttachment.java
+++ b/src/main/java/org/gitlab4j/api/models/WikiAttachment.java
@@ -5,11 +5,11 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class WikiAttachment implements Serializable {
-
-    private static final long serialVersionUID = -7916180068718971133L;
+    private static final long serialVersionUID = 1L;
 
     public static class Link implements Serializable {
-        private static final long serialVersionUID = -5037434183307088155L;
+        private static final long serialVersionUID = 1L;
+
         private String url;
         private String markdown;
 

--- a/src/main/java/org/gitlab4j/api/models/WikiPage.java
+++ b/src/main/java/org/gitlab4j/api/models/WikiPage.java
@@ -28,8 +28,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 import java.io.Serializable;
 
 public class WikiPage implements Serializable {
+    private static final long serialVersionUID = 1L;
 
-    private static final long serialVersionUID = 1105471433119053382L;
     private String title;
     private String content;
     private String slug;

--- a/src/main/java/org/gitlab4j/api/models/WikiPage.java
+++ b/src/main/java/org/gitlab4j/api/models/WikiPage.java
@@ -25,8 +25,11 @@ package org.gitlab4j.api.models;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
-public class WikiPage {
+import java.io.Serializable;
 
+public class WikiPage implements Serializable {
+
+    private static final long serialVersionUID = 1105471433119053382L;
     private String title;
     private String content;
     private String slug;

--- a/src/main/java/org/gitlab4j/api/services/NotificationService.java
+++ b/src/main/java/org/gitlab4j/api/services/NotificationService.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.services;
 
+import java.io.Serializable;
 import java.util.Date;
 import java.util.HashMap;
 import java.util.Map;
@@ -9,7 +10,8 @@ import org.gitlab4j.api.utils.JacksonJson;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
-public abstract class NotificationService {
+public abstract class NotificationService implements Serializable{
+    private static final long serialVersionUID = 1L;
 
     public static final String NOTIFY_ONLY_BROKEN_PIPELINES_PROP = "notify_only_broken_pipelines";
     public static final String NOTIFY_ONLY_DEFAULT_BRANCH_PROP = "notify_only_default_branch";

--- a/src/main/java/org/gitlab4j/api/services/SlackService.java
+++ b/src/main/java/org/gitlab4j/api/services/SlackService.java
@@ -5,7 +5,8 @@ import org.gitlab4j.api.GitLabApiForm;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 
 public class SlackService extends NotificationService {
-    
+    private static final long serialVersionUID = 1L;
+
     private String defaultChannel;
 
     /**

--- a/src/main/java/org/gitlab4j/api/webhook/ExternalStatusCheckEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/ExternalStatusCheckEvent.java
@@ -1,5 +1,6 @@
 package org.gitlab4j.api.webhook;
 
+import java.io.Serializable;
 import java.util.List;
 
 import org.gitlab4j.api.models.Assignee;
@@ -7,7 +8,8 @@ import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.webhook.MergeRequestEvent.ObjectAttributes;
 
-public class ExternalStatusCheckEvent {
+public class ExternalStatusCheckEvent implements Serializable {
+    private static final long serialVersionUID = 1L;
 
     private String objectKind;
     private String eventType;

--- a/src/test/java/org/gitlab4j/api/JsonUtils.java
+++ b/src/test/java/org/gitlab4j/api/JsonUtils.java
@@ -1,13 +1,24 @@
 package org.gitlab4j.api;
 
+import static org.junit.jupiter.api.Assertions.fail;
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
 import java.io.Reader;
+import java.io.Serializable;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.gitlab4j.api.utils.JacksonJson;
+import org.junit.jupiter.api.Assertions;
 
 import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -26,7 +37,7 @@ public class JsonUtils {
     }
 
     static JsonNode readTreeFromMap(Map<String, Object> map) throws JsonParseException, JsonMappingException, IOException {
-	String jsonString = jacksonJson.getObjectMapper().writeValueAsString(map);
+        String jsonString = jacksonJson.getObjectMapper().writeValueAsString(map);
         return (jacksonJson.readTree(jsonString));
     }
     
@@ -40,46 +51,118 @@ public class JsonUtils {
     }
 
     static <T> T unmarshalResource(Class<T> returnType, String filename) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
         return (jacksonJson.unmarshal(returnType, reader));
     }
 
-    static <T> List<T> unmarshalResourceList(Class<T> returnType,  String filename) throws JsonParseException, JsonMappingException, IOException {
+    static <T> List<T> unmarshalResourceList(Class<T> returnType, String filename) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
         return (JsonUtils.unmarshalList(returnType, reader));
     }
 
     static <T> Map<String, T> unmarshalResourceMap(Class<T> returnType, String filename) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         InputStreamReader reader = new InputStreamReader(TestGitLabApiBeans.class.getResourceAsStream(filename));
         return (jacksonJson.unmarshalMap(returnType, reader));
     }
 
     static <T> T unmarshal(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshal(returnType, reader));
     }
 
     static <T> T unmarshal(Class<T> returnType, JsonNode tree) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshal(returnType, tree));
     }
 
     static <T> T unmarshal(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshal(returnType, json));
     }
 
     static <T> List<T> unmarshalList(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshalList(returnType, reader));
     }
 
     static <T> List<T> unmarshalList(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshalList(returnType, json));
     }
 
     static <T> Map<String, T> unmarshalMap(Class<T> returnType, Reader reader) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshalMap(returnType, reader));
     }
 
     static <T> Map<String, T> unmarshalMap(Class<T> returnType, String json) throws JsonParseException, JsonMappingException, IOException {
+        checkSerializable(returnType);
         return (jacksonJson.unmarshalMap(returnType, json));
+    }
+
+    static <T> void checkSerializable(Class<T> cls) {
+        if(!isSerializable(cls, new HashSet<>())) {
+            fail("Class " + cls.getCanonicalName() + " or one of its member does not implement Serializable");
+        }
+    }
+    static <T> boolean isSerializable(Class<T> cls, Set<Class<?>> checkedTypes) {
+        if (checkedTypes.contains(cls)) {
+            return true;
+        }
+        checkedTypes.add(cls);
+
+        if (!Serializable.class.isAssignableFrom(cls)) {
+            return false;
+        }
+
+        Field[] fields = cls.getDeclaredFields();
+        for (Field field : fields) {
+            if (!Modifier.isStatic(field.getModifiers()) && !Modifier.isTransient(field.getModifiers())) {
+                Class<?> fieldClass = field.getType();
+                if (!isSimpleType(fieldClass) && !isSerializable(fieldClass, checkedTypes) && !isCollectionSerializable(field, checkedTypes)) {
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    private static boolean isSimpleType(Class<?> type) {
+        return type.isPrimitive() ||
+               type.equals(String.class) ||
+               type.equals(Integer.class) ||
+               type.equals(Long.class) ||
+               type.equals(Double.class) ||
+               type.equals(Float.class) ||
+               type.equals(Boolean.class) ||
+               type.equals(Character.class) ||
+               type.equals(Byte.class) ||
+               type.equals(Short.class);
+    }
+    
+    private static boolean isCollectionSerializable(Field field, Set<Class<?>> checkedTypes) {
+        Class<?> fieldType = field.getType();
+        if (Collection.class.isAssignableFrom(fieldType) || Map.class.isAssignableFrom(fieldType)) {
+            Type genericType = field.getGenericType();
+
+            if (genericType instanceof ParameterizedType) {
+                ParameterizedType parameterizedType = (ParameterizedType) genericType;
+                Type[] typeArguments = parameterizedType.getActualTypeArguments();
+
+                for (Type typeArg : typeArguments) {
+                    if (typeArg instanceof Class) {
+                        Class<?> typeClass = (Class<?>) typeArg;
+                        if (!isSimpleType(typeClass) && !isSerializable(typeClass, checkedTypes)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+        }
+        return true;
     }
 
     static <T> boolean compareJson(T apiObject, String filename) throws IOException {


### PR DESCRIPTION
Hi guys! When building a native image, the classes under the models package need to be registered in the form of serialization, so they need to implement the serialization interface.