### PR TITLE
Update ProjectApi.java to allow last topic removal

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1360,7 +1360,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 formData.withParam("tag_list", String.join(",", project.getTagList()));
             }
 
-            if (project.getTopics() != null && !project.getTopics().isEmpty()) {
+            if (project.getTopics() != null) {
                 formData.withParam("topics", String.join(",", project.getTopics()));
             }
         }


### PR DESCRIPTION
Based on issue #1100 

Fixed a problem where the last topic could not be removed.

Fixes #1100 