### PR TITLE
Add the draft option to the Merge Request creation

### DIFF
--- a/.tool-versions
+++ b/.tool-versions
@@ -1,0 +1,1 @@
+java temurin-11.0.28+6

--- a/.tool-versions
+++ b/.tool-versions
@@ -1,1 +1,0 @@
-java temurin-11.0.28+6

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -244,7 +244,6 @@ public class MergeRequestParams implements Serializable {
         String titleToUse = title;
         if (Boolean.TRUE.equals(draft)) {
             titleToUse = "Draft: " + (title != null ? title : "");
-            // titleToUse = "Draft: " + title;
         }
 
         GitLabForm form = new GitLabForm()

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -29,6 +29,7 @@ public class MergeRequestParams implements Serializable {
     private Boolean discussionLocked;
     private Boolean allowCollaboration;
     private Integer approvalsBeforeMerge;
+    private Boolean draft;
 
     /**
      * Set the source branch. This is for merge request creation only.
@@ -221,6 +222,17 @@ public class MergeRequestParams implements Serializable {
     }
 
     /**
+     * Set the draft flag of the merge request.
+     *
+     * @param draft the draft flag to set
+     * @return the reference to this MergeRequestParams instance
+     */
+    public MergeRequestParams withDraft(Boolean draft) {
+        this.draft = draft;
+        return (this);
+    }
+
+    /**
      * Get the form params specified by this instance.
      *
      * @param isCreate set to true if this is for a create merge request API call,
@@ -229,9 +241,15 @@ public class MergeRequestParams implements Serializable {
      */
     public GitLabForm getForm(boolean isCreate) {
 
+        String titleToUse = title;
+        if (Boolean.TRUE.equals(draft)) {
+            titleToUse = "Draft: " + (title != null ? title : "");
+            // titleToUse = "Draft: " + title;
+        }
+
         GitLabForm form = new GitLabForm()
                 .withParam("target_branch", targetBranch, isCreate)
-                .withParam("title", title, isCreate)
+                .withParam("title", titleToUse, isCreate)
                 .withParam("assignee_id", assigneeId)
                 .withParam("assignee_ids", assigneeIds)
                 .withParam("reviewer_ids", reviewerIds)

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -241,9 +241,11 @@ public class MergeRequestParams implements Serializable {
      */
     public GitLabForm getForm(boolean isCreate) {
 
-        String titleToUse = title;
+        String titleToUse;
         if (Boolean.TRUE.equals(draft)) {
             titleToUse = "Draft: " + (title != null ? title : "");
+        } else {
+            titleToUse = title;
         }
 
         GitLabForm form = new GitLabForm()

--- a/gitlab4j-models/src/test/java/org/gitlab4j/api/models/TestMergeRequestParams.java
+++ b/gitlab4j-models/src/test/java/org/gitlab4j/api/models/TestMergeRequestParams.java
@@ -1,0 +1,61 @@
+package org.gitlab4j.api.models;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.gitlab4j.models.GitLabForm;
+import org.gitlab4j.models.GitLabFormValue;
+import org.junit.jupiter.api.Test;
+
+public class TestMergeRequestParams {
+
+    @Test
+    public void testDraftPrefix() {
+        MergeRequestParams params =
+                new MergeRequestParams().withTitle("My Title").withDraft(true);
+
+        GitLabForm form = params.getForm(true);
+        Object titleValue = form.getFormValues().get("title").getValue();
+        assertEquals("Draft: My Title", titleValue);
+    }
+
+    @Test
+    public void testNoDraftPrefix() {
+        MergeRequestParams params =
+                new MergeRequestParams().withTitle("My Title").withDraft(false);
+
+        GitLabForm form = params.getForm(true);
+        Object titleValue = form.getFormValues().get("title").getValue();
+        assertEquals("My Title", titleValue);
+    }
+
+    @Test
+    public void testNullDraftPrefix() {
+        MergeRequestParams params =
+                new MergeRequestParams().withTitle("My Title").withDraft(null);
+
+        GitLabForm form = params.getForm(true);
+        Object titleValue = form.getFormValues().get("title").getValue();
+        assertEquals("My Title", titleValue);
+    }
+
+    @Test
+    public void testDraftWithNullTitle() {
+        MergeRequestParams params = new MergeRequestParams().withTitle(null).withDraft(true);
+
+        GitLabForm form = params.getForm(true);
+        Object titleValue = form.getFormValues().get("title").getValue();
+        assertEquals("Draft: ", titleValue);
+    }
+
+    @Test
+    public void testNoDraftWithNullTitle() {
+        MergeRequestParams params = new MergeRequestParams().withTitle(null).withDraft(false);
+
+        GitLabForm form = params.getForm(true);
+        GitLabFormValue titleFormValue = form.getFormValues().get("title");
+        assertNotNull(titleFormValue);
+        assertNull(titleFormValue.getValue());
+    }
+}


### PR DESCRIPTION
The GitLab API does not provide a draft parameter (wip or similar) to create a draft Merge Request, see the documentation: https://docs.gitlab.com/api/merge_requests/#create-a-merge-request

The intention here is to make using the Merge Request creation API more fluid by adding the `draft` option.
