### PR TITLE
Fix getUploadFiles(..) in GroupApi

### DIFF
--- a/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -2451,7 +2451,7 @@ public class GroupApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public List<UploadedFile> getUploadFiles(Object groupIdOrPath) throws GitLabApiException {
-        Response response = get(Response.Status.OK, null, "projects", getGroupIdOrPath(groupIdOrPath), "uploads");
+        Response response = get(Response.Status.OK, null, "groups", getGroupIdOrPath(groupIdOrPath), "uploads");
         return (response.readEntity(new GenericType<List<UploadedFile>>() {}));
     }
 


### PR DESCRIPTION
Follow up of https://github.com/gitlab4j/gitlab4j-api/pull/1184