### PR TITLE
Add missing attributes for NotesApi and DiscussionApi (#1193)

### DIFF
--- a/src/main/java/org/gitlab4j/api/DiscussionsApi.java
+++ b/src/main/java/org/gitlab4j/api/DiscussionsApi.java
@@ -11,6 +11,7 @@ import javax.ws.rs.core.Response;
 import org.gitlab4j.api.models.Discussion;
 import org.gitlab4j.api.models.Note;
 import org.gitlab4j.api.models.Position;
+import org.gitlab4j.api.utils.ISO8601;
 
 /**
  * This class implements the client side API for the GitLab Discussions API.
@@ -644,6 +645,39 @@ public class DiscussionsApi extends AbstractApi {
                 .withParam("position[height]", position.getHeight())
                 .withParam("position[x]", position.getX())
                 .withParam("position[y]", position.getY());
+
+        Response response = post(
+                Response.Status.CREATED,
+                formData,
+                "projects",
+                getProjectIdOrPath(projectIdOrPath),
+                "repository",
+                "commits",
+                commitSha,
+                "discussions");
+        return (response.readEntity(Discussion.class));
+    }
+
+    /**
+     * Creates a new discussion to a single project commit. This is similar to creating
+     * a note but other comments (replies) can be added to it later.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/repository/commits/:commit_sha/discussions</code></pre>
+     *
+     * @param projectIdOrPath projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param commitSha the commit SHA to create the discussion for
+     * @param body the content of a discussion
+     * @param createdAt date the discussion was created (requires admin or project/group owner rights) (Optional)
+     * @return a Discussion instance containing the newly created discussion
+     * @throws GitLabApiException if any exception occurs during execution
+     */
+    public Discussion createCommitDiscussion(Object projectIdOrPath, String commitSha, String body, Date createdAt)
+            throws GitLabApiException {
+
+        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+        if (createdAt != null) {
+            formData.withParam("created_at", ISO8601.toString(createdAt));
+        }
 
         Response response = post(
                 Response.Status.CREATED,

--- a/src/main/java/org/gitlab4j/api/NotesApi.java
+++ b/src/main/java/org/gitlab4j/api/NotesApi.java
@@ -8,6 +8,7 @@ import javax.ws.rs.core.GenericType;
 import javax.ws.rs.core.Response;
 
 import org.gitlab4j.api.models.Note;
+import org.gitlab4j.api.utils.ISO8601;
 
 public class NotesApi extends AbstractApi {
 
@@ -500,12 +501,18 @@ public class NotesApi extends AbstractApi {
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
      * @param mergeRequestIid  the merge request IID to create the notes for
      * @param body the content of note
+     * @param createdAt date the discussion was created (requires admin or project/group owner rights) (Optional)
      * @return the created Note instance
      * @throws GitLabApiException if any exception occurs
      */
-    public Note createMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, String body)
+    public Note createMergeRequestNote(
+            Object projectIdOrPath, Long mergeRequestIid, String body, Date createdAt, boolean internal)
             throws GitLabApiException {
-        GitLabApiForm formData = new GitLabApiForm().withParam("body", body, true);
+        GitLabApiForm formData =
+                new GitLabApiForm().withParam("body", body, true).withParam("internal", internal);
+        if (createdAt != null) {
+            formData.withParam("created_at", ISO8601.toString(createdAt));
+        }
         Response response = post(
                 Response.Status.CREATED,
                 formData,

--- a/src/main/java/org/gitlab4j/api/models/Setting.java
+++ b/src/main/java/org/gitlab4j/api/models/Setting.java
@@ -488,7 +488,7 @@ public enum Setting {
     /**
      * Gitaly fast operation timeout, in seconds. Some Gitaly operations are
      * expected to be fast. If they exceed this threshold, there may be a problem
-     * with a storage shard and ‘failing fast’ can help maintain the stability of
+     * with a storage shard and 'failing fast' can help maintain the stability of
      * the GitLab instance. Set to 0 to disable timeouts.
      */
     GITALY_TIMEOUT_FAST(Integer.class),
@@ -1534,7 +1534,7 @@ public enum Setting {
 
     /**
      * When rate limiting is enabled via the throttle_* settings, send this plain text response
-     * when a rate limit is exceeded. ‘Retry later’ is sent if this is blank.
+     * when a rate limit is exceeded. 'Retry later' is sent if this is blank.
      */
     RATE_LIMITING_RESPONSE_TEXT(String.class),
 
@@ -1575,7 +1575,7 @@ public enum Setting {
     USER_DEACTIVATION_EMAILS_ENABLED(Boolean.class),
 
     /**
-     * track or compress. Sets the behavior for Sidekiq job size limits. Default: ‘compress’.
+     * track or compress. Sets the behavior for Sidekiq job size limits. Default: 'compress'.
      */
     SIDEKIQ_JOB_LIMITER_MODE(String.class),
 


### PR DESCRIPTION
Add attributes "created_at", "internal" for NotesApi commits and DiscussionApi merge requests

- Replace unmappable characters in javadocs

Fixes: #1193