### PR TITLE
Fix "after" and "before" parameters in GroupApi#getAuditEvents()

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/AuditEventApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/AuditEventApi.java
@@ -25,16 +25,16 @@ public class AuditEventApi extends AbstractApi {
      *
      * <pre><code>GET /audit_events/</code></pre>
      *
-     * @param created_after Return group audit events created on or after the given time.
-     * @param created_before Return group audit events created on or before the given time.
+     * @param createdAfter Return group audit events created on or after the given time.
+     * @param createdBefore Return group audit events created on or before the given time.
      * @param entityType Return audit events for the given entity type. Valid values are: User, Group, or Project.
      * @param entityId Return audit events for the given entity ID. Requires entityType attribute to be present.
      * @return a List of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public List<AuditEvent> getAuditEvents(Date created_after, Date created_before, String entityType, Long entityId)
+    public List<AuditEvent> getAuditEvents(Date createdAfter, Date createdBefore, String entityType, Long entityId)
             throws GitLabApiException {
-        return (getAuditEvents(created_after, created_before, entityType, entityId, getDefaultPerPage())
+        return (getAuditEvents(createdAfter, createdBefore, entityType, entityId, getDefaultPerPage())
                 .all());
     }
 
@@ -43,8 +43,8 @@ public class AuditEventApi extends AbstractApi {
      *
      * <pre><code>GET /audit_events</code></pre>
      *
-     * @param created_after Return group audit events created on or after the given time.
-     * @param created_before Return group audit events created on or before the given time.
+     * @param createdAfter Return group audit events created on or after the given time.
+     * @param createdBefore Return group audit events created on or before the given time.
      * @param entityType Return audit events for the given entity type. Valid values are: User, Group, or Project.
      * @param entityId Return audit events for the given entity ID. Requires entityType attribute to be present.
      * @param itemsPerPage the number of Audit Event instances that will be fetched per page
@@ -52,11 +52,11 @@ public class AuditEventApi extends AbstractApi {
      * @throws GitLabApiException if any exception occurs
      */
     public Pager<AuditEvent> getAuditEvents(
-            Date created_after, Date created_before, String entityType, Long entityId, int itemsPerPage)
+            Date createdAfter, Date createdBefore, String entityType, Long entityId, int itemsPerPage)
             throws GitLabApiException {
         Form form = new GitLabApiForm()
-                .withParam("created_before", ISO8601.toString(created_before, false))
-                .withParam("created_after", ISO8601.toString(created_after, false))
+                .withParam("created_after", ISO8601.toString(createdAfter, false))
+                .withParam("created_before", ISO8601.toString(createdBefore, false))
                 .withParam("entity_type", entityType)
                 .withParam("entity_id", entityId);
         return (new Pager<AuditEvent>(this, AuditEvent.class, itemsPerPage, form.asMap(), "audit_events"));

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -1768,14 +1768,14 @@ public class GroupApi extends AbstractApi {
      * <pre><code>GET /groups/:id/audit_events</code></pre>
      *
      * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
+     * @param createdAfter Group audit events created on or after the given time.
+     * @param createdBefore Group audit events created on or before the given time.
      * @return a List of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public List<AuditEvent> getAuditEvents(Object groupIdOrPath, Date created_after, Date created_before)
+    public List<AuditEvent> getAuditEvents(Object groupIdOrPath, Date createdAfter, Date createdBefore)
             throws GitLabApiException {
-        return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage())
+        return (getAuditEvents(groupIdOrPath, createdAfter, createdBefore, getDefaultPerPage())
                 .all());
     }
 
@@ -1785,17 +1785,18 @@ public class GroupApi extends AbstractApi {
      * <pre><code>GET /groups/:id/audit_events</code></pre>
      *
      * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
+     * @param createdAfter Group audit events created on or after the given time.
+     * @param createdBefore Group audit events created on or before the given time.
      * @param itemsPerPage the number of Audit Event instances that will be fetched per page
      * @return a Pager of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
     public Pager<AuditEvent> getAuditEvents(
-            Object groupIdOrPath, Date created_after, Date created_before, int itemsPerPage) throws GitLabApiException {
+            Object groupIdOrPath, Date createdAfter, Date createdBefore, int itemsPerPage) throws GitLabApiException {
         Form form = new GitLabApiForm()
-                .withParam("created_before", ISO8601.toString(created_after, false))
-                .withParam("created_after", ISO8601.toString(created_before, false));
+                .withParam("created_after", ISO8601.toString(createdAfter, false))
+                .withParam("created_before", ISO8601.toString(createdBefore, false));
+
         return (new Pager<AuditEvent>(
                 this,
                 AuditEvent.class,
@@ -1812,14 +1813,14 @@ public class GroupApi extends AbstractApi {
      * <pre><code>GET /groups/:id/audit_events</code></pre>
      *
      * @param groupIdOrPath the group ID, path of the group, or a Group instance holding the group ID or path
-     * @param created_after Group audit events created on or after the given time.
-     * @param created_before Group audit events created on or before the given time.
+     * @param createdAfter Group audit events created on or after the given time.
+     * @param createdBefore Group audit events created on or before the given time.
      * @return a Stream of group Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<AuditEvent> getAuditEventsStream(Object groupIdOrPath, Date created_after, Date created_before)
+    public Stream<AuditEvent> getAuditEventsStream(Object groupIdOrPath, Date createdAfter, Date createdBefore)
             throws GitLabApiException {
-        return (getAuditEvents(groupIdOrPath, created_after, created_before, getDefaultPerPage()).stream());
+        return (getAuditEvents(groupIdOrPath, createdAfter, createdBefore, getDefaultPerPage()).stream());
     }
 
     /**

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -3424,14 +3424,14 @@ public class ProjectApi extends AbstractApi implements Constants {
      * <pre><code>GET /projects/:id/audit_events</code></pre>
      *
      * @param projectIdOrPath the project ID, path of the project, or a project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
+     * @param createdAfter Project audit events created on or after the given time.
+     * @param createdBefore Project audit events created on or before the given time.
      * @return a List of project Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public List<AuditEvent> getAuditEvents(Object projectIdOrPath, Date created_after, Date created_before)
+    public List<AuditEvent> getAuditEvents(Object projectIdOrPath, Date createdAfter, Date createdBefore)
             throws GitLabApiException {
-        return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage())
+        return (getAuditEvents(projectIdOrPath, createdAfter, createdBefore, getDefaultPerPage())
                 .all());
     }
 
@@ -3441,18 +3441,17 @@ public class ProjectApi extends AbstractApi implements Constants {
      * <pre><code>GET /projects/:id/audit_events</code></pre>
      *
      * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
+     * @param createdAfter Project audit events created on or after the given time.
+     * @param createdBefore Project audit events created on or before the given time.
      * @param itemsPerPage the number of Audit Event instances that will be fetched per page
      * @return a Pager of project Audit events
      * @throws GitLabApiException if any exception occurs
      */
     public Pager<AuditEvent> getAuditEvents(
-            Object projectIdOrPath, Date created_after, Date created_before, int itemsPerPage)
-            throws GitLabApiException {
+            Object projectIdOrPath, Date createdAfter, Date createdBefore, int itemsPerPage) throws GitLabApiException {
         Form form = new GitLabApiForm()
-                .withParam("created_before", ISO8601.toString(created_before, false))
-                .withParam("created_after", ISO8601.toString(created_after, false));
+                .withParam("created_after", ISO8601.toString(createdAfter, false))
+                .withParam("created_before", ISO8601.toString(createdBefore, false));
         return (new Pager<AuditEvent>(
                 this,
                 AuditEvent.class,
@@ -3469,14 +3468,14 @@ public class ProjectApi extends AbstractApi implements Constants {
      * <pre><code>GET /projects/:id/audit_events</code></pre>
      *
      * @param projectIdOrPath the project ID, path of the project, or a Project instance holding the project ID or path
-     * @param created_after Project audit events created on or after the given time.
-     * @param created_before Project audit events created on or before the given time.
+     * @param createdAfter Project audit events created on or after the given time.
+     * @param createdBefore Project audit events created on or before the given time.
      * @return a Stream of project Audit events
      * @throws GitLabApiException if any exception occurs
      */
-    public Stream<AuditEvent> getAuditEventsStream(Object projectIdOrPath, Date created_after, Date created_before)
+    public Stream<AuditEvent> getAuditEventsStream(Object projectIdOrPath, Date createdAfter, Date createdBefore)
             throws GitLabApiException {
-        return (getAuditEvents(projectIdOrPath, created_after, created_before, getDefaultPerPage()).stream());
+        return (getAuditEvents(projectIdOrPath, createdAfter, createdBefore, getDefaultPerPage()).stream());
     }
 
     /**


### PR DESCRIPTION
* In `GroupApi#getAuditEvents()` the parameters `created_after` and `created_before` are inverted.
* In `GroupApi`, `ProjectApi` and `AuditEventApi`, fix the parameters name (camelCase).
     - `createdAfter` instead of `created_after`
     - `createdBefore` instead of `created_before`

Fixes #1262