### PR TITLE
Restore API compatibility with 5.5.0 and earlier releases

### DIFF
--- a/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2213,7 +2213,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * @throws GitLabApiException if any exception occurs
      */
     public ProjectHook addHook(Object projectIdOrPath, String url, ProjectHook enabledHooks,
-            Boolean enableSslVerification, String secretToken) throws GitLabApiException {
+            boolean enableSslVerification, String secretToken) throws GitLabApiException {
 
         GitLabApiForm formData = new GitLabApiForm()
                 .withParam("url", url, true)
@@ -2260,7 +2260,7 @@ public class ProjectApi extends AbstractApi implements Constants {
 
     /**
      * Adds a hook to project.
-     * Convenience method for {@link #addHook(Object, String, ProjectHook, Boolean, String)}
+     * Convenience method for {@link #addHook(Object, String, ProjectHook, boolean, String)}
      *
      * <pre><code>GitLab Endpoint: POST /projects/:id/hooks</code></pre>
      *
@@ -2280,7 +2280,7 @@ public class ProjectApi extends AbstractApi implements Constants {
             .withIssuesEvents(doIssuesEvents)
             .withMergeRequestsEvents(doMergeRequestsEvents)
             .withNoteEvents(doNoteEvents);
-        return addHook(projectIdOrPath, url, enabledHooks , null, null);
+        return addHook(projectIdOrPath, url, enabledHooks , false, null);
     }
 
     /**


### PR DESCRIPTION
## Restore API compatibility with 5.5.0 and earlier releases

https://github.com/gitlab4j/gitlab4j-api/commit/224f4c5b9f15d54ad3efa6702009e6d99c0445fd#commitcomment-145297850 notes that the change from boolean to Boolean is a breaking change in the API.

It seems easiest and safest to restore API compatibility rather than requiring lock-step upgrades from consumers of the API.  Jenkins (as an example) allows users to upgrade the GitLab API plugin without requiring that they upgrade the GitLab branch source plugin.  When that happens, the breaking change in the API causes runtime failures for Jenkins users.

https://github.com/jenkinsci/gitlab-branch-source-plugin/issues/435 reports some of those runtime failures.

[JENKINS-73672](https://issues.jenkins.io/browse/JENKINS-73672) reports more runtime failures due to the breaking change in the API.

Fixes https://github.com/gitlab4j/gitlab4j-api/issues/1155
