### PR TITLE
add user_update_for_group and  event to SystemHookEvent

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/GroupMemberSystemHookEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/GroupMemberSystemHookEvent.java
@@ -9,6 +9,7 @@ public class GroupMemberSystemHookEvent extends AbstractSystemHookEvent {
 
     public static final String NEW_GROUP_MEMBER_EVENT = "user_add_to_group";
     public static final String GROUP_MEMBER_REMOVED_EVENT = "user_remove_from_group";
+    public static final String GROUP_MEMBER_UPDATE_EVENT = "user_update_for_group";
 
     private Date createdAt;
     private Date updatedAt;

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
@@ -40,6 +40,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(
             value = RemoveGroupMemberSystemHookEvent.class,
             name = GroupMemberSystemHookEvent.GROUP_MEMBER_REMOVED_EVENT),
+    @JsonSubTypes.Type(
+            value = UpdateGroupMemberSystemHookEvent.class,
+            name = GroupMemberSystemHookEvent.GROUP_MEMBER_UPDATE_EVENT),
     @JsonSubTypes.Type(value = PushSystemHookEvent.class, name = PushSystemHookEvent.PUSH_EVENT),
     @JsonSubTypes.Type(value = TagPushSystemHookEvent.class, name = TagPushSystemHookEvent.TAG_PUSH_EVENT),
     @JsonSubTypes.Type(
@@ -140,5 +143,9 @@ class NewGroupMemberSystemHookEvent extends GroupMemberSystemHookEvent {
 }
 
 class RemoveGroupMemberSystemHookEvent extends GroupMemberSystemHookEvent {
+    private static final long serialVersionUID = 1L;
+}
+
+class UpdateGroupMemberSystemHookEvent extends GroupMemberSystemHookEvent {
     private static final long serialVersionUID = 1L;
 }

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/SystemHookEvent.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo;
     @JsonSubTypes.Type(
             value = RemoveTeamMemberSystemHookEvent.class,
             name = TeamMemberSystemHookEvent.TEAM_MEMBER_REMOVED_EVENT),
+    @JsonSubTypes.Type(
+            value = UpdateTeamMemberSystemHookEvent.class,
+            name = TeamMemberSystemHookEvent.TEAM_MEMBER_UPDATED_EVENT),
     @JsonSubTypes.Type(value = CreateUserSystemHookEvent.class, name = UserSystemHookEvent.USER_CREATE_EVENT),
     @JsonSubTypes.Type(value = DestroyUserSystemHookEvent.class, name = UserSystemHookEvent.USER_DESTROY_EVENT),
     @JsonSubTypes.Type(
@@ -99,6 +102,10 @@ class NewTeamMemberSystemHookEvent extends TeamMemberSystemHookEvent {
 }
 
 class RemoveTeamMemberSystemHookEvent extends TeamMemberSystemHookEvent {
+    private static final long serialVersionUID = 1L;
+}
+
+class UpdateTeamMemberSystemHookEvent extends TeamMemberSystemHookEvent {
     private static final long serialVersionUID = 1L;
 }
 

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/TeamMemberSystemHookEvent.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/systemhooks/TeamMemberSystemHookEvent.java
@@ -10,6 +10,7 @@ public class TeamMemberSystemHookEvent extends AbstractSystemHookEvent {
 
     public static final String NEW_TEAM_MEMBER_EVENT = "user_add_to_team";
     public static final String TEAM_MEMBER_REMOVED_EVENT = "user_remove_from_team";
+    public static final String TEAM_MEMBER_UPDATED_EVENT = "user_update_for_team";
 
     private Date createdAt;
     private Date updatedAt;

--- a/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiEvents.java
+++ b/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiEvents.java
@@ -241,6 +241,13 @@ public class TestGitLabApiEvents {
     }
 
     @Test
+    public void testTeamMemberUpdateSystemHookEvent() throws Exception {
+        TeamMemberSystemHookEvent event =
+                unmarshalResource(TeamMemberSystemHookEvent.class, "team-member-update-system-hook-event.json");
+        assertTrue(compareJson(event, "team-member-update-system-hook-event.json"));
+    }
+
+    @Test
     public void testPushSystemHookEvent() throws Exception {
         PushSystemHookEvent event = unmarshalResource(PushSystemHookEvent.class, "push-system-hook-event.json");
         assertTrue(compareJson(event, "push-system-hook-event.json"));

--- a/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiEvents.java
+++ b/gitlab4j-models/src/test/java/org/gitlab4j/models/TestGitLabApiEvents.java
@@ -272,6 +272,12 @@ public class TestGitLabApiEvents {
     }
 
     @Test
+    public void testGroupMemberUpdateSystemHookEvent() throws Exception {
+        SystemHookEvent event = unmarshalResource(SystemHookEvent.class, "group-member-update-system-hook-event.json");
+        assertTrue(compareJson(event, "group-member-update-system-hook-event.json"));
+    }
+
+    @Test
     public void testTagPushSystemHookEvent() throws Exception {
         SystemHookEvent event = unmarshalResource(SystemHookEvent.class, "tag-push-system-hook-event.json");
         assertTrue(compareJson(event, "tag-push-system-hook-event.json"));

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/group-member-update-system-hook-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/group-member-update-system-hook-event.json
@@ -1,0 +1,13 @@
+{
+  "created_at": "2025-07-09T09:09:27Z",
+  "updated_at": "2025-09-06T07:12:24Z",
+  "group_name": "StoreCloud",
+  "group_path": "storecloud",
+  "group_id": 17995,
+  "user_username": "john-doe",
+  "user_name": "John Doe",
+  "user_email": "johndoe@example.com",
+  "user_id": 12218,
+  "group_access": "Maintainer",
+  "event_name": "user_update_for_group"
+}

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/team-member-update-system-hook-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/team-member-update-system-hook-event.json
@@ -1,0 +1,15 @@
+{
+  "created_at": "2012-07-21T07:30:56Z",
+  "updated_at": "2012-07-21T07:38:22Z",
+  "event_name": "user_update_for_team",
+  "access_level": "Maintainer",
+  "project_id": 74,
+  "project_name": "StoreCloud",
+  "project_path": "storecloud",
+  "project_path_with_namespace": "jsmith/storecloud",
+  "user_email": "johnsmith@example.com",
+  "user_name": "John Smith",
+  "user_username": "johnsmith",
+  "user_id": 41,
+  "project_visibility": "private"
+}


### PR DESCRIPTION
Adds the `user_update_for_group` and `user_update_for_team` Systemhook event.

See https://docs.gitlab.com/administration/system_hooks/

It is missing currently, resulting in Unmarshalling Errors:

```
org.gitlab4j.api.GitLabApiException: Could not resolve type id 'user_update_for_group' as a subtype of `org.gitlab4j.api.systemhooks.SystemHookEvent`: known type ids = [group_create, group_destroy, group_rename, key_create, key_destroy, merge_request, project_create, project_destroy, project_rename, project_transfer, project_update, push, repository_update, tag_push, user_add_to_group, user_add_to_team, user_create, user_destroy, user_failed_login, user_remove_from_group, user_remove_from_team, user_rename]
 at [Source: UNKNOWN; byte offset: #UNKNOWN]
	at org.gitlab4j.api.SystemHookManager.handleRequest(SystemHookManager.java:176)
```