### PR TITLE
Add NamespaceApi.getNamespace(idOrPath) using /namespaces/:id

### DIFF
--- a/src/main/java/org/gitlab4j/api/AbstractApi.java
+++ b/src/main/java/org/gitlab4j/api/AbstractApi.java
@@ -13,6 +13,7 @@ import javax.ws.rs.core.StreamingOutput;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
 import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.Label;
+import org.gitlab4j.api.models.Namespace;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.UrlEncoder;
@@ -166,6 +167,34 @@ public abstract class AbstractApi implements Constants {
         } else {
             throw (new RuntimeException("Cannot determine ID or name from provided " + obj.getClass().getSimpleName() +
                     " instance, must be Long, String, or a Label instance"));
+        }
+    }
+
+    public Object getNamespaceIdOrPath(Object obj) throws GitLabApiException {
+
+        if (obj == null) {
+            throw (new RuntimeException("Cannot determine ID or path from null object"));
+        } else if (obj instanceof Long) {
+            return (obj);
+        } else if (obj instanceof String) {
+            return (urlEncode(((String) obj).trim()));
+        } else if (obj instanceof Namespace) {
+
+            Long id = ((Namespace) obj).getId();
+            if (id != null && id.longValue() > 0) {
+                return (id);
+            }
+
+            String path = ((Namespace) obj).getFullPath();
+            if (path != null && path.trim().length() > 0) {
+                return (urlEncode(path.trim()));
+            }
+
+            throw (new RuntimeException("Cannot determine ID or path from provided Namespace instance"));
+
+        } else {
+            throw (new RuntimeException("Cannot determine ID or path from provided " + obj.getClass().getSimpleName() +
+                    " instance, must be Long, String, or a Namespace instance"));
         }
     }
 

--- a/src/main/java/org/gitlab4j/api/NamespaceApi.java
+++ b/src/main/java/org/gitlab4j/api/NamespaceApi.java
@@ -155,7 +155,7 @@ public class NamespaceApi extends AbstractApi {
      * @param namespaceIdOrPath the namespace ID, path of the namespace, or a Namespace instance holding the namespace ID or path
      * @return the Group for the specified group path as an Optional instance
      */
-    public Optional<Namespace> getOptionalGroup(Object namespaceIdOrPath) {
+    public Optional<Namespace> getOptionalNamespace(Object namespaceIdOrPath) {
         try {
             return (Optional.ofNullable(getNamespace(namespaceIdOrPath)));
         } catch (GitLabApiException glae) {

--- a/src/main/java/org/gitlab4j/api/NamespaceApi.java
+++ b/src/main/java/org/gitlab4j/api/NamespaceApi.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Stream;
 
 import javax.ws.rs.core.GenericType;
@@ -129,5 +130,36 @@ public class NamespaceApi extends AbstractApi {
      */
     public Stream<Namespace> findNamespacesStream(String query) throws GitLabApiException {
         return (findNamespaces(query, getDefaultPerPage()).stream());
+    }
+
+    /**
+     * Get all details of a namespace.
+     *
+     * <pre><code>GitLab Endpoint: GET /namespaces/:id</code></pre>
+     *
+     * @param namespaceIdOrPath the namespace ID, path of the namespace, or a Namespace instance holding the namespace ID or path
+     * @return the Namespace instance for the specified path
+     * @throws GitLabApiException if any exception occurs
+     */
+
+    public Namespace getNamespace(Object namespaceIdOrPath) throws GitLabApiException {
+        Response response = get(Response.Status.OK, null, "namespaces", getNamespaceIdOrPath(namespaceIdOrPath));
+        return (response.readEntity(Namespace .class));
+    }
+
+    /**
+     * Get all details of a namespace as an Optional instance.
+     *
+     * <pre><code>GitLab Endpoint: GET /namespaces/:id</code></pre>
+     *
+     * @param namespaceIdOrPath the namespace ID, path of the namespace, or a Namespace instance holding the namespace ID or path
+     * @return the Group for the specified group path as an Optional instance
+     */
+    public Optional<Namespace> getOptionalGroup(Object namespaceIdOrPath) {
+        try {
+            return (Optional.ofNullable(getNamespace(namespaceIdOrPath)));
+        } catch (GitLabApiException glae) {
+            return (GitLabApi.createOptionalFromException(glae));
+        }
     }
 }


### PR DESCRIPTION
Just like `GroupApi.getGroup(idOrPath)` and `ProjectApi.getProject(idOrPath)`, 
`getNamespace(idOrPath)` method has been added to `NamespaceApi` as well.

See: https://docs.gitlab.com/ee/api/namespaces.html#get-namespace-by-id