### PR TITLE
Remove classes to prevent "split packages" issues

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/systemhooks/SystemHookManager.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/systemhooks/SystemHookManager.java
@@ -1,9 +1,0 @@
-package org.gitlab4j.api.systemhooks;
-
-import org.gitlab4j.api.HookManager;
-
-/**
- * @deprecated use {@link org.gitlab4j.api.SystemHookManager} instead
- */
-@Deprecated
-public class SystemHookManager extends org.gitlab4j.api.SystemHookManager implements HookManager {}

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/webhook/WebHookManager.java
@@ -1,9 +1,0 @@
-package org.gitlab4j.api.webhook;
-
-import org.gitlab4j.api.HookManager;
-
-/**
- * @deprecated use {@link org.gitlab4j.api.WebHookManager} instead
- */
-@Deprecated
-public class WebHookManager extends org.gitlab4j.api.WebHookManager implements HookManager {}


### PR DESCRIPTION
* Class `org.gitlab4j.api.systemhooks.SystemHookManager`
    - Was moved to `org.gitlab4j.api.SystemHookManager`
* Class `org.gitlab4j.api.webhook.WebHookManager`
    - Was moved to `org.gitlab4j.api.WebHookManager`

Fixes #1210