### PR TITLE
Update Jackson dependencies to version 2.18.6

### DIFF
--- a/gitlab4j-models/build.gradle
+++ b/gitlab4j-models/build.gradle
@@ -1,6 +1,6 @@
 dependencies {
-    api 'com.fasterxml.jackson.core:jackson-annotations:2.18.0'
-    api 'com.fasterxml.jackson.core:jackson-databind:2.18.0'
+    api 'com.fasterxml.jackson.core:jackson-annotations:2.18.6'
+    api 'com.fasterxml.jackson.core:jackson-databind:2.18.6'
     testImplementation 'org.mockito:mockito-core:5.2.0'
     testImplementation 'org.mockito:mockito-junit-jupiter:5.2.0'
     testImplementation 'org.hamcrest:hamcrest-all:1.3'


### PR DESCRIPTION
The problem with version 2.18.0 is that there is a security finding (https://github.com/advisories/GHSA-72hv-8253-57qq). I would appreciate it very much if you would consider releasing a patch version.