### PR TITLE
Added missing attributes for webhook events

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Build.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Build.java
@@ -1,0 +1,161 @@
+package org.gitlab4j.api.models;
+
+import java.util.Date;
+
+import org.gitlab4j.models.utils.JacksonJson;
+
+/**
+ * @author Yaris van Thiel
+ */
+public class Build {
+
+    private Long id;
+    private String stage;
+    private String name;
+    private BuildStatus status;
+    private Date createdAt;
+    private Date startedAt;
+    private Date finishedAt;
+    private Float duration;
+    private Float queuedDuration;
+    private String failureReason;
+    private String when;
+    private Boolean manual;
+    private Boolean allowFailure;
+    private User user;
+    private Runner runner;
+    private ArtifactsFile artifactsFile;
+
+    public Long getId() {
+        return id;
+    }
+
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    public String getStage() {
+        return stage;
+    }
+
+    public void setStage(String stage) {
+        this.stage = stage;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public BuildStatus getStatus() {
+        return status;
+    }
+
+    public void setStatus(BuildStatus status) {
+        this.status = status;
+    }
+
+    public Date getCreatedAt() {
+        return createdAt;
+    }
+
+    public void setCreatedAt(Date createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    public Date getStartedAt() {
+        return startedAt;
+    }
+
+    public void setStartedAt(Date startedAt) {
+        this.startedAt = startedAt;
+    }
+
+    public Date getFinishedAt() {
+        return finishedAt;
+    }
+
+    public void setFinishedAt(Date finishedAt) {
+        this.finishedAt = finishedAt;
+    }
+
+    public Float getDuration() {
+        return duration;
+    }
+
+    public void setDuration(Float duration) {
+        this.duration = duration;
+    }
+
+    public Float getQueuedDuration() {
+        return queuedDuration;
+    }
+
+    public void setQueuedDuration(Float queuedDuration) {
+        this.queuedDuration = queuedDuration;
+    }
+
+    public String getFailureReason() {
+        return failureReason;
+    }
+
+    public void setFailureReason(String failureReason) {
+        this.failureReason = failureReason;
+    }
+
+    public String getWhen() {
+        return when;
+    }
+
+    public void setWhen(String when) {
+        this.when = when;
+    }
+
+    public Boolean getManual() {
+        return manual;
+    }
+
+    public void setManual(Boolean manual) {
+        this.manual = manual;
+    }
+
+    public Boolean getAllowFailure() {
+        return allowFailure;
+    }
+
+    public void setAllowFailure(Boolean allowFailure) {
+        this.allowFailure = allowFailure;
+    }
+
+    public User getUser() {
+        return user;
+    }
+
+    public void setUser(User user) {
+        this.user = user;
+    }
+
+    public Runner getRunner() {
+        return runner;
+    }
+
+    public void setRunner(Runner runner) {
+        this.runner = runner;
+    }
+
+    public ArtifactsFile getArtifactsFile() {
+        return artifactsFile;
+    }
+
+    public void setArtifactsFile(ArtifactsFile artifactsFile) {
+        this.artifactsFile = artifactsFile;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/BuildStatus.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/BuildStatus.java
@@ -1,0 +1,60 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2017 Greg Messner <greg@messners.com>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy of
+ * this software and associated documentation files (the "Software"), to deal in
+ * the Software without restriction, including without limitation the rights to
+ * use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of
+ * the Software, and to permit persons to whom the Software is furnished to do so,
+ * subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS
+ * FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR
+ * COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
+ * IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
+ * CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+ */
+
+package org.gitlab4j.api.models;
+
+import org.gitlab4j.models.utils.JacksonJsonEnumHelper;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonValue;
+
+/**
+ * Enum for the various Build status values.
+ */
+public enum BuildStatus {
+    CREATED,
+    RUNNING,
+    PENDING,
+    SUCCESS,
+    FAILED,
+    CANCELED,
+    SKIPPED,
+    MANUAL;
+
+    private static JacksonJsonEnumHelper<BuildStatus> enumHelper = new JacksonJsonEnumHelper<>(BuildStatus.class);
+
+    @JsonCreator
+    public static BuildStatus forValue(String value) {
+        return enumHelper.forValue(value);
+    }
+
+    @JsonValue
+    public String toValue() {
+        return (enumHelper.toString(this));
+    }
+
+    @Override
+    public String toString() {
+        return (enumHelper.toString(this));
+    }
+}

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Runner.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Runner.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api.models;
 
 import java.io.Serializable;
+import java.util.List;
 
 import org.gitlab4j.models.utils.JacksonJson;
 import org.gitlab4j.models.utils.JacksonJsonEnumHelper;
@@ -13,8 +14,10 @@ public class Runner implements Serializable {
 
     private Long id;
     private String description;
+    private RunnerType runnerType;
     private Boolean active;
     private Boolean isShared;
+    private List<String> tags;
     private String name;
     private Boolean online;
     private RunnerStatus status;
@@ -88,6 +91,14 @@ public class Runner implements Serializable {
         this.description = description;
     }
 
+    public RunnerType getRunnerType() {
+        return runnerType;
+    }
+
+    public void setRunnerType(RunnerType runnerType) {
+        this.runnerType = runnerType;
+    }
+
     public Boolean getActive() {
         return active;
     }
@@ -102,6 +113,14 @@ public class Runner implements Serializable {
 
     public void setIs_shared(Boolean is_shared) {
         this.isShared = is_shared;
+    }
+
+    public List<String> getTags() {
+        return tags;
+    }
+
+    public void setTags(List<String> tags) {
+        this.tags = tags;
     }
 
     public String getName() {

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/AbstractPushEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/AbstractPushEvent.java
@@ -11,6 +11,7 @@ public abstract class AbstractPushEvent {
     private String after;
     private String before;
     private String ref;
+    private Boolean refProtected;
     private String checkoutSha;
 
     private Long userId;
@@ -59,6 +60,14 @@ public abstract class AbstractPushEvent {
 
     public void setRef(String ref) {
         this.ref = ref;
+    }
+
+    public Boolean getRefProtected() {
+        return refProtected;
+    }
+
+    public void setRefProtected(Boolean refProtected) {
+        this.refProtected = refProtected;
     }
 
     public String getCheckoutSha() {

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/BuildCommit.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/BuildCommit.java
@@ -7,6 +7,7 @@ import org.gitlab4j.models.utils.JacksonJson;
 public class BuildCommit {
 
     private Long id;
+    private String name;
     private String sha;
     private String message;
     private String authorName;
@@ -23,6 +24,14 @@ public class BuildCommit {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
     }
 
     public String getSha() {

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/BuildEvent.java
@@ -2,6 +2,7 @@ package org.gitlab4j.api.webhook;
 
 import java.util.Date;
 
+import org.gitlab4j.api.models.Runner;
 import org.gitlab4j.models.utils.JacksonJson;
 
 /**
@@ -18,10 +19,12 @@ public class BuildEvent extends AbstractEvent {
     private Boolean tag;
     private String beforeSha;
     private String sha;
+    private Integer retriesCount;
     private Long buildId;
     private String buildName;
     private String buildStage;
     private String buildStatus;
+    private Date buildCreatedAt;
     private Date buildStartedAt;
     private Date buildFinishedAt;
     private Float buildDuration;
@@ -36,6 +39,8 @@ public class BuildEvent extends AbstractEvent {
     private EventUser user;
     private BuildCommit commit;
     private EventRepository repository;
+    private EventProject project;
+    private Runner runner;
 
     @Override
     public String getObjectKind() {
@@ -79,6 +84,14 @@ public class BuildEvent extends AbstractEvent {
         this.sha = sha;
     }
 
+    public Integer getRetriesCount() {
+        return retriesCount;
+    }
+
+    public void setRetriesCount(Integer retriesCount) {
+        this.retriesCount = retriesCount;
+    }
+
     public Long getBuildId() {
         return buildId;
     }
@@ -109,6 +122,14 @@ public class BuildEvent extends AbstractEvent {
 
     public void setBuildStatus(String buildStatus) {
         this.buildStatus = buildStatus;
+    }
+
+    public Date getBuildCreatedAt() {
+        return buildCreatedAt;
+    }
+
+    public void setBuildCreatedAt(Date buildCreatedAt) {
+        this.buildCreatedAt = buildCreatedAt;
     }
 
     public Date getBuildStartedAt() {
@@ -205,6 +226,22 @@ public class BuildEvent extends AbstractEvent {
 
     public void setRepository(EventRepository repository) {
         this.repository = repository;
+    }
+
+    public EventProject getProject() {
+        return project;
+    }
+
+    public void setProject(EventProject project) {
+        this.project = project;
+    }
+
+    public Runner getRunner() {
+        return runner;
+    }
+
+    public void setRunner(Runner runner) {
+        this.runner = runner;
     }
 
     @Override

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventCommit.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventCommit.java
@@ -10,6 +10,7 @@ public class EventCommit {
 
     private String id;
     private String message;
+    private String title;
     private Date timestamp;
     private String url;
     private Author author;
@@ -31,6 +32,14 @@ public class EventCommit {
 
     public void setMessage(String message) {
         this.message = message;
+    }
+
+    public String getTitle() {
+        return title;
+    }
+
+    public void setTitle(String title) {
+        this.title = title;
     }
 
     public Date getTimestamp() {

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventIssue.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventIssue.java
@@ -1,6 +1,7 @@
 package org.gitlab4j.api.webhook;
 
 import java.util.Date;
+import java.util.List;
 
 import org.gitlab4j.models.utils.JacksonJson;
 
@@ -25,6 +26,29 @@ public class EventIssue {
 
     private String url;
     private String action;
+
+    private List<Long> assigneeIds;
+    private Long updatedById;
+    private Date lastEditedAt;
+    private Long lastEditedById;
+    private Long relativePosition;
+    private Long stateId;
+    private Boolean confidential;
+    private Boolean discussionLocked;
+    private Date dueDate;
+    private Long movedToId;
+    private Long duplicatedToId;
+    private Long timeEstimate;
+    private Long totalTimeSpent;
+    private Long timeChange;
+    private String humanTimeEstimate;
+    private String humanTotalTimeSpent;
+    private String humanTimeChange;
+    private Long weight;
+    private String healthStatus;
+    private String type;
+    private String severity;
+    private List<EventLabel> labels;
 
     public Long getAssigneeId() {
         return this.assigneeId;
@@ -144,6 +168,182 @@ public class EventIssue {
 
     public void setAction(String action) {
         this.action = action;
+    }
+
+    public List<Long> getAssigneeIds() {
+        return assigneeIds;
+    }
+
+    public void setAssigneeIds(List<Long> assigneeIds) {
+        this.assigneeIds = assigneeIds;
+    }
+
+    public Long getUpdatedById() {
+        return updatedById;
+    }
+
+    public void setUpdatedById(Long updatedById) {
+        this.updatedById = updatedById;
+    }
+
+    public Date getLastEditedAt() {
+        return lastEditedAt;
+    }
+
+    public void setLastEditedAt(Date lastEditedAt) {
+        this.lastEditedAt = lastEditedAt;
+    }
+
+    public Long getLastEditedById() {
+        return lastEditedById;
+    }
+
+    public void setLastEditedById(Long lastEditedById) {
+        this.lastEditedById = lastEditedById;
+    }
+
+    public Long getRelativePosition() {
+        return relativePosition;
+    }
+
+    public void setRelativePosition(Long relativePosition) {
+        this.relativePosition = relativePosition;
+    }
+
+    public Long getStateId() {
+        return stateId;
+    }
+
+    public void setStateId(Long stateId) {
+        this.stateId = stateId;
+    }
+
+    public Boolean getConfidential() {
+        return confidential;
+    }
+
+    public void setConfidential(Boolean confidential) {
+        this.confidential = confidential;
+    }
+
+    public Boolean getDiscussionLocked() {
+        return discussionLocked;
+    }
+
+    public void setDiscussionLocked(Boolean discussionLocked) {
+        this.discussionLocked = discussionLocked;
+    }
+
+    public Date getDueDate() {
+        return dueDate;
+    }
+
+    public void setDueDate(Date dueDate) {
+        this.dueDate = dueDate;
+    }
+
+    public Long getMovedToId() {
+        return movedToId;
+    }
+
+    public void setMovedToId(Long movedToId) {
+        this.movedToId = movedToId;
+    }
+
+    public Long getDuplicatedToId() {
+        return duplicatedToId;
+    }
+
+    public void setDuplicatedToId(Long duplicatedToId) {
+        this.duplicatedToId = duplicatedToId;
+    }
+
+    public Long getTimeEstimate() {
+        return timeEstimate;
+    }
+
+    public void setTimeEstimate(Long timeEstimate) {
+        this.timeEstimate = timeEstimate;
+    }
+
+    public Long getTotalTimeSpent() {
+        return totalTimeSpent;
+    }
+
+    public void setTotalTimeSpent(Long totalTimeSpent) {
+        this.totalTimeSpent = totalTimeSpent;
+    }
+
+    public Long getTimeChange() {
+        return timeChange;
+    }
+
+    public void setTimeChange(Long timeChange) {
+        this.timeChange = timeChange;
+    }
+
+    public String getHumanTimeEstimate() {
+        return humanTimeEstimate;
+    }
+
+    public void setHumanTimeEstimate(String humanTimeEstimate) {
+        this.humanTimeEstimate = humanTimeEstimate;
+    }
+
+    public String getHumanTotalTimeSpent() {
+        return humanTotalTimeSpent;
+    }
+
+    public void setHumanTotalTimeSpent(String humanTotalTimeSpent) {
+        this.humanTotalTimeSpent = humanTotalTimeSpent;
+    }
+
+    public String getHumanTimeChange() {
+        return humanTimeChange;
+    }
+
+    public void setHumanTimeChange(String humanTimeChange) {
+        this.humanTimeChange = humanTimeChange;
+    }
+
+    public Long getWeight() {
+        return weight;
+    }
+
+    public void setWeight(Long weight) {
+        this.weight = weight;
+    }
+
+    public String getHealthStatus() {
+        return healthStatus;
+    }
+
+    public void setHealthStatus(String healthStatus) {
+        this.healthStatus = healthStatus;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public void setType(String type) {
+        this.type = type;
+    }
+
+    public String getSeverity() {
+        return severity;
+    }
+
+    public void setSeverity(String severity) {
+        this.severity = severity;
+    }
+
+    public List<EventLabel> getLabels() {
+        return labels;
+    }
+
+    public void setLabels(List<EventLabel> labels) {
+        this.labels = labels;
     }
 
     @Override

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
@@ -2,6 +2,7 @@ package org.gitlab4j.api.webhook;
 
 import java.util.Date;
 
+import org.gitlab4j.api.models.Runner;
 import org.gitlab4j.models.utils.JacksonJson;
 
 public class JobEvent extends AbstractEvent {
@@ -23,11 +24,26 @@ public class JobEvent extends AbstractEvent {
     private Integer jobDuration;
     private Boolean jobAllowFailure;
     private String jobFailureReason;
+    private Long buildId;
+    private String buildName;
+    private String buildStage;
+    private String buildStatus;
+    private Date buildCreatedAt;
+    private Date buildStartedAt;
+    private Date buildFinishedAt;
+    private Integer buildDuration;
+    private Double buildQueuedDuration;
+    private Boolean buildAllowFailure;
+    private String buildFailureReason;
+    private Integer retriesCount;
+    private Integer pipelineId;
     private Long projectId;
     private String projectName;
     private EventUser user;
     private BuildCommit commit;
     private EventRepository repository;
+    private EventProject project;
+    private Runner runner;
 
     @Override
     public String getObjectKind() {
@@ -143,6 +159,110 @@ public class JobEvent extends AbstractEvent {
         this.jobFailureReason = jobFailureReason;
     }
 
+    public Long getBuildId() {
+        return buildId;
+    }
+
+    public void setBuildId(Long buildId) {
+        this.buildId = buildId;
+    }
+
+    public String getBuildName() {
+        return buildName;
+    }
+
+    public void setBuildName(String buildName) {
+        this.buildName = buildName;
+    }
+
+    public String getBuildStage() {
+        return buildStage;
+    }
+
+    public void setBuildStage(String buildStage) {
+        this.buildStage = buildStage;
+    }
+
+    public String getBuildStatus() {
+        return buildStatus;
+    }
+
+    public void setBuildStatus(String buildStatus) {
+        this.buildStatus = buildStatus;
+    }
+
+    public Date getBuildCreatedAt() {
+        return buildCreatedAt;
+    }
+
+    public void setBuildCreatedAt(Date buildCreatedAt) {
+        this.buildCreatedAt = buildCreatedAt;
+    }
+
+    public Date getBuildStartedAt() {
+        return buildStartedAt;
+    }
+
+    public void setBuildStartedAt(Date buildStartedAt) {
+        this.buildStartedAt = buildStartedAt;
+    }
+
+    public Date getBuildFinishedAt() {
+        return buildFinishedAt;
+    }
+
+    public void setBuildFinishedAt(Date buildFinishedAt) {
+        this.buildFinishedAt = buildFinishedAt;
+    }
+
+    public Integer getBuildDuration() {
+        return buildDuration;
+    }
+
+    public void setBuildDuration(Integer buildDuration) {
+        this.buildDuration = buildDuration;
+    }
+
+    public Double getBuildQueuedDuration() {
+        return buildQueuedDuration;
+    }
+
+    public void setBuildQueuedDuration(Double buildQueuedDuration) {
+        this.buildQueuedDuration = buildQueuedDuration;
+    }
+
+    public Boolean getBuildAllowFailure() {
+        return buildAllowFailure;
+    }
+
+    public void setBuildAllowFailure(Boolean buildAllowFailure) {
+        this.buildAllowFailure = buildAllowFailure;
+    }
+
+    public String getBuildFailureReason() {
+        return buildFailureReason;
+    }
+
+    public void setBuildFailureReason(String buildFailureReason) {
+        this.buildFailureReason = buildFailureReason;
+    }
+
+    public Integer getRetriesCount() {
+        return retriesCount;
+    }
+
+    public void setRetriesCount(Integer retriesCount) {
+        this.retriesCount = retriesCount;
+    }
+
+    public Integer getPipelineId() {
+        return pipelineId;
+    }
+
+    public void setPipelineId(Integer pipelineId) {
+        this.pipelineId = pipelineId;
+    }
+
     public Long getProjectId() {
         return projectId;
     }
@@ -181,6 +301,22 @@ public class JobEvent extends AbstractEvent {
 
     public void setRepository(EventRepository repository) {
         this.repository = repository;
+    }
+
+    public EventProject getProject() {
+        return project;
+    }
+
+    public void setProject(EventProject project) {
+        this.project = project;
+    }
+
+    public Runner getRunner() {
+        return runner;
+    }
+
+    public void setRunner(Runner runner) {
+        this.runner = runner;
     }
 
     @Override

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
@@ -2,14 +2,13 @@ package org.gitlab4j.api.webhook;
 
 import java.util.Date;
 
-import org.gitlab4j.api.models.Runner;
 import org.gitlab4j.models.utils.JacksonJson;
 
 public class JobEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
     public static final String JOB_HOOK_X_GITLAB_EVENT = "Job Hook";
-    public static final String OBJECT_KIND = "build";
+    public static final String OBJECT_KIND = "job";
 
     private String ref;
     private Boolean tag;
@@ -24,26 +23,11 @@ public class JobEvent extends AbstractEvent {
     private Integer jobDuration;
     private Boolean jobAllowFailure;
     private String jobFailureReason;
-    private Long buildId;
-    private String buildName;
-    private String buildStage;
-    private String buildStatus;
-    private Date buildCreatedAt;
-    private Date buildStartedAt;
-    private Date buildFinishedAt;
-    private Integer buildDuration;
-    private Double buildQueuedDuration;
-    private Boolean buildAllowFailure;
-    private String buildFailureReason;
-    private Integer retriesCount;
-    private Integer pipelineId;
     private Long projectId;
     private String projectName;
     private EventUser user;
     private BuildCommit commit;
     private EventRepository repository;
-    private EventProject project;
-    private Runner runner;
 
     @Override
     public String getObjectKind() {
@@ -159,110 +143,6 @@ public class JobEvent extends AbstractEvent {
         this.jobFailureReason = jobFailureReason;
     }
 
-    public Long getBuildId() {
-        return buildId;
-    }
-
-    public void setBuildId(Long buildId) {
-        this.buildId = buildId;
-    }
-
-    public String getBuildName() {
-        return buildName;
-    }
-
-    public void setBuildName(String buildName) {
-        this.buildName = buildName;
-    }
-
-    public String getBuildStage() {
-        return buildStage;
-    }
-
-    public void setBuildStage(String buildStage) {
-        this.buildStage = buildStage;
-    }
-
-    public String getBuildStatus() {
-        return buildStatus;
-    }
-
-    public void setBuildStatus(String buildStatus) {
-        this.buildStatus = buildStatus;
-    }
-
-    public Date getBuildCreatedAt() {
-        return buildCreatedAt;
-    }
-
-    public void setBuildCreatedAt(Date buildCreatedAt) {
-        this.buildCreatedAt = buildCreatedAt;
-    }
-
-    public Date getBuildStartedAt() {
-        return buildStartedAt;
-    }
-
-    public void setBuildStartedAt(Date buildStartedAt) {
-        this.buildStartedAt = buildStartedAt;
-    }
-
-    public Date getBuildFinishedAt() {
-        return buildFinishedAt;
-    }
-
-    public void setBuildFinishedAt(Date buildFinishedAt) {
-        this.buildFinishedAt = buildFinishedAt;
-    }
-
-    public Integer getBuildDuration() {
-        return buildDuration;
-    }
-
-    public void setBuildDuration(Integer buildDuration) {
-        this.buildDuration = buildDuration;
-    }
-
-    public Double getBuildQueuedDuration() {
-        return buildQueuedDuration;
-    }
-
-    public void setBuildQueuedDuration(Double buildQueuedDuration) {
-        this.buildQueuedDuration = buildQueuedDuration;
-    }
-
-    public Boolean getBuildAllowFailure() {
-        return buildAllowFailure;
-    }
-
-    public void setBuildAllowFailure(Boolean buildAllowFailure) {
-        this.buildAllowFailure = buildAllowFailure;
-    }
-
-    public String getBuildFailureReason() {
-        return buildFailureReason;
-    }
-
-    public void setBuildFailureReason(String buildFailureReason) {
-        this.buildFailureReason = buildFailureReason;
-    }
-
-    public Integer getRetriesCount() {
-        return retriesCount;
-    }
-
-    public void setRetriesCount(Integer retriesCount) {
-        this.retriesCount = retriesCount;
-    }
-
-    public Integer getPipelineId() {
-        return pipelineId;
-    }
-
-    public void setPipelineId(Integer pipelineId) {
-        this.pipelineId = pipelineId;
-    }
-
     public Long getProjectId() {
         return projectId;
     }
@@ -301,22 +181,6 @@ public class JobEvent extends AbstractEvent {
 
     public void setRepository(EventRepository repository) {
         this.repository = repository;
-    }
-
-    public EventProject getProject() {
-        return project;
-    }
-
-    public void setProject(EventProject project) {
-        this.project = project;
-    }
-
-    public Runner getRunner() {
-        return runner;
-    }
-
-    public void setRunner(Runner runner) {
-        this.runner = runner;
     }
 
     @Override

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/JobEvent.java
@@ -9,7 +9,7 @@ public class JobEvent extends AbstractEvent {
     private static final long serialVersionUID = 1L;
 
     public static final String JOB_HOOK_X_GITLAB_EVENT = "Job Hook";
-    public static final String OBJECT_KIND = "job";
+    public static final String OBJECT_KIND = "build";
 
     private String ref;
     private Boolean tag;

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/PipelineEvent.java
@@ -3,6 +3,7 @@ package org.gitlab4j.api.webhook;
 import java.util.Date;
 import java.util.List;
 
+import org.gitlab4j.api.models.Build;
 import org.gitlab4j.api.models.Job;
 import org.gitlab4j.api.models.Variable;
 import org.gitlab4j.models.utils.JacksonJson;
@@ -14,10 +15,12 @@ public class PipelineEvent extends AbstractEvent {
     public static final String OBJECT_KIND = "pipeline";
 
     private ObjectAttributes objectAttributes;
+    private EventMergeRequest mergeRequest;
     private EventUser user;
     private EventProject project;
     private EventCommit commit;
     private List<Job> jobs;
+    private List<Build> builds;
 
     public String getObjectKind() {
         return (OBJECT_KIND);
@@ -34,6 +37,14 @@ public class PipelineEvent extends AbstractEvent {
 
     public void setObjectAttributes(ObjectAttributes objectAttributes) {
         this.objectAttributes = objectAttributes;
+    }
+
+    public EventMergeRequest getMergeRequest() {
+        return mergeRequest;
+    }
+
+    public void setMergeRequest(EventMergeRequest mergeRequest) {
+        this.mergeRequest = mergeRequest;
     }
 
     public EventUser getUser() {
@@ -68,21 +79,33 @@ public class PipelineEvent extends AbstractEvent {
         this.jobs = jobs;
     }
 
+    public List<Build> getBuilds() {
+        return builds;
+    }
+
+    public void setBuilds(List<Build> builds) {
+        this.builds = builds;
+    }
+
     public static class ObjectAttributes {
 
         private Long id;
+        private Long iid;
+        private String name;
         private String ref;
         private Boolean tag;
         private String sha;
         private String beforeSha;
         private String source;
         private String status;
+        private String detailedStatus;
         private List<String> stages;
         private Date createdAt;
         private Date finishedAt;
         private Integer duration;
         private Float queuedDuration;
         private List<Variable> variables;
+        private String url;
 
         public Long getId() {
             return id;
@@ -90,6 +113,22 @@ public class PipelineEvent extends AbstractEvent {
 
         public void setId(Long id) {
             this.id = id;
+        }
+
+        public Long getIid() {
+            return iid;
+        }
+
+        public void setIid(Long iid) {
+            this.iid = iid;
+        }
+
+        public String getName() {
+            return name;
+        }
+
+        public void setName(String name) {
+            this.name = name;
         }
 
         public String getRef() {
@@ -140,6 +179,14 @@ public class PipelineEvent extends AbstractEvent {
             this.status = status;
         }
 
+        public String getDetailedStatus() {
+            return detailedStatus;
+        }
+
+        public void setDetailedStatus(String detailedStatus) {
+            this.detailedStatus = detailedStatus;
+        }
+
         public List<String> getStages() {
             return stages;
         }
@@ -186,6 +233,14 @@ public class PipelineEvent extends AbstractEvent {
 
         public void setVariables(List<Variable> variables) {
             this.variables = variables;
+        }
+
+        public String getUrl() {
+            return url;
+        }
+
+        public void setUrl(String url) {
+            this.url = url;
         }
     }
 

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/WikiPageEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/WikiPageEvent.java
@@ -112,6 +112,8 @@ public class WikiPageEvent extends AbstractEvent {
         private String slug;
         private String url;
         private String action;
+        private String diffUrl;
+        private String versionId;
 
         public String getTitle() {
             return title;
@@ -167,6 +169,22 @@ public class WikiPageEvent extends AbstractEvent {
 
         public void setUrl(String url) {
             this.url = url;
+        }
+
+        public String getDiffUrl() {
+            return diffUrl;
+        }
+
+        public void setDiffUrl(String diffUrl) {
+            this.diffUrl = diffUrl;
+        }
+
+        public String getVersionId() {
+            return versionId;
+        }
+
+        public void setVersionId(String versionId) {
+            this.versionId = versionId;
         }
     }
 

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/build-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/build-event.json
@@ -4,16 +4,19 @@
 	"tag": false,
 	"before_sha": "8a49a94f1a7cd64985074cb11b1a42a7ab2d9b46",
 	"sha": "a890bee24574603c522c756b9346649fbec4c812",
+	"retries_count": 2,
 	"build_id": 214655258,
 	"build_name": "build1",
 	"build_stage": "build",
 	"build_status": "running",
+	"build_created_at": "2019-05-17T17:09:21Z",
 	"build_started_at": "2019-05-17T18:09:21Z",
+	"build_finished_at": "2019-05-17T19:09:21Z",
 	"build_duration": 0.05880817,
 	"build_queued_duration": 1095.5887,
 	"build_allow_failure": false,
 	"build_failure_reason": "unknown_failure",
-	"pipeline_id": 2366,	
+	"pipeline_id": 2366,
 	"project_id": 3115610,
 	"project_name": "GitLab4J / test-project",
 	"user": {
@@ -38,5 +41,28 @@
 		"git_http_url": "https://gitlab.com/gitlab4j/test-project.git",
 		"git_ssh_url": "git@gitlab.com:gitlab4j/test-project.git",
 		"visibility_level": 20
+	},
+	"project":{
+		"id": 380,
+		"name": "Gitlab Test",
+		"description": "Atque in sunt eos similique dolores voluptatem.",
+		"web_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+		"git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+		"git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+		"namespace": "Gitlab Org",
+		"visibility_level": 20,
+		"path_with_namespace": "gitlab-org/gitlab-test",
+		"default_branch": "master"
+	},
+	"runner": {
+		"active": true,
+		"runner_type": "project_type",
+		"is_shared": false,
+		"id": 380987,
+		"description": "shared-runners-manager-6.gitlab.com",
+		"tags": [
+			"linux",
+			"docker"
+		]
 	}
 }

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/issue-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/issue-event.json
@@ -29,17 +29,53 @@
   "object_attributes": {
     "id": 301,
     "title": "New API: create/update/delete file",
+    "assignee_ids": [51],
     "assignee_id": 51,
     "author_id": 51,
     "project_id": 14,
     "created_at": "2013-12-03T17:15:43Z",
     "updated_at": "2013-12-03T17:15:43Z",
     "position": 0,
+    "updated_by_id": 1,
+    "last_edited_at": "2013-12-03T18:15:43Z",
+    "last_edited_by_id": 1,
+    "relative_position": 0,
     "description": "Create new API for manipulations with repository",
     "state": "opened",
+    "milestone_id": "1",
+    "state_id": 1,
+    "confidential": false,
+    "discussion_locked": true,
+    "due_date": "2014-12-03T18:15:43Z",
+    "moved_to_id": 1,
+    "duplicated_to_id": 1,
+    "time_estimate": 1800,
+    "total_time_spent": 1800,
+    "time_change": 30,
+    "human_time_estimate": "30m",
+    "human_total_time_spent": "30m",
+    "human_time_change": "30s",
+    "weight": 1,
+    "health_status": "at_risk",
+    "type": "Issue",
     "iid": 23,
     "url": "http://example.com/diaspora/issues/23",
-    "action": "open"
+    "action": "open",
+    "severity": "high",
+    "labels": [
+      {
+        "id": 206,
+        "title": "API",
+        "color": "#ffffff",
+        "project_id": 14,
+        "created_at": "2013-12-03T17:15:43Z",
+        "updated_at": "2013-12-03T17:15:43Z",
+        "template": false,
+        "description": "API related issues",
+        "type": "ProjectLabel",
+        "group_id": 41
+      }
+    ]
   },
    "assignees": [{
     "name": "User1",
@@ -80,10 +116,6 @@
     "milestone_id": {
        "previous":0,
        "current":1
-    },
-    "confidential": {
-       "previous":false,
-       "current":true
     },
     "labels": {
       "previous": [{

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/job-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/job-event.json
@@ -10,6 +10,19 @@
   "job_status": "created",
   "job_allow_failure": false,
   "job_failure_reason": "script_failure",
+  "build_id": 1977,
+  "build_name": "test",
+  "build_stage": "test",
+  "build_status": "created",
+  "build_created_at": "2021-02-23T02:41:37.886Z",
+  "build_started_at": "2021-02-23T02:41:37.886Z",
+  "build_finished_at": "2021-02-23T02:41:37.886Z",
+  "build_duration": 2224,
+  "build_queued_duration": 1095.588715,
+  "build_allow_failure": false,
+  "build_failure_reason": "script_failure",
+  "retries_count": 2,
+  "pipeline_id": 2366,
   "project_id": 380,
   "project_name": "gitlab-org/gitlab-test",
   "user": {
@@ -19,11 +32,15 @@
   },
   "commit": {
     "id": 2366,
+    "name": "Build pipeline",
     "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
     "message": "test\n",
     "author_name": "User",
     "author_email": "user@gitlab.com",
-    "status": "created"
+    "status": "created",
+    "duration": 2264.0,
+    "started_at": "2025-04-09T17:00:09.082Z",
+    "finished_at": "2025-04-09T18:00:09.082Z"
   },
   "repository": {
     "name": "gitlab_test",
@@ -32,5 +49,28 @@
     "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
     "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
     "visibility_level": 20
+  },
+  "project":{
+    "id": 380,
+    "name": "Gitlab Test",
+    "description": "Atque in sunt eos similique dolores voluptatem.",
+    "web_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
+    "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
+    "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
+    "namespace": "Gitlab Org",
+    "visibility_level": 20,
+    "path_with_namespace": "gitlab-org/gitlab-test",
+    "default_branch": "master"
+  },
+  "runner": {
+    "active": true,
+    "runner_type": "project_type",
+    "is_shared": false,
+    "id": 380987,
+    "description": "shared-runners-manager-6.gitlab.com",
+    "tags": [
+      "linux",
+      "docker"
+    ]
   }
 }

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/job-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/job-event.json
@@ -10,19 +10,6 @@
   "job_status": "created",
   "job_allow_failure": false,
   "job_failure_reason": "script_failure",
-  "build_id": 1977,
-  "build_name": "test",
-  "build_stage": "test",
-  "build_status": "created",
-  "build_created_at": "2021-02-23T02:41:37.886Z",
-  "build_started_at": "2021-02-23T02:41:37.886Z",
-  "build_finished_at": "2021-02-23T02:41:37.886Z",
-  "build_duration": 2224,
-  "build_queued_duration": 1095.588715,
-  "build_allow_failure": false,
-  "build_failure_reason": "script_failure",
-  "retries_count": 2,
-  "pipeline_id": 2366,
   "project_id": 380,
   "project_name": "gitlab-org/gitlab-test",
   "user": {
@@ -32,15 +19,11 @@
   },
   "commit": {
     "id": 2366,
-    "name": "Build pipeline",
     "sha": "2293ada6b400935a1378653304eaf6221e0fdb8f",
     "message": "test\n",
     "author_name": "User",
     "author_email": "user@gitlab.com",
-    "status": "created",
-    "duration": 2264.0,
-    "started_at": "2025-04-09T17:00:09.082Z",
-    "finished_at": "2025-04-09T18:00:09.082Z"
+    "status": "created"
   },
   "repository": {
     "name": "gitlab_test",
@@ -49,28 +32,5 @@
     "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
     "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
     "visibility_level": 20
-  },
-  "project":{
-    "id": 380,
-    "name": "Gitlab Test",
-    "description": "Atque in sunt eos similique dolores voluptatem.",
-    "web_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test",
-    "git_ssh_url": "git@192.168.64.1:gitlab-org/gitlab-test.git",
-    "git_http_url": "http://192.168.64.1:3005/gitlab-org/gitlab-test.git",
-    "namespace": "Gitlab Org",
-    "visibility_level": 20,
-    "path_with_namespace": "gitlab-org/gitlab-test",
-    "default_branch": "master"
-  },
-  "runner": {
-    "active": true,
-    "runner_type": "project_type",
-    "is_shared": false,
-    "id": 380987,
-    "description": "shared-runners-manager-6.gitlab.com",
-    "tags": [
-      "linux",
-      "docker"
-    ]
   }
 }

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/pipeline-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/pipeline-event.json
@@ -2,6 +2,8 @@
    "object_kind": "pipeline",
    "object_attributes":{
       "id": 31,
+      "iid": 1,
+      "name": "Pipeline for branch: master",
       "ref": "master",
       "tag": false,
       "sha": "bcbb5ec396a2c0f828686f14fac9b80b780504f2",
@@ -22,12 +24,27 @@
           "key": "NESTOR_PROD_ENVIRONMENT",
           "value": "us-west-1"
         }
-      ]
+      ],
+      "url": "http://example.com/gitlab-org/gitlab-test/-/pipelines/31"
+   },
+   "merge_request": {
+      "id": 1,
+      "iid": 1,
+      "title": "Test",
+      "source_branch": "test",
+      "source_project_id": 1,
+      "target_branch": "master",
+      "target_project_id": 1,
+      "state": "opened",
+      "merge_status": "can_be_merged",
+      "detailed_merge_status": "mergeable",
+      "url": "http://192.168.64.1:3005/gitlab-org/gitlab-test/merge_requests/1"
    },
    "user":{
       "name": "Administrator",
       "username": "root",
-      "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon"
+      "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+      "email": "user_email@gitlab.com"
    },
    "project":{
       "id": 1,
@@ -155,5 +172,139 @@
          "artifacts_file":{
          }
       }
-   ]
+   ],
+    "builds":[
+    {
+      "id": 380,
+      "stage": "deploy",
+      "name": "production",
+      "status": "skipped",
+      "created_at": "2016-08-12T15:23:28Z",
+      "when": "manual",
+      "manual": true,
+      "allow_failure": false,
+      "user":{
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+        "email": "admin@example.com"
+      }
+    },
+    {
+      "id": 377,
+      "stage": "test",
+      "name": "test-image",
+      "status": "success",
+      "created_at": "2016-08-12T15:23:28Z",
+      "started_at": "2016-08-12T15:26:12Z",
+      "finished_at": "2016-08-12T15:26:29Z",
+      "duration": 17.0,
+      "queued_duration": 196.0,
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user":{
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+        "email": "admin@example.com"
+      },
+      "runner": {
+        "id": 380987,
+        "description": "shared-runners-manager-6.gitlab.com",
+        "active": true,
+        "runner_type": "instance_type",
+        "is_shared": true,
+        "tags": [
+          "linux",
+          "docker",
+          "shared-runner"
+        ]
+      }
+    },
+    {
+      "id": 378,
+      "stage": "test",
+      "name": "test-build",
+      "status": "failed",
+      "created_at": "2016-08-12T15:23:28Z",
+      "started_at": "2016-08-12T15:26:12Z",
+      "finished_at": "2016-08-12T15:26:29Z",
+      "duration": 17.0,
+      "queued_duration": 196.0,
+      "failure_reason": "script_failure",
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user":{
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+        "email": "admin@example.com"
+      },
+      "runner": {
+        "id":380987,
+        "description":"shared-runners-manager-6.gitlab.com",
+        "active":true,
+        "runner_type": "instance_type",
+        "is_shared": true,
+        "tags": [
+          "linux",
+          "docker"
+        ]
+      }
+    },
+    {
+      "id": 376,
+      "stage": "build",
+      "name": "build-image",
+      "status": "success",
+      "created_at": "2016-08-12T15:23:28Z",
+      "started_at": "2016-08-12T15:24:56Z",
+      "finished_at": "2016-08-12T15:25:26Z",
+      "duration": 17.0,
+      "queued_duration": 196.0,
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user":{
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+        "email": "admin@example.com"
+      },
+      "runner": {
+        "id": 380987,
+        "description": "shared-runners-manager-6.gitlab.com",
+        "active": true,
+        "runner_type": "instance_type",
+        "is_shared": true,
+        "tags": [
+          "linux",
+          "docker"
+        ]
+      }
+    },
+    {
+      "id": 379,
+      "stage": "deploy",
+      "name": "staging",
+      "status": "created",
+      "created_at": "2016-08-12T15:23:28Z",
+      "when": "on_success",
+      "manual": false,
+      "allow_failure": false,
+      "user":{
+        "id": 1,
+        "name": "Administrator",
+        "username": "root",
+        "avatar_url": "http://www.gravatar.com/avatar/e32bd13e2add097461cb96824b7a829c?s=80\u0026d=identicon",
+        "email": "admin@example.com"
+      }
+    }
+  ]
 }

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/push-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/push-event.json
@@ -1,8 +1,10 @@
 {
   "object_kind": "push",
+  "event_name": "push",
   "before": "95790bf891e76fee5e1747ab589903a6a1f80f22",
   "after": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "ref": "refs/heads/master",
+  "ref_protected": true,
   "checkout_sha": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
   "user_id": 4,
   "user_name": "John Smith",
@@ -11,6 +13,7 @@
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 15,
   "project":{
+    "id": 15,
     "name":"Diaspora",
     "description":"",
     "web_url":"http://example.com/mike/diaspora",
@@ -37,7 +40,8 @@
   "commits": [
     {
       "id": "b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
-      "message": "Update Catalan translation to e38cb41.",
+      "message": "Update Catalan translation to e38cb41.\n\nSee https://gitlab.com/gitlab-org/gitlab for more information",
+      "title": "Update Catalan translation to e38cb41.",
       "timestamp": "2011-12-12T14:27:31Z",
       "url": "http://example.com/mike/diaspora/commit/b6568db1bc1dcd7f8b4d5a946b0b91f9dacd7327",
       "author": {
@@ -51,6 +55,7 @@
     {
       "id": "da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "message": "fixed readme",
+      "title": "fixed readme",
       "timestamp": "2012-01-03T23:36:29Z",
       "url": "http://example.com/mike/diaspora/commit/da1560886d4f094c3e6c9ef40349f7d38b5d27d7",
       "author": {

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/tag-push-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/tag-push-event.json
@@ -1,14 +1,17 @@
 {
   "object_kind": "tag_push",
+  "event_name": "tag_push",
   "before": "0000000000000000000000000000000000000000",
   "after": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
   "ref": "refs/tags/v1.0.0",
+  "ref_protected": true,
   "checkout_sha": "82b3d5ae55f7080f1e6022629cdb57bfae7cccc7",
   "user_id": 1,
   "user_name": "John Smith",
   "user_avatar": "https://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=8://s.gravatar.com/avatar/d4c74594d841139328695756648b6bd6?s=80",
   "project_id": 1,
   "project":{
+    "id": 1,
     "name":"Example",
     "description":"",
     "web_url":"http://example.com/jsmith/example",

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/wiki-page-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/wiki-page-event.json
@@ -34,6 +34,9 @@
     "message": "adding an awesome page to the wiki",
     "slug": "awesome",
     "url": "http://example.com/root/awesome-project/wikis/awesome",
-    "action": "create"
+    "action": "create",
+    "diff_url": "http://example.com/root/awesome-project/-/wikis/home/diff?version_id=78ee4a6705abfbff4f4132c6646dbaae9c8fb6ec",
+    "version_id": "3ad67c972065298d226dd80b2b03e0fc2421e731"
+
   }
 }


### PR DESCRIPTION
Updated the following events with missing properties
- `AbstractPushEvent`
- `BuildCommit`
- `EventCommit`
- `EventIssue`
- `JobEvent`
- `PipelineEvent`
- `WikiPageEvent`

Especially, `PipelineEvent` and `JobEvent` have changed.

`PipelineEvent`  no longer uses a `jobs` array (`Job`), but a `builds` array (`Build`). I have not removed the `jobs` array for backwards compatibility.

`JobEvent` no longer uses `job` prefixed properties, but `build` prefixed properties. I have not removed the `job` prefixed properties for backwards compatibility. I did change the object_kind to `build` as it should be according to the docs (used to be `job` in version 12.x, but changed to `build` in version 13.x). This might break backwards compatibility.