### PR TITLE
Add getters to ProjectFilter

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/ProjectFilter.java
@@ -53,6 +53,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getArchived() {
+        return archived;
+    }
+
     /**
      * Limit by visibility public, internal, or private.
      *
@@ -62,6 +66,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withVisibility(Visibility visibility) {
         this.visibility = visibility;
         return (this);
+    }
+
+    public Visibility getVisibility() {
+        return visibility;
     }
 
     /**
@@ -75,6 +83,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public ProjectOrderBy getOrderBy() {
+        return orderBy;
+    }
+
     /**
      * Return projects sorted in asc or desc order. Default is desc.
      *
@@ -84,6 +96,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withSortOder(SortOrder sort) {
         this.sort = sort;
         return (this);
+    }
+
+    public SortOrder getSort() {
+        return sort;
     }
 
     /**
@@ -97,6 +113,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public String getSearch() {
+        return search;
+    }
+
     /**
      * Include ancestor namespaces when matching search criteria. Default is false.
      *
@@ -106,6 +126,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withSearchNamespaces(Boolean searchNamespaces) {
         this.searchNamespaces = searchNamespaces;
         return (this);
+    }
+
+    public Boolean getSearchNamespaces() {
+        return searchNamespaces;
     }
 
     /**
@@ -120,6 +144,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getSimple() {
+        return simple;
+    }
+
     /**
      * Limit by projects explicitly owned by the current user
      *
@@ -129,6 +157,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withOwned(Boolean owned) {
         this.owned = owned;
         return (this);
+    }
+
+    public Boolean getOwned() {
+        return owned;
     }
 
     /**
@@ -142,6 +174,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getMembership() {
+        return membership;
+    }
+
     /**
      * Limit by projects starred by the current user.
      *
@@ -151,6 +187,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withStarred(Boolean starred) {
         this.starred = starred;
         return (this);
+    }
+
+    public Boolean getStarred() {
+        return starred;
     }
 
     /**
@@ -164,6 +204,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getStatistics() {
+        return statistics;
+    }
+
     /**
      *  Include custom attributes in response (admins only).
      *
@@ -173,6 +217,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withCustomAttributes(Boolean withCustomAttributes) {
         this.withCustomAttributes = withCustomAttributes;
         return (this);
+    }
+
+    public Boolean getWithCustomAttributes() {
+        return withCustomAttributes;
     }
 
     /**
@@ -186,6 +234,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getWithIssuesEnabled() {
+        return withIssuesEnabled;
+    }
+
     /**
      * Limit by enabled merge requests feature
      *
@@ -197,6 +249,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getWithMergeRequestsEnabled() {
+        return withMergeRequestsEnabled;
+    }
+
     /**
      * Limit by projects which use the given programming language.
      *
@@ -206,6 +262,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withProgrammingLanguage(String withProgrammingLanguage) {
         this.withProgrammingLanguage = withProgrammingLanguage;
         return (this);
+    }
+
+    public String getWithProgrammingLanguage() {
+        return withProgrammingLanguage;
     }
 
     /**
@@ -220,6 +280,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getWikiChecksumFailed() {
+        return wikiChecksumFailed;
+    }
+
     /**
      * Limit projects where the repository checksum calculation has failed.
      *
@@ -230,6 +294,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withRepositoryChecksumFailed(Boolean repositoryChecksumFailed) {
         this.repositoryChecksumFailed = repositoryChecksumFailed;
         return (this);
+    }
+
+    public Boolean getRepositoryChecksumFailed() {
+        return repositoryChecksumFailed;
     }
 
     /**
@@ -243,6 +311,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public AccessLevel getMinAccessLevel() {
+        return minAccessLevel;
+    }
+
     /**
      * Limit results to projects with IDs greater than the specified projectID.
      *
@@ -252,6 +324,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withIdAfter(Long idAfter) {
         this.idAfter = idAfter;
         return (this);
+    }
+
+    public Long getIdAfter() {
+        return idAfter;
     }
 
     /**
@@ -265,6 +341,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Long getIdBefore() {
+        return idBefore;
+    }
+
     /**
      * Limit results to projects with last_activity after specified time.
      *
@@ -274,6 +354,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withLastActivityAfter(Date lastActivityAfter) {
         this.lastActivityAfter = lastActivityAfter;
         return (this);
+    }
+
+    public Date getLastActivityAfter() {
+        return lastActivityAfter;
     }
 
     /**
@@ -287,6 +371,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Date getLastActivityBefore() {
+        return lastActivityBefore;
+    }
+
     /**
      * Limit results to projects stored on the specified repository_storage. Available for admins only.
      *
@@ -296,6 +384,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withRepositoryStorage(String repositoryStorage) {
         this.repositoryStorage = repositoryStorage;
         return (this);
+    }
+
+    public String getRepositoryStorage() {
+        return repositoryStorage;
     }
 
     /**
@@ -309,6 +401,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public Boolean getImported() {
+        return imported;
+    }
+
     /**
      *  Limit results to projects that match all of given topics.
      *
@@ -320,6 +416,10 @@ public class ProjectFilter implements Serializable {
         return (this);
     }
 
+    public String getTopic() {
+        return topic;
+    }
+
     /**
      *  Limit results to projects with the assigned topic given by the topic ID.
      *
@@ -329,6 +429,10 @@ public class ProjectFilter implements Serializable {
     public ProjectFilter withTopicId(Integer topic_id) {
         this.topic_id = topic_id;
         return (this);
+    }
+
+    public Integer getTopicId() {
+        return topic_id;
     }
 
     /**


### PR DESCRIPTION
ProjectFilter currently does not expose its internal fields via getters, which makes it difficult to verify filter configuration in tests.

In my tests, I need to ensure that ProjectFilter is created with a specific lastActivityAfter value. A similar approach is already possible with MergeRequestFilter, which provides getters for its fields, but ProjectFilter does not.

This PR adds getters to ProjectFilter to improve testability and make its API more consistent with other filter classes in the project.