### PR TITLE
Add "static" to "values()" on search scopes

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/models/Constants.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/models/Constants.java
@@ -919,7 +919,7 @@ public interface Constants {
             return (SearchScope<T>) jsonLookup.get(value);
         }
 
-        public Set<String> values() {
+        public static Set<String> values() {
             return jsonLookup.keySet();
         }
 
@@ -975,7 +975,7 @@ public interface Constants {
             return (GroupSearchScope<T>) jsonLookup.get(value);
         }
 
-        public Set<String> values() {
+        public static Set<String> values() {
             return jsonLookup.keySet();
         }
 
@@ -1030,7 +1030,7 @@ public interface Constants {
             return (ProjectSearchScope<T>) jsonLookup.get(value);
         }
 
-        public Set<String> values() {
+        public static Set<String> values() {
             return jsonLookup.keySet();
         }
 


### PR DESCRIPTION
Follow up of https://github.com/gitlab4j/gitlab4j-api/pull/1203, the `static` modifier was missing 