### PR TITLE
Use PropertyNamingStrategies instead of PropertyNamingStrategy

### DIFF
--- a/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
+++ b/src/main/java/org/gitlab4j/api/utils/JacksonJson.java
@@ -32,7 +32,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.JsonSerializer;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.ObjectWriter;
-import com.fasterxml.jackson.databind.PropertyNamingStrategy;
+import com.fasterxml.jackson.databind.PropertyNamingStrategies;
 import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.databind.SerializerProvider;
 import com.fasterxml.jackson.databind.module.SimpleModule;
@@ -59,7 +59,7 @@ public class JacksonJson extends JacksonJaxbJsonProvider implements ContextResol
         objectMapper = new ObjectMapper();
 
         objectMapper.setSerializationInclusion(Include.NON_NULL);
-        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE);
+        objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.SNAKE_CASE);
 
         objectMapper.configure(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS, false);
         objectMapper.configure(SerializationFeature.WRITE_ENUMS_USING_TO_STRING, true);
@@ -359,7 +359,7 @@ public class JacksonJson extends JacksonJaxbJsonProvider implements ContextResol
         private static final JacksonJson JACKSON_JSON = new JacksonJson();
 
         static {
-            JACKSON_JSON.objectMapper.setPropertyNamingStrategy(PropertyNamingStrategy.LOWER_CAMEL_CASE);
+            JACKSON_JSON.objectMapper.setPropertyNamingStrategy(PropertyNamingStrategies.LOWER_CAMEL_CASE);
             JACKSON_JSON.objectMapper.setSerializationInclusion(Include.ALWAYS);
         }
     }


### PR DESCRIPTION
`PropertyNamingStrategy` was deprecated as of 2.12 and removed in jackson-databind 2.20.

Fixes #1280