### PR TITLE
Update EventMergeRequest webhook to handle non-string merge param values

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventMergeRequest.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/webhook/EventMergeRequest.java
@@ -2,11 +2,13 @@ package org.gitlab4j.api.webhook;
 
 import java.util.Date;
 import java.util.List;
-import java.util.Map;
 
 import org.gitlab4j.api.models.Assignee;
 import org.gitlab4j.api.models.Duration;
 import org.gitlab4j.models.utils.JacksonJson;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonInclude;
 
 public class EventMergeRequest {
 
@@ -48,7 +50,8 @@ public class EventMergeRequest {
 
     private Long updatedById;
     private String mergeError;
-    private Map<String, String> mergeParams;
+    private MergeParams mergeParams;
+
     private Boolean mergeWhenPipelineSucceeds;
     private Long mergeUserId;
     private Date deletedAt;
@@ -358,11 +361,11 @@ public class EventMergeRequest {
         this.mergeError = mergeError;
     }
 
-    public Map<String, String> getMergeParams() {
+    public MergeParams getMergeParams() {
         return mergeParams;
     }
 
-    public void setMergeParams(Map<String, String> mergeParams) {
+    public void setMergeParams(MergeParams mergeParams) {
         this.mergeParams = mergeParams;
     }
 
@@ -516,6 +519,105 @@ public class EventMergeRequest {
 
     public void setOldrev(String oldrev) {
         this.oldrev = oldrev;
+    }
+
+    @JsonIgnoreProperties(ignoreUnknown = true)
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    public static class MergeParams {
+        private String autoMergeStrategy;
+        private String forceRemoveSourceBranch;
+        private Boolean shouldRemoveSourceBranch;
+        private String commitMessage;
+        private String squashCommitMessage;
+        private String sha;
+        private TrainRef trainRef;
+
+        public String getAutoMergeStrategy() {
+            return autoMergeStrategy;
+        }
+
+        public void setAutoMergeStrategy(String autoMergeStrategy) {
+            this.autoMergeStrategy = autoMergeStrategy;
+        }
+
+        public String getForceRemoveSourceBranch() {
+            return forceRemoveSourceBranch;
+        }
+
+        public void setForceRemoveSourceBranch(String forceRemoveSourceBranch) {
+            this.forceRemoveSourceBranch = forceRemoveSourceBranch;
+        }
+
+        public Boolean getShouldRemoveSourceBranch() {
+            return shouldRemoveSourceBranch;
+        }
+
+        public void setShouldRemoveSourceBranch(Boolean shouldRemoveSourceBranch) {
+            this.shouldRemoveSourceBranch = shouldRemoveSourceBranch;
+        }
+
+        public String getCommitMessage() {
+            return commitMessage;
+        }
+
+        public void setCommitMessage(String commitMessage) {
+            this.commitMessage = commitMessage;
+        }
+
+        public String getSquashCommitMessage() {
+            return squashCommitMessage;
+        }
+
+        public void setSquashCommitMessage(String squashCommitMessage) {
+            this.squashCommitMessage = squashCommitMessage;
+        }
+
+        public String getSha() {
+            return sha;
+        }
+
+        public void setSha(String sha) {
+            this.sha = sha;
+        }
+
+        public TrainRef getTrainRef() {
+            return trainRef;
+        }
+
+        public void setTrainRef(TrainRef trainRef) {
+            this.trainRef = trainRef;
+        }
+
+        @JsonIgnoreProperties(ignoreUnknown = true)
+        public static class TrainRef {
+            private String commitSha;
+            private String mergeCommitSha;
+            private String squashCommitSha;
+
+            public String getCommitSha() {
+                return commitSha;
+            }
+
+            public void setCommitSha(String commitSha) {
+                this.commitSha = commitSha;
+            }
+
+            public String getMergeCommitSha() {
+                return mergeCommitSha;
+            }
+
+            public void setMergeCommitSha(String mergeCommitSha) {
+                this.mergeCommitSha = mergeCommitSha;
+            }
+
+            public String getSquashCommitSha() {
+                return squashCommitSha;
+            }
+
+            public void setSquashCommitSha(String squashCommitSha) {
+                this.squashCommitSha = squashCommitSha;
+            }
+        }
     }
 
     @Override

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/merge-request-system-hook-event.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/merge-request-system-hook-event.json
@@ -40,7 +40,17 @@
     "description": "",
     "updated_by_id": 1,
     "merge_params": {
-      "force_remove_source_branch": "0"
+      "auto_merge_strategy": "merge_train",
+      "force_remove_source_branch": "0",
+      "should_remove_source_branch": true,
+      "commit_message": "commit message",
+      "squash_commit_message": "squash commit message",
+      "sha": "123abc",
+      "train_ref": {
+        "commit_sha": "abcd1234",
+        "merge_commit_sha": "bcde2345",
+        "squash_commit_sha": "cdef3456"
+      }
     },
     "merge_when_pipeline_succeeds": false,
     "lock_version": 5,


### PR DESCRIPTION
Calls from GitLab's merge request webhook event can have the `merge_params` property contain non-string values, such as `should_remove_source_branch` which is a boolean or `train_ref` which is an object (https://gitlab.com/gitlab-org/gitlab/-/merge_requests/129979). Example:

```
"object_attributes": {
  ...
  "merge_params": {
    "force_remove_source_branch": "1",
    "auto_merge_strategy": "merge_train",
    "should_remove_source_branch": true,
    "sha": "61f4798ee6668860a47f2f84b31bf8b88ab52bb9",
    "train_ref": {
      "commit_sha": "83d69a142f2fb301c3cce0a802ec1c5ee3a091a8",
      "merge_commit_sha": "83d69a142f2fb301c3cce0a802ec1c5ee3a091a8",
      "squash_commit_sha": "61f4798ee6668860a47f2f84b31bf8b88ab52bb9"
    }
  },
  ...
}
```

This causes issues when handling the event since the `merge_params` attribute in `EventMergeRequest` is a `Map<String, String>`, which expects every value to be a string. This change updates `merge_params` so it can handle the `should_remove_source_branch` and `train_ref` non-string values when converting the JSON.