### PR TITLE
[5.x.x] NotesApi: fix createMergeRequestNote() API breakage introduced in 5.8.0

### DIFF
--- a/src/main/java/org/gitlab4j/api/NotesApi.java
+++ b/src/main/java/org/gitlab4j/api/NotesApi.java
@@ -525,6 +525,22 @@ public class NotesApi extends AbstractApi {
     }
 
     /**
+     * Create a merge request's note.
+     *
+     * <pre><code>GitLab Endpoint: POST /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>
+     *
+     * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance
+     * @param mergeRequestIid  the merge request IID to create the notes for
+     * @param body the content of note
+     * @return the created Note instance
+     * @throws GitLabApiException if any exception occurs
+     */
+    public Note createMergeRequestNote(Object projectIdOrPath, Long mergeRequestIid, String body)
+            throws GitLabApiException {
+        return createMergeRequestNote(projectIdOrPath, mergeRequestIid, body, null, false);
+    }
+
+    /**
      * Update the specified merge request's note.
      *
      * <pre><code>GitLab Endpoint: PUT /projects/:id/merge_requests/:merge_request_iid/notes/:note_id</code></pre>


### PR DESCRIPTION
Even when the new `created_at` and `internal` arguments are marked as "optional", that doesn't mean one can simply omit them from argument list. This means `createMergeRequestNote()`'s function signature has been changed, which is a breaking change which happens without major version bump.

So add a wrapper function with the old signature that calls the new signature, which restores compatibility to un-migrated code.

IMO this change is not needed for 6.x.x line, as that can be seen as major update and API breakage is fine that way. Although, I'll admit that with 5.8.0 released over a year ago, I'm not sure if this still matters anymore...

Fixes: 60259a69da ("Add attributes "created_at", "internal" for NotesApi commits and DiscussionApi merge requests (#1194)")