### PR TITLE
moved "property" calls on Jersey APIs

### DIFF
--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -1,21 +1,5 @@
 package org.gitlab4j.api;
 
-import org.gitlab4j.api.Constants.TokenType;
-import org.gitlab4j.api.GitLabApi.ApiVersion;
-import org.gitlab4j.api.utils.JacksonJson;
-import org.gitlab4j.api.utils.MaskingLoggingFilter;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.jackson.JacksonFeature;
-import org.glassfish.jersey.media.multipart.*;
-import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
-import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
-
-import javax.net.ssl.*;
-import javax.ws.rs.client.*;
-import javax.ws.rs.core.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -30,6 +14,23 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
+
+import javax.net.ssl.*;
+import javax.ws.rs.client.*;
+import javax.ws.rs.core.*;
+
+import org.gitlab4j.api.Constants.TokenType;
+import org.gitlab4j.api.GitLabApi.ApiVersion;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.MaskingLoggingFilter;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.media.multipart.*;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 
 /**
  * This class utilizes the Jersey client package to communicate with a GitLab API endpoint.

--- a/src/main/java/org/gitlab4j/api/GitLabApiClient.java
+++ b/src/main/java/org/gitlab4j/api/GitLabApiClient.java
@@ -1,5 +1,21 @@
 package org.gitlab4j.api;
 
+import org.gitlab4j.api.Constants.TokenType;
+import org.gitlab4j.api.GitLabApi.ApiVersion;
+import org.gitlab4j.api.utils.JacksonJson;
+import org.gitlab4j.api.utils.MaskingLoggingFilter;
+import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
+import org.glassfish.jersey.client.ClientConfig;
+import org.glassfish.jersey.client.ClientProperties;
+import org.glassfish.jersey.client.JerseyClientBuilder;
+import org.glassfish.jersey.jackson.JacksonFeature;
+import org.glassfish.jersey.media.multipart.*;
+import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
+import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
+
+import javax.net.ssl.*;
+import javax.ws.rs.client.*;
+import javax.ws.rs.core.*;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
@@ -14,41 +30,6 @@ import java.util.Map;
 import java.util.function.Supplier;
 import java.util.logging.Level;
 import java.util.logging.Logger;
-
-import javax.net.ssl.HostnameVerifier;
-import javax.net.ssl.SSLContext;
-import javax.net.ssl.SSLEngine;
-import javax.net.ssl.SSLSession;
-import javax.net.ssl.TrustManager;
-import javax.net.ssl.X509ExtendedTrustManager;
-import javax.ws.rs.client.Client;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.client.Entity;
-import javax.ws.rs.client.Invocation;
-import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.Form;
-import javax.ws.rs.core.MediaType;
-import javax.ws.rs.core.MultivaluedMap;
-import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
-
-import org.gitlab4j.api.Constants.TokenType;
-import org.gitlab4j.api.GitLabApi.ApiVersion;
-import org.gitlab4j.api.utils.JacksonJson;
-import org.gitlab4j.api.utils.MaskingLoggingFilter;
-import org.glassfish.jersey.apache.connector.ApacheConnectorProvider;
-import org.glassfish.jersey.client.ClientConfig;
-import org.glassfish.jersey.client.ClientProperties;
-import org.glassfish.jersey.client.JerseyClientBuilder;
-import org.glassfish.jersey.jackson.JacksonFeature;
-import org.glassfish.jersey.media.multipart.BodyPart;
-import org.glassfish.jersey.media.multipart.Boundary;
-import org.glassfish.jersey.media.multipart.FormDataBodyPart;
-import org.glassfish.jersey.media.multipart.FormDataMultiPart;
-import org.glassfish.jersey.media.multipart.MultiPart;
-import org.glassfish.jersey.media.multipart.MultiPartFeature;
-import org.glassfish.jersey.media.multipart.file.FileDataBodyPart;
-import org.glassfish.jersey.media.multipart.file.StreamDataBodyPart;
 
 /**
  * This class utilizes the Jersey client package to communicate with a GitLab API endpoint.
@@ -72,9 +53,6 @@ public class GitLabApiClient implements AutoCloseable {
     private SSLContext openSslContext;
     private HostnameVerifier openHostnameVerifier;
     private Long sudoAsId;
-    private Integer connectTimeout;
-    private Integer readTimeout;
-
     /**
      * Construct an instance to communicate with a GitLab API server using the specified GitLab API version,
      * server URL, private token, and secret token.
@@ -259,6 +237,7 @@ public class GitLabApiClient implements AutoCloseable {
         // to use the features and services explicitly configured by gitlab4j
         clientConfig.property(ClientProperties.FEATURE_AUTO_DISCOVERY_DISABLE, true);
         clientConfig.property(ClientProperties.METAINF_SERVICES_LOOKUP_DISABLE, true);
+        clientConfig.property(ClientProperties.FOLLOW_REDIRECTS, true);
 
         clientConfig.register(JacksonJson.class);
         clientConfig.register(JacksonFeature.class);
@@ -304,8 +283,13 @@ public class GitLabApiClient implements AutoCloseable {
      * @param readTimeout the per request read timeout in milliseconds, can be null to use default
      */
     void setRequestTimeout(Integer connectTimeout, Integer readTimeout) {
-        this.connectTimeout = connectTimeout;
-        this.readTimeout = readTimeout;
+        clientConfig.property(ClientProperties.CONNECT_TIMEOUT, connectTimeout);
+        clientConfig.property(ClientProperties.READ_TIMEOUT, readTimeout);
+
+        // Recreate the Client instance if already created.
+        if (apiClient != null) {
+            createApiClient();
+        }
     }
 
     /**
@@ -855,7 +839,7 @@ public class GitLabApiClient implements AutoCloseable {
             createApiClient();
         }
 
-        WebTarget target = apiClient.target(url.toExternalForm()).property(ClientProperties.FOLLOW_REDIRECTS, true);
+        WebTarget target = apiClient.target(url.toExternalForm());
         if (queryParams != null) {
             for (Map.Entry<String, List<String>> param : queryParams.entrySet()) {
                 target = target.queryParam(param.getKey(), param.getValue().toArray());
@@ -873,16 +857,6 @@ public class GitLabApiClient implements AutoCloseable {
 
         // If sudo as ID is set add the Sudo header
         if (sudoAsId != null && sudoAsId.intValue() > 0) builder = builder.header(SUDO_HEADER, sudoAsId);
-
-        // Set the per request connect timeout
-        if (connectTimeout != null) {
-            builder.property(ClientProperties.CONNECT_TIMEOUT, connectTimeout);
-        }
-
-        // Set the per request read timeout
-        if (readTimeout != null) {
-            builder.property(ClientProperties.READ_TIMEOUT, readTimeout);
-        }
 
         return (builder);
     }


### PR DESCRIPTION
Mutating the client (which property calls do) after creation, changes the ClientConfig mode to RequestScoped. This forces Jersey to reinitialize the injection scope with each request, which degrades performance when many API calls are made

Running the client with a profiler led me down the rabbit hole of, "why is Jersey calling initRuntime on the ClientConfig$State for each request". This task is slow and requires the creation of a new InjectionManager for each request. The calls to set the redirect and timeout properties made in invocation were what was doing it. It did not look like those needed to happen with each invocation, and instead could be done during client initialization so that Jersey would re-use the config for subsequent requests. Our project uses 5.x because we are stuck on java 8 so I made the change there. Let me know what I need to do to actually get this change approved and released. Thanks!