### PR TITLE
Add jandex plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -57,6 +57,10 @@ subprojects {
     tasks.named('test') {
         useJUnitPlatform()
     }
+
+    tasks.named("javadoc") {
+        inputs.files(tasks.getByPath("jandex").outputs.files)
+    }
 }
 
 nexusPublishing {

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,6 @@
 plugins {
     id 'com.diffplug.spotless' version '6.25.0' apply false
+    id 'org.kordamp.gradle.jandex' version '2.1.0' apply false
     id 'io.github.gradle-nexus.publish-plugin' version '1.3.0'
     id 'net.researchgate.release' version '3.0.2'
 }
@@ -15,6 +16,7 @@ subprojects {
     apply plugin: 'signing'
     apply plugin: 'com.diffplug.spotless'
     apply plugin: 'maven-publish'
+    apply plugin: 'org.kordamp.gradle.jandex'
 
     group = groupId
 


### PR DESCRIPTION
Some framework like Quarkus leverage jandex indexes for some optimization. Computing this index at build time make sense.