### PR TITLE
Resolved mismatch stubbings in TestGitLabApiEvents.java

### DIFF
--- a/gitlab4j-api/src/test/java/org/gitlab4j/api/TestGitLabApiEvents.java
+++ b/gitlab4j-api/src/test/java/org/gitlab4j/api/TestGitLabApiEvents.java
@@ -52,6 +52,7 @@ public class TestGitLabApiEvents {
         // Arrange
         HttpServletRequest request = mock(HttpServletRequest.class);
         given(request.getHeader("X-Gitlab-Event")).willReturn(SystemHookManager.SYSTEM_HOOK_EVENT);
+        given(request.getHeader("X-Gitlab-Token")).willReturn(null);
 
         JsonNode tree = readTreeFromResource("merge-request-system-hook-event.json");
         ((ObjectNode) tree).remove("event_name");


### PR DESCRIPTION
I analyzed the test doubles (mocks) in the test code of the project. In my analysis of the project, I observed that

In the test `testSystemHookManagerHandleEvent`:

* The `getHeader` method for the `request` object:
i) during test execution the method is actually called with argument `"X-Gitlab-Token"`, but is not stubbed, resulting in a mismatch stubbing

In general, a mismatched stubbing occurs when a method is stubbed with specific arguments in a test but later invoked with different arguments in the code. Mockito recommends addressing this type of issue (https://www.javadoc.io/doc/org.mockito/mockito-core/latest/org.mockito/org/mockito/exceptions/misusing/PotentialStubbingProblem.html).

I propose a solution below to resolve the mismatch stubbing. Happy to modify the pull request based on your feedback.