### PR TITLE
Support add_labels / remove_labels in update Merge Request

### DIFF
--- a/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
+++ b/gitlab4j-models/src/main/java/org/gitlab4j/api/models/MergeRequestParams.java
@@ -21,6 +21,8 @@ public class MergeRequestParams implements Serializable {
     private List<Long> reviewerIds;
     private Long milestoneId;
     private List<String> labels;
+    private List<String> addLabels;
+    private List<String> removeLabels;
     private String description;
     private Long targetProjectId;
     private StateEvent stateEvent;
@@ -129,6 +131,56 @@ public class MergeRequestParams implements Serializable {
      */
     public MergeRequestParams withLabels(String[] labels) {
         this.labels = (labels != null ? Arrays.asList(labels) : null);
+        return (this);
+    }
+
+    /**
+     * Add labels to the merge request (without affecting existing labels).
+     * If a label does not already exist, this creates a new project label and assigns it to the merge request.
+     * This is for merge request updates only.
+     *
+     * @param addLabels the List of labels to add
+     * @return the reference to this MergeRequestParams instance
+     */
+    public MergeRequestParams withAddLabels(List<String> addLabels) {
+        this.addLabels = addLabels;
+        return (this);
+    }
+
+    /**
+     * Add labels to the merge request (without affecting existing labels).
+     * If a label does not already exist, this creates a new project label and assigns it to the merge request.
+     * This is for merge request updates only.
+     *
+     * @param addLabels the array of labels to add
+     * @return the reference to this MergeRequestParams instance
+     */
+    public MergeRequestParams withAddLabels(String[] addLabels) {
+        this.addLabels = (addLabels != null ? Arrays.asList(addLabels) : null);
+        return (this);
+    }
+
+    /**
+     * Remove labels from the merge request (without affecting other labels).
+     * This is for merge request updates only.
+     *
+     * @param removeLabels the List of labels to remove
+     * @return the reference to this MergeRequestParams instance
+     */
+    public MergeRequestParams withRemoveLabels(List<String> removeLabels) {
+        this.removeLabels = removeLabels;
+        return (this);
+    }
+
+    /**
+     * Remove labels from the merge request (without affecting other labels).
+     * This is for merge request updates only.
+     *
+     * @param removeLabels the array of labels to remove
+     * @return the reference to this MergeRequestParams instance
+     */
+    public MergeRequestParams withRemoveLabels(String[] removeLabels) {
+        this.removeLabels = (removeLabels != null ? Arrays.asList(removeLabels) : null);
         return (this);
     }
 
@@ -266,7 +318,10 @@ public class MergeRequestParams implements Serializable {
                     .withParam("target_project_id", targetProjectId)
                     .withParam("approvals_before_merge", approvalsBeforeMerge);
         } else {
-            form.withParam("state_event", stateEvent).withParam("discussion_locked", discussionLocked);
+            form.withParam("state_event", stateEvent)
+                    .withParam("discussion_locked", discussionLocked)
+                    .withParam("add_labels", (addLabels != null ? String.join(",", addLabels) : null))
+                    .withParam("remove_labels", (removeLabels != null ? String.join(",", removeLabels) : null));
         }
 
         return (form);

--- a/gitlab4j-models/src/test/java/org/gitlab4j/api/models/TestMergeRequestParams.java
+++ b/gitlab4j-models/src/test/java/org/gitlab4j/api/models/TestMergeRequestParams.java
@@ -4,6 +4,8 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.util.Arrays;
+
 import org.gitlab4j.models.GitLabForm;
 import org.gitlab4j.models.GitLabFormValue;
 import org.junit.jupiter.api.Test;
@@ -57,5 +59,33 @@ public class TestMergeRequestParams {
         GitLabFormValue titleFormValue = form.getFormValues().get("title");
         assertNotNull(titleFormValue);
         assertNull(titleFormValue.getValue());
+    }
+
+    @Test
+    public void testAddLabels() {
+        MergeRequestParams params = new MergeRequestParams().withAddLabels(Arrays.asList("bug", "urgent"));
+
+        GitLabForm form = params.getForm(false);
+        assertEquals("bug,urgent", form.getFormValues().get("add_labels").getValue());
+    }
+
+    @Test
+    public void testRemoveLabels() {
+        MergeRequestParams params = new MergeRequestParams().withRemoveLabels(new String[] {"wontfix"});
+
+        GitLabForm form = params.getForm(false);
+        assertEquals("wontfix", form.getFormValues().get("remove_labels").getValue());
+    }
+
+    @Test
+    public void testNoAddRemoveLabelsOnCreate() {
+        MergeRequestParams params = new MergeRequestParams()
+                .withTitle("T")
+                .withAddLabels(Arrays.asList("bug"))
+                .withRemoveLabels(Arrays.asList("wontfix"));
+
+        GitLabForm form = params.getForm(true);
+        assertNull(form.getFormValues().get("add_labels"));
+        assertNull(form.getFormValues().get("remove_labels"));
     }
 }


### PR DESCRIPTION
## Summary

Adds `withAddLabels(...)` and `withRemoveLabels(...)` to `MergeRequestParams`, mapping to the `add_labels` and `remove_labels` form parameters of the GitLab Update Merge Request endpoint: https://docs.gitlab.com/api/merge_requests/#update-a-merge-request

## Motivation

Currently `MergeRequestParams` only exposes `withLabels(...)`, which sends the full `labels` list and replaces the merge request's labels entirely. Adding or removing a single label therefore requires fetching the current label set and re-sending it.

The GitLab API already supports incremental label changes via `add_labels` and `remove_labels` only on the update endpoint: https://docs.gitlab.com/api/merge_requests/#update-a-merge-request

## Changes

- `MergeRequestParams`: two new fields (`addLabels`, `removeLabels`) and serialization wired into the update-only branch of `getForm(boolean isCreate)`
- `TestMergeRequestParams`: add some tests

The change is strictly additive - existing behavior of `withLabels(...)` is unchanged.

## Usage

```java
mergeRequestApi.updateMergeRequest(projectIdOrPath, mrIid,
    new MergeRequestParams()
        .withAddLabels(List.of("bug"))
        .withRemoveLabels(List.of("wontfix")));
```

ps: I'm already using these changes in my application and everything is fine.