### PR TITLE
Expose ci_delete_pipelines_in_seconds via Project API

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1074,6 +1074,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * ciConfigPath (optional) - Set path to CI configuration file
      * autoDevopsEnabled (optional) - Enable Auto DevOps for this project
      * squashOption (optional) - set squash option for merge requests
+     * ciDeletePipelinesInSeconds (optional) - set the automatic pipeline cleanup time in seconds
      *
      * @param project the Project instance with the configuration for the new project
      * @param importUrl the URL to import the repository from
@@ -1125,6 +1126,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("build_git_strategy", project.getBuildGitStrategy())
                 .withParam("build_coverage_regex", project.getBuildCoverageRegex())
                 .withParam("ci_config_path", project.getCiConfigPath())
+                .withParam("ci_delete_pipelines_in_seconds", project.getCiDeletePipelinesInSeconds())
                 .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
                 .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())
                 .withParam("auto_devops_enabled", project.getAutoDevopsEnabled())
@@ -1445,6 +1447,7 @@ public class ProjectApi extends AbstractApi implements Constants {
      * ciConfigPath (optional) - Set path to CI configuration file
      * ciForwardDeploymentEnabled (optional) - When a new deployment job starts, skip older deployment jobs that are still pending
      * squashOption (optional) - set squash option for merge requests
+     * ciDeletePipelinesInSeconds (optional) - set the automatic pipeline cleanup time in seconds
      *
      * NOTE: The following parameters specified by the GitLab API edit project are not supported:
      *     import_url
@@ -1494,6 +1497,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("build_coverage_regex", project.getBuildCoverageRegex())
                 .withParam("ci_config_path", project.getCiConfigPath())
                 .withParam("ci_forward_deployment_enabled", project.getCiForwardDeploymentEnabled())
+                .withParam("ci_delete_pipelines_in_seconds", project.getCiDeletePipelinesInSeconds())
                 .withParam("merge_method", project.getMergeMethod())
                 .withParam("suggestion_commit_message", project.getSuggestionCommitMessage())
                 .withParam("remove_source_branch_after_merge", project.getRemoveSourceBranchAfterMerge())

--- a/gitlab4j-api/src/test/java/org/gitlab4j/api/TestProjectApi.java
+++ b/gitlab4j-api/src/test/java/org/gitlab4j/api/TestProjectApi.java
@@ -274,7 +274,8 @@ public class TestProjectApi extends AbstractIntegrationTest {
                 .withTagList(Arrays.asList("tag1", "tag2"))
                 .withMergeMethod(Project.MergeMethod.MERGE)
                 .withSuggestionCommitMessage("SuggestionCommitMessageOriginal")
-                .withRemoveSourceBranchAfterMerge(false);
+                .withRemoveSourceBranchAfterMerge(false)
+                .withCiDeletePipelineInSeconds(3600);
 
         Project newProject = gitLabApi.getProjectApi().createProject(project);
         assertNotNull(newProject);
@@ -289,6 +290,7 @@ public class TestProjectApi extends AbstractIntegrationTest {
         assertEquals(Project.MergeMethod.MERGE, newProject.getMergeMethod());
         assertEquals(project.getSuggestionCommitMessage(), newProject.getSuggestionCommitMessage());
         assertEquals(project.getRemoveSourceBranchAfterMerge(), newProject.getRemoveSourceBranchAfterMerge());
+        assertEquals(project.getCiDeletePipelinesInSeconds(), newProject.getCiDeletePipelinesInSeconds());
 
         project = new Project()
                 .withId(newProject.getId())

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Project.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/Project.java
@@ -155,6 +155,7 @@ public class Project implements Serializable {
     private String ciRestrictPipelineCancellationRole;
     private String ciPipelineVariablesMinimumOverrideRole;
     private Boolean ciPushRepositoryForJobTokenAllowed;
+    private Integer ciDeletePipelinesInSeconds;
     private Boolean allowPipelineTriggerApproveDeployment;
     private Boolean restrictUserDefinedVariables;
     private Boolean enforceAuthChecksOnUploads;
@@ -1381,6 +1382,19 @@ public class Project implements Serializable {
 
     public void setCiPushRepositoryForJobTokenAllowed(Boolean ciPushRepositoryForJobTokenAllowed) {
         this.ciPushRepositoryForJobTokenAllowed = ciPushRepositoryForJobTokenAllowed;
+    }
+
+    public Integer getCiDeletePipelinesInSeconds() {
+        return ciDeletePipelinesInSeconds;
+    }
+
+    public void setCiDeletePipelinesInSeconds(Integer ciDeletePipelinesInSeconds) {
+        this.ciDeletePipelinesInSeconds = ciDeletePipelinesInSeconds;
+    }
+
+    public Project withCiDeletePipelineInSeconds(Integer ciDeletePipelineInSeconds) {
+        this.ciDeletePipelinesInSeconds = ciDeletePipelineInSeconds;
+        return this;
     }
 
     public Boolean getAllowPipelineTriggerApproveDeployment() {

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/project.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/project.json
@@ -194,5 +194,6 @@
   "requirements_access_level" : "enabled",
   "security_and_compliance_access_level" : "private",
   "snippets_access_level" : "enabled",
-  "wiki_access_level" : "enabled"
+  "wiki_access_level" : "enabled",
+  "ci_delete_pipelines_in_seconds": 604800
 }


### PR DESCRIPTION
Since gitlab 17.9, it is possible to configure a project variable after which project pipelines get deleted automatically.

This commit exposes this setting via the Project API.