### PR TITLE
moved "property" calls on Jersey APIs

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 	<groupId>org.gitlab4j</groupId>
 	<artifactId>gitlab4j-api</artifactId>
 	<packaging>jar</packaging>
-	<version>5.0.1</version>
+	<version>5.0.2</version>
 	<name>GitLab4J-API - GitLab API Java Client</name>
 	<description>GitLab4J-API (gitlab4j-api) provides a full featured Java client library for working with GitLab repositories and servers via the GitLab REST API.</description>
 	<url>https://github.com/gitlab4j/gitlab4j-api</url>


### PR DESCRIPTION
Mutating the client (which property calls do) after creation, changes the ClientConfig mode to RequestScoped. This forces Jersey to reinitialize the injection scope with each request, which degrades performance when many API calls are made

Running the client with a profiler led me down the rabbit hole of, "why is Jersey calling `initRuntime` on the `ClientConfig$State` for each request". This task is slow and requires the creation of a new InjectionManager for each request. The calls to set the redirect and timeout properties made in `invocation` were what was doing it. It did not look like those needed to happen with each invocation, and instead could be done during client initialization so that Jersey would re-use the config for subsequent requests. Our project uses 5.x because we are stuck on java 8 so I made the change there. Let me know what I need to do to actually get this change approved and released. Thanks!