### PR TITLE
MergeRequest: add draft flag

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequest.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequest.java
@@ -29,6 +29,7 @@ public class MergeRequest implements Serializable {
     private Boolean discussionLocked;
     private Integer divergedCommitsCount;
     private Integer downvotes;
+    private Boolean draft;
     private Boolean forceRemoveSourceBranch;
     private Boolean hasConflicts;
     private Long id;
@@ -215,6 +216,14 @@ public class MergeRequest implements Serializable {
 
     public void setDownvotes(Integer downvotes) {
         this.downvotes = downvotes;
+    }
+
+    public Boolean getDraft() {
+        return draft;
+    }
+
+    public void setDraft(Boolean draft) {
+        this.draft = draft;
     }
 
     public Boolean getForceRemoveSourceBranch() {

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/merge-request.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/merge-request.json
@@ -46,6 +46,7 @@
         "state":"active",
         "created_at":"2012-04-29T08:46:00Z"
     },
+    "draft": false,
     "allow_collaboration": false,
     "allow_maintainer_to_push": false,
     "discussion_locked": false,


### PR DESCRIPTION
Source: https://docs.gitlab.com/ee/api/merge_requests.html

[].draft	boolean	Indicates if the merge request is a draft.