### PR TITLE
Replace unmappable character causing Windows build failure

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Setting.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Setting.java
@@ -1131,8 +1131,8 @@ public enum Setting {
     USER_OAUTH_APPLICATIONS(Boolean.class),
 
     /**
-     * When set to false disable the “You won’t be able to pull or push project code
-     * via SSH” warning shown to users with no uploaded SSH key.
+     * When set to false disable the "You won’t be able to pull or push project code
+     * via SSH" warning shown to users with no uploaded SSH key.
      */
     USER_SHOW_ADD_SSH_KEY_MESSAGE(Boolean.class),
 


### PR DESCRIPTION
The special quote character was causing a build failure on Windows: 

```java
Setting.java:1135: error: unmappable character (0x9D) for encoding windows-1252
     * via SSH�? warning shown to users with no uploaded SSH key.
```