### PR TITLE
Use Boolean instead of primitive boolean type for parameters

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -2502,9 +2502,9 @@ public class ProjectApi extends AbstractApi implements Constants {
     public ProjectHook addHook(
             Object projectIdOrPath,
             String url,
-            boolean doPushEvents,
-            boolean doIssuesEvents,
-            boolean doMergeRequestsEvents)
+            Boolean doPushEvents,
+            Boolean doIssuesEvents,
+            Boolean doMergeRequestsEvents)
             throws GitLabApiException {
         return addHook(projectIdOrPath, url, doPushEvents, doIssuesEvents, doMergeRequestsEvents, null);
     }


### PR DESCRIPTION
It is possible to use `null` as value for those parameters