### PR TITLE
Add associations count for users

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/UserApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/UserApi.java
@@ -13,6 +13,7 @@ import jakarta.ws.rs.core.GenericType;
 import jakarta.ws.rs.core.Response;
 
 import org.gitlab4j.api.GitLabApi.ApiVersion;
+import org.gitlab4j.api.models.Associations;
 import org.gitlab4j.api.models.CustomAttribute;
 import org.gitlab4j.api.models.Email;
 import org.gitlab4j.api.models.Exists;
@@ -1500,6 +1501,20 @@ public class UserApi extends AbstractApi {
     public Pager<Membership> getMemberships(Long userId, int itemsPerPage) throws GitLabApiException {
         GitLabApiForm formData = new GitLabApiForm();
         return (new Pager<>(this, Membership.class, itemsPerPage, formData.asMap(), "users", userId, "memberships"));
+    }
+
+    /**
+     * Get a count of a user’s projects, groups, issues, and merge requests
+     *
+     * <pre><code>GitLab Endpoint: GET /user/:id/associations_count</code></pre>
+     *
+     * @param userId the ID of the user to get the associations for
+     * @return the count of each type of association
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Associations getAssociationsCount(Long userId) throws GitLabApiException {
+        Response response = get(Response.Status.OK, null, "users", userId, "associations_count");
+        return (response.readEntity(Associations.class));
     }
 
     /**

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Associations.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Associations.java
@@ -1,0 +1,51 @@
+package org.gitlab4j.api.models;
+
+import java.io.Serializable;
+
+import org.gitlab4j.models.utils.JacksonJson;
+
+public class Associations implements Serializable {
+    private static final long serialVersionUID = 1L;
+
+    private int groupsCount;
+    private int projectsCount;
+    private int issuesCount;
+    private int mergeRequestsCount;
+
+    public int getGroupsCount() {
+        return groupsCount;
+    }
+
+    public void setGroupsCount(int groupsCount) {
+        this.groupsCount = groupsCount;
+    }
+
+    public int getProjectsCount() {
+        return projectsCount;
+    }
+
+    public void setProjectsCount(int projectsCount) {
+        this.projectsCount = projectsCount;
+    }
+
+    public int getIssuesCount() {
+        return issuesCount;
+    }
+
+    public void setIssuesCount(int issuesCount) {
+        this.issuesCount = issuesCount;
+    }
+
+    public int getMergeRequestsCount() {
+        return mergeRequestsCount;
+    }
+
+    public void setMergeRequestsCount(int mergeRequestsCount) {
+        this.mergeRequestsCount = mergeRequestsCount;
+    }
+
+    @Override
+    public String toString() {
+        return (JacksonJson.toJsonString(this));
+    }
+}

--- a/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiBeans.java
+++ b/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiBeans.java
@@ -54,6 +54,12 @@ public class TestGitLabApiBeans {
     }
 
     @Test
+    public void testAssociations() throws Exception {
+        Associations associations = unmarshalResource(Associations.class, "associations.json");
+        assertTrue(compareJson(associations, "associations.json"));
+    }
+
+    @Test
     public void testAuditEvent() throws Exception {
         List<AuditEvent> auditEvents = unmarshalResourceList(AuditEvent.class, "audit-events.json");
         assertTrue(compareJson(auditEvents, "audit-events.json"));

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/associations.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/associations.json
@@ -1,0 +1,6 @@
+{
+  "groups_count": 2,
+  "projects_count": 3,
+  "issues_count": 8,
+  "merge_requests_count": 5
+}


### PR DESCRIPTION
Based on https://docs.gitlab.com/api/users/#get-a-count-of-a-users-projects-groups-issues-and-merge-requests