### PR TITLE
Fix Accept Header to use MediaType.WILDCARD

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/GroupApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/GroupApi.java
@@ -2265,12 +2265,7 @@ public class GroupApi extends AbstractApi {
     public InputStream getAvatar(Object groupIdOrPath) throws GitLabApiException {
 
         Response response = getWithAccepts(
-                Response.Status.OK,
-                null,
-                MediaType.MEDIA_TYPE_WILDCARD,
-                "groups",
-                getGroupIdOrPath(groupIdOrPath),
-                "avatar");
+                Response.Status.OK, null, MediaType.WILDCARD, "groups", getGroupIdOrPath(groupIdOrPath), "avatar");
         return (response.readEntity(InputStream.class));
     }
 

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ImportExportApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ImportExportApi.java
@@ -126,7 +126,7 @@ public class ImportExportApi extends AbstractApi {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 null,
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "export",

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/JobApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/JobApi.java
@@ -378,7 +378,7 @@ public class JobApi extends AbstractApi implements Constants {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 formData.asMap(),
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "jobs",
@@ -421,7 +421,7 @@ public class JobApi extends AbstractApi implements Constants {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 formData.asMap(),
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "jobs",
@@ -449,7 +449,7 @@ public class JobApi extends AbstractApi implements Constants {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 null,
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "jobs",
@@ -485,7 +485,7 @@ public class JobApi extends AbstractApi implements Constants {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 null,
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "jobs",

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -1194,7 +1194,7 @@ public class ProjectApi extends AbstractApi implements Constants {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 null,
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "avatar");

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/RepositoryApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/RepositoryApi.java
@@ -488,7 +488,7 @@ public class RepositoryApi extends AbstractApi {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 null,
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "repository",

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/RepositoryFileApi.java
@@ -422,7 +422,7 @@ public class RepositoryFileApi extends AbstractApi {
         Response response = getWithAccepts(
                 Response.Status.OK,
                 formData.asMap(),
-                MediaType.MEDIA_TYPE_WILDCARD,
+                MediaType.WILDCARD,
                 "projects",
                 getProjectIdOrPath(projectIdOrPath),
                 "repository",


### PR DESCRIPTION
This pull request corrects the formatting of the HTTP `Accept` request header across multiple request methods to align with requirements defined in [RFC 9110 Section 12.5.1](https://www.rfc-editor.org/rfc/rfc9110.html#section-12.5.1).

The Jakarta REST API [MediaType](https://jakarta.ee/specifications/restful-ws/3.0/apidocs/jakarta/ws/rs/core/mediatype) defines multiple constants including `WILDCARD` and `MEDIA_TYPE_WILDCARD` as follows:

- `MEDIA_TYPE_WILDCARD` as `*`
- `WILDCARD` as `*/*`

Several methods in the GitLab4J API used the `MEDIA_TYPE_WILDCARD` constant, resulting in an invalid `Accept` header value of `*`, which should be limited to subtype references.

Following existing usage and aligning with RFC requirements, changing method calls to use the `WILDCARD` constant corrects the behavior and sends `*/*` as the `Accept` header.