### PR TITLE
added  WAITING_FOR_RESOURCE to job scopes

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/models/Constants.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/models/Constants.java
@@ -443,7 +443,8 @@ public interface Constants {
         SUCCESS,
         CANCELED,
         SKIPPED,
-        MANUAL;
+        MANUAL,
+        WAITING_FOR_RESOURCE;
 
         private static JacksonJsonEnumHelper<JobScope> enumHelper = new JacksonJsonEnumHelper<>(JobScope.class);
 


### PR DESCRIPTION
I need this scope to track the jobs queued in the resource group.

MR also relates to https://github.com/gitlab4j/gitlab4j-api/issues/1104