### PR TITLE
Add API-based avatar retrieval

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api;
 
 import java.io.File;
+import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Date;
 import java.util.List;
@@ -11,6 +12,7 @@ import java.util.stream.Stream;
 
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 
@@ -1879,6 +1881,23 @@ public class GroupApi extends AbstractApi {
         Response response = putUpload(Response.Status.OK,
                 "avatar", avatarFile, "groups", getGroupIdOrPath(groupIdOrPath));
         return (response.readEntity(Group.class));
+    }
+
+    /**
+     * Gets the group avatar.
+     *
+     * <pre><code>GitLab Endpoint: GET /groups/:id/avatar</code></pre>
+     * 
+     * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
+     * @return an InputStream to read the raw file from
+     * @throws GitLabApiException if any exception occurs
+     */
+    public InputStream getAvatar(Object groupIdOrPath) throws GitLabApiException {
+
+        Response response = getWithAccepts(Response.Status.OK, null,  MediaType.MEDIA_TYPE_WILDCARD,
+                "groups", getGroupIdOrPath(groupIdOrPath), "avatar");
+        return (response.readEntity(InputStream.class));
+
     }
 
     /**

--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -1885,6 +1885,7 @@ public class GroupApi extends AbstractApi {
 
     /**
      * Gets the group avatar.
+     * Only working with GitLab 14.0 and above.
      *
      * <pre><code>GitLab Endpoint: GET /groups/:id/avatar</code></pre>
      * 

--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -35,6 +35,7 @@ import java.util.Optional;
 import java.util.stream.Stream;
 import javax.ws.rs.core.Form;
 import javax.ws.rs.core.GenericType;
+import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.MultivaluedMap;
 import javax.ws.rs.core.Response;
 import org.gitlab4j.api.GitLabApi.ApiVersion;
@@ -1066,6 +1067,24 @@ public class ProjectApi extends AbstractApi implements Constants {
 
         Response response = post(Response.Status.CREATED, formData, "projects");
         return (response.readEntity(Project.class));
+    }
+
+    /**
+     * Gets the project avatar.
+     * Only working with GitLab 16.9 and above.
+     *
+     * <pre><code>GitLab Endpoint: GET /projects/:id/avatar</code></pre>
+     * 
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @return an InputStream to read the raw file from
+     * @throws GitLabApiException if any exception occurs
+     */
+    public InputStream getAvatar(Object projectIdOrPath) throws GitLabApiException {
+
+        Response response = getWithAccepts(Response.Status.OK, null,  MediaType.MEDIA_TYPE_WILDCARD,
+                "projects", getProjectIdOrPath(projectIdOrPath), "avatar");
+        return (response.readEntity(InputStream.class));
+
     }
 
     /**

--- a/src/test/java/org/gitlab4j/api/TestAvatarUpload.java
+++ b/src/test/java/org/gitlab4j/api/TestAvatarUpload.java
@@ -7,6 +7,7 @@ import static org.junit.jupiter.api.Assumptions.assumeTrue;
 import java.io.File;
 import java.util.Map;
 
+import org.gitlab4j.api.models.Group;
 import org.gitlab4j.api.models.Project;
 import org.gitlab4j.api.models.User;
 import org.junit.jupiter.api.BeforeAll;
@@ -45,6 +46,7 @@ public class TestAvatarUpload extends AbstractIntegrationTest {
 
     private static GitLabApi gitLabApi;
     private static Project testProject;
+    private static Group testGroup;
 
     public TestAvatarUpload() {
         super();
@@ -52,9 +54,10 @@ public class TestAvatarUpload extends AbstractIntegrationTest {
 
     @BeforeAll
     public static void setup() {
-        // Must setup the connection to the GitLab test server and get the test Project instance
+        // Must setup the connection to the GitLab test server and get the test Project and Group instances
         gitLabApi = baseTestSetup();
         testProject = getTestProject();
+        testGroup = getTestGroup();
     }
 
     @Test
@@ -99,5 +102,16 @@ public class TestAvatarUpload extends AbstractIntegrationTest {
         User updatedUser = gitLabApi.getUserApi().setUserAvatar(user, avatarFile);
         assertNotNull(updatedUser);
         assertTrue(updatedUser.getAvatarUrl().endsWith(AVATAR_FILENAME));
+    }
+
+    @Test
+    public void testSetGroupAvatar() throws GitLabApiException {
+
+        assumeTrue(testGroup != null);
+
+        File avatarFile = new File("src/test/resources/org/gitlab4j/api", AVATAR_FILENAME);
+        Group updatedGroup = gitLabApi.getGroupApi().setGroupAvatar(testGroup.getId(), avatarFile);
+        assertNotNull(updatedGroup);
+        assertTrue(updatedGroup.getAvatarUrl().endsWith(AVATAR_FILENAME));
     }
 }

--- a/src/test/java/org/gitlab4j/api/TestGroupApi.java
+++ b/src/test/java/org/gitlab4j/api/TestGroupApi.java
@@ -6,6 +6,12 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Stream;
@@ -21,6 +27,7 @@ import org.gitlab4j.api.models.User;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -45,6 +52,8 @@ public class TestGroupApi extends AbstractIntegrationTest {
     private static final String TEST_GROUP = HelperUtils.getProperty(GROUP_KEY);
     private static final String TEST_GROUP_MEMBER_USERNAME = HelperUtils.getProperty(GROUP_MEMBER_USERNAME_KEY);
     private static final String TEST_REQUEST_ACCESS_USERNAME = HelperUtils.getProperty(TEST_REQUEST_ACCESS_USERNAME_KEY);
+
+    private static final String AVATAR_FILENAME = "avatar.png";
 
     private static GitLabApi gitLabApi;
     private static Group testGroup;
@@ -194,6 +203,25 @@ public class TestGroupApi extends AbstractIntegrationTest {
         assertNotNull(optional);
         assertFalse(optional.isPresent());
         assertEquals(Response.Status.NOT_FOUND.getStatusCode(), GitLabApi.getOptionalException(optional).getHttpStatus());
+    }
+
+    @Test
+    @Disabled("Required Gitlab version not less then 14.0")
+    public void testGetAvatar() throws GitLabApiException, IOException {
+        
+        assumeTrue(testGroup != null);
+
+        File avatarFile = new File("src/test/resources/org/gitlab4j/api", AVATAR_FILENAME);
+        gitLabApi.getGroupApi().setGroupAvatar(testGroup.getId(), avatarFile);
+
+        // Get the avatar of the test Group
+        InputStream in = gitLabApi.getGroupApi().getAvatar(testGroup);
+
+        Path target = Files.createTempFile(TEST_PROJECT_NAME + "-avatar", "png");
+        Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+
+        assertTrue(target.toFile().length() > 0);
+        Files.delete(target);
     }
 
 

--- a/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -31,6 +31,12 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assumptions.assumeTrue;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.Date;
@@ -56,6 +62,7 @@ import org.gitlab4j.api.utils.ISO8601;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.MethodOrderer;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -93,6 +100,8 @@ public class TestProjectApi extends AbstractIntegrationTest {
     private static final String TEST_PROJECT_NAME_UPDATE = "test-gitlab4j-create-project-update";
     private static final String TEST_XFER_PROJECT_NAME = "test-gitlab4j-xfer-project";
     private static final String TEST_VARIABLE_KEY_PREFIX = "TEST_VARIABLE_KEY_";
+
+    private static final String AVATAR_FILENAME = "avatar.png";
 
     private static GitLabApi gitLabApi;
     private static Project testProject;
@@ -309,6 +318,25 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(2, projects.size());
         assertEquals(TEST_PROJECT_NAME_2, projects.get(0).getName());
         assertEquals(TEST_PROJECT_NAME_1, projects.get(1).getName());
+    }
+
+    @Test
+    @Disabled("Required Gitlab version not less then 16.9")
+    public void testGetAvatar() throws GitLabApiException, IOException {
+        
+        assumeTrue(testProject != null);
+
+        File avatarFile = new File("src/test/resources/org/gitlab4j/api", AVATAR_FILENAME);
+        gitLabApi.getProjectApi().setProjectAvatar(testProject.getId(), avatarFile);
+
+        // Get the avatar of the test project
+        InputStream in = gitLabApi.getProjectApi().getAvatar(testProject);
+
+        Path target = Files.createTempFile(TEST_PROJECT_NAME + "-avatar", "png");
+        Files.copy(in, target, StandardCopyOption.REPLACE_EXISTING);
+
+        assertTrue(target.toFile().length() > 0);
+        Files.delete(target);
     }
 
     @Test


### PR DESCRIPTION
This PR adds methods to retrieve avatar images for groups and projects via the API. This is a useful alternative to the public upload URL from the project/group properties in situations like if the project/group is internal or private.