### PR TITLE
Add 'project' parameter to Markdown API

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
+++ b/src/main/java/org/gitlab4j/api/models/MarkdownRequest.java
@@ -7,10 +7,17 @@ public class MarkdownRequest implements Serializable {
 
     private String text;
     private boolean gfm;
+    private String project;
 
     public MarkdownRequest(String text, boolean gfm) {
         this.text = text;
         this.gfm = gfm;
+    }
+
+    public MarkdownRequest(String text, boolean gfm, String project) {
+        this.text = text;
+        this.gfm = gfm;
+        this.project = project;
     }
 
     public String getText() {
@@ -27,5 +34,13 @@ public class MarkdownRequest implements Serializable {
 
     public void setGfm(boolean gfm) {
         this.gfm = gfm;
+    }
+
+    public String getProject() {
+        return project;
+    }
+
+    public void setProject(String project) {
+        this.project = project;
     }
 }


### PR DESCRIPTION
@ddoleye has proposed an addition that was originally part of PR https://github.com/gitlab4j/gitlab4j-api/pull/1079 to support a `project` attribute as documented here https://docs.gitlab.com/ee/api/markdown.html

This is now a separated PR.