### PR TITLE
Add PositionType.FILE

### DIFF
--- a/src/main/java/org/gitlab4j/api/models/Position.java
+++ b/src/main/java/org/gitlab4j/api/models/Position.java
@@ -12,7 +12,7 @@ public class Position implements Serializable {
 
     public static enum PositionType {
 
-        TEXT, IMAGE;
+        TEXT, IMAGE, FILE;
         private static JacksonJsonEnumHelper<PositionType> enumHelper = new JacksonJsonEnumHelper<>(PositionType.class,
                 false, false);
 


### PR DESCRIPTION
A note can have a positoin of type `image`, `text` and `file`. The type `file` wasn't allowed in the API, but only due to a bug. It is supported now.

Official Issue: https://gitlab.com/gitlab-org/gitlab/-/issues/423046
Official MR: https://gitlab.com/gitlab-org/gitlab/-/merge_requests/130404