### PR TITLE
Adding projectId field in DownstreamPipeline

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/DownstreamPipeline.java
@@ -9,6 +9,7 @@ public class DownstreamPipeline implements Serializable {
     private static final long serialVersionUID = 1L;
 
     private Long id;
+    private Long projectId;
     private String sha;
     private String ref;
     private String status;
@@ -22,6 +23,14 @@ public class DownstreamPipeline implements Serializable {
 
     public void setId(Long id) {
         this.id = id;
+    }
+
+    public Long getProjectId() {
+        return projectId;
+    }
+
+    public void setProjectId(Long projectId) {
+        this.projectId = projectId;
     }
 
     public String getSha() {

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/bridge.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/bridge.json
@@ -50,6 +50,7 @@
   },
   "downstream_pipeline": {
     "id": 5,
+    "project_id": 8,
     "sha": "f62a4b2fb89754372a346f24659212eb8da13601",
     "ref": "main",
     "status": "pending",


### PR DESCRIPTION
## Changes 
- Added `private Long projectId;` to `DownstreamPipeline`
- Added getter/setter for `projectId`

## Testing
- Unit test for JSON mapping

## Fixes 
- Fixes https://github.com/gitlab4j/gitlab4j-api/issues/1300