### PR TITLE
Missing push rules properties

### DIFF
--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -3171,7 +3171,9 @@ public class ProjectApi extends AbstractApi implements Constants {
      * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
      * maxFileSize (optional) - Maximum file size (MB)
      * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
+     * commitCommitterNameCheck (optional) - Users can only push commits to this repository if the commit author name is consistent with their GitLab account name.
      * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
+     * rejectNonDcoCommits (optional) - Reject commit when it is not DCO certified
      *</code>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
@@ -3191,7 +3193,9 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("file_name_regex", pushRule.getFileNameRegex())
                 .withParam("max_file_size", pushRule.getMaxFileSize())
                 .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
-                .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits());
+                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameChack())
+                .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits())
+                .withParam("reject_non_dco_commits", pushRule.getRejectNonDcoCommits());
 
         Response response =
                 post(Response.Status.CREATED, formData, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");
@@ -3216,7 +3220,9 @@ public class ProjectApi extends AbstractApi implements Constants {
      * fileNameRegex (optional) - All committed filenames must not match this, e.g. `(jar
      * maxFileSize (optional) - Maximum file size (MB)
      * commitCommitterCheck (optional) - Users can only push commits to this repository that were committed with one of their own verified emails.
+     * commitCommitterNameCheck (optional) - Users can only push commits to this repository if the commit author name is consistent with their GitLab account name.
      * rejectUnsignedCommits (optional) - Reject commit when it is not signed through GPG
+     * rejectNonDcoCommits (optional) - Reject commit when it is not DCO certified
      *</code>
      *
      * @param projectIdOrPath the project in the form of an Long(ID), String(path), or Project instance, required
@@ -3236,7 +3242,9 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("file_name_regex", pushRule.getFileNameRegex())
                 .withParam("max_file_size", pushRule.getMaxFileSize())
                 .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
-                .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits());
+                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameChack())
+                .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits())
+                .withParam("reject_non_dco_commits", pushRule.getRejectNonDcoCommits());
 
         final Response response = putWithFormData(
                 Response.Status.OK, formData, "projects", getProjectIdOrPath(projectIdOrPath), "push_rule");

--- a/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
+++ b/gitlab4j-api/src/main/java/org/gitlab4j/api/ProjectApi.java
@@ -3193,7 +3193,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("file_name_regex", pushRule.getFileNameRegex())
                 .withParam("max_file_size", pushRule.getMaxFileSize())
                 .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
-                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameChack())
+                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameCheck())
                 .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits())
                 .withParam("reject_non_dco_commits", pushRule.getRejectNonDcoCommits());
 
@@ -3242,7 +3242,7 @@ public class ProjectApi extends AbstractApi implements Constants {
                 .withParam("file_name_regex", pushRule.getFileNameRegex())
                 .withParam("max_file_size", pushRule.getMaxFileSize())
                 .withParam("commit_committer_check", pushRule.getCommitCommitterCheck())
-                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameChack())
+                .withParam("commit_committer_name_check", pushRule.getCommitCommitterNameCheck())
                 .withParam("reject_unsigned_commits", pushRule.getRejectUnsignedCommits())
                 .withParam("reject_non_dco_commits", pushRule.getRejectNonDcoCommits());
 

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
@@ -23,6 +23,7 @@ public class PushRules implements Serializable {
     private Boolean commitCommitterCheck;
     private Boolean commitCommitterNameCheck;
     private Boolean rejectUnsignedCommits;
+    private Boolean rejectNonDcoCommits;
 
     public Long getId() {
         return id;
@@ -206,6 +207,19 @@ public class PushRules implements Serializable {
 
     public PushRules withRejectUnsignedCommits(Boolean rejectUnsignedCommits) {
         this.rejectUnsignedCommits = rejectUnsignedCommits;
+        return (this);
+    }
+
+    public Boolean getRejectNonDcoCommits() {
+        return rejectNonDcoCommits;
+    }
+
+    public void setRejectNonDcoCommits(Boolean rejectUnsignedCommits) {
+        this.rejectNonDcoCommits = rejectNonDcoCommits;
+    }
+
+    public PushRules withRejectNonDcoCommits(Boolean rejectNonDcoCommits) {
+        this.rejectNonDcoCommits = rejectNonDcoCommits;
         return (this);
     }
 

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
@@ -214,7 +214,7 @@ public class PushRules implements Serializable {
         return rejectNonDcoCommits;
     }
 
-    public void setRejectNonDcoCommits(Boolean rejectUnsignedCommits) {
+    public void setRejectNonDcoCommits(Boolean rejectNonDcoCommits) {
         this.rejectNonDcoCommits = rejectNonDcoCommits;
     }
 

--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/PushRules.java
@@ -182,6 +182,11 @@ public class PushRules implements Serializable {
         this.commitCommitterNameCheck = commitCommitterNameCheck;
     }
 
+    public PushRules withCommitCommitterNameCheck(Boolean commitCommitterNameCheck) {
+        this.commitCommitterNameCheck = commitCommitterNameCheck;
+        return (this);
+    }
+
     public void setCommitCommitterCheck(Boolean commitCommitterCheck) {
         this.commitCommitterCheck = commitCommitterCheck;
     }

--- a/gitlab4j-models/src/test/resources/org/gitlab4j/models/push-rule.json
+++ b/gitlab4j-models/src/test/resources/org/gitlab4j/models/push-rule.json
@@ -13,5 +13,6 @@
   "max_file_size": 5,
   "commit_committer_check": false,
   "commit_committer_name_check": false,
-  "reject_unsigned_commits": false
+  "reject_unsigned_commits": false,
+  "reject_non_dco_commits": false
 }


### PR DESCRIPTION
We are using gitlab4j  with Gilab 18.6 and it seems now, properties : commit_committer_name_check and reject_non_dco_commits are mandatory when creating or updating push rules.