### PR TITLE
Object Attributes

### DIFF
--- a/src/main/java/org/gitlab4j/api/webhook/ExternalStatusCheckEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/ExternalStatusCheckEvent.java
@@ -7,6 +7,8 @@ import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.webhook.MergeRequestEvent.ObjectAttributes;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class ExternalStatusCheckEvent implements Serializable {
     private static final long serialVersionUID = 1L;
 
@@ -15,7 +17,10 @@ public class ExternalStatusCheckEvent implements Serializable {
     private EventUser user;
     private EventProject project;
     private EventRepository repository;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private List<EventLabel> labels;
     private MergeRequestChanges changes;
     private List<Assignee> assignees;

--- a/src/main/java/org/gitlab4j/api/webhook/IssueEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/IssueEvent.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class IssueEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
@@ -14,7 +16,10 @@ public class IssueEvent extends AbstractEvent {
     private EventUser user;
     private EventProject project;
     private EventRepository repository;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private List<Assignee> assignees;
     private Assignee assignee;
     private List<EventLabel> labels;

--- a/src/main/java/org/gitlab4j/api/webhook/MergeRequestEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/MergeRequestEvent.java
@@ -6,6 +6,8 @@ import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.models.Reviewer;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class MergeRequestEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
@@ -15,7 +17,10 @@ public class MergeRequestEvent extends AbstractEvent {
     private EventUser user;
     private EventProject project;
     private EventRepository repository;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private List<EventLabel> labels;
     private MergeRequestChanges changes;
     private List<Assignee> assignees;

--- a/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
@@ -7,6 +7,7 @@ import org.gitlab4j.api.utils.JacksonJson;
 import org.gitlab4j.api.utils.JacksonJsonEnumHelper;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public class NoteEvent extends AbstractEvent {
@@ -19,7 +20,10 @@ public class NoteEvent extends AbstractEvent {
     private Long projectId;
     private EventProject project;
     private EventRepository repository;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private EventCommit commit;
     private EventIssue issue;
     private EventMergeRequest mergeRequest;

--- a/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/NoteEvent.java
@@ -26,7 +26,10 @@ public class NoteEvent extends AbstractEvent {
 
     private EventCommit commit;
     private EventIssue issue;
+
+    @JsonProperty(value = "merge_request")
     private EventMergeRequest mergeRequest;
+
     private EventSnippet snippet;
 
     @Override

--- a/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
@@ -7,13 +7,17 @@ import org.gitlab4j.api.models.Job;
 import org.gitlab4j.api.models.Variable;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class PipelineEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
     public static final String X_GITLAB_EVENT = "Pipeline Hook";
     public static final String OBJECT_KIND = "pipeline";
 
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private EventUser user;
     private EventProject project;
     private EventCommit commit;

--- a/src/main/java/org/gitlab4j/api/webhook/WikiPageEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WikiPageEvent.java
@@ -2,6 +2,8 @@ package org.gitlab4j.api.webhook;
 
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class WikiPageEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
@@ -11,6 +13,8 @@ public class WikiPageEvent extends AbstractEvent {
     private EventUser user;
     private EventProject project;
     private Wiki wiki;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
 
     public String getObjectKind() {

--- a/src/main/java/org/gitlab4j/api/webhook/WorkItemEvent.java
+++ b/src/main/java/org/gitlab4j/api/webhook/WorkItemEvent.java
@@ -5,6 +5,8 @@ import java.util.List;
 import org.gitlab4j.api.models.User;
 import org.gitlab4j.api.utils.JacksonJson;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
+
 public class WorkItemEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
@@ -14,7 +16,10 @@ public class WorkItemEvent extends AbstractEvent {
     private User user;
     private EventProject project;
     private EventRepository repository;
+
+    @JsonProperty(value = "object_attributes")
     private ObjectAttributes objectAttributes;
+
     private List<EventLabel> labels;
     private WorkItemChanges changes;
 


### PR DESCRIPTION
I keep getting MergeRequestEvent having a null objectAttributes field.  It looks like the API actually uses the syntax: object_attributes.  This seems to fix it.  There could be other instances of elsewhere in the API.

I'm trying create a simple webhook trigger using a managed GitLab CE 17.5.1 server, and am getting event json like:  [sample.json](https://github.com/user-attachments/files/17894370/sample.json)